### PR TITLE
Hearth v1 foundation + release workflow (BRAT)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release Obsidian plugin
+
+on:
+  push:
+    tags:
+      # Run only for version tags that match the manifest version, e.g. 0.1.0
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Install & build
+        run: |
+          npm install
+          npm run build
+
+      - name: Verify build output
+        run: test -f main.js && test -f manifest.json && test -f styles.css
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          # Assets must be attached as individual files (not zipped) so that
+          # BRAT can fetch manifest.json, main.js and styles.css directly.
+          gh release create "$tag" \
+            --title="$tag" \
+            --generate-notes \
+            main.js manifest.json styles.css

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,14 @@ name: Release Obsidian plugin
 on:
   push:
     tags:
-      # Run only for version tags that match the manifest version, e.g. 0.1.0
+      # Run for version tags that match the manifest version, e.g. 0.1.0
       - "[0-9]+.[0-9]+.[0-9]+"
+  # Allow cutting a release manually from the Actions tab / API.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.1.0). Defaults to manifest.json version."
+        required: false
 
 permissions:
   contents: write
@@ -29,14 +35,31 @@ jobs:
       - name: Verify build output
         run: test -f main.js && test -f manifest.json && test -f styles.css
 
-      - name: Create release
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ github.event.inputs.version }}"
+            [ -z "$tag" ] && tag="$(node -p "require('./manifest.json').version")"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Publish release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
-          # Assets must be attached as individual files (not zipped) so that
-          # BRAT can fetch manifest.json, main.js and styles.css directly.
-          gh release create "$tag" \
-            --title="$tag" \
-            --generate-notes \
-            main.js manifest.json styles.css
+          tag="${{ steps.tag.outputs.tag }}"
+          # Assets must be attached as individual files (not zipped) so BRAT can
+          # fetch manifest.json, main.js and styles.css directly. Idempotent so
+          # re-runs just refresh the assets.
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" main.js manifest.json styles.css --clobber
+          else
+            gh release create "$tag" \
+              --target "$GITHUB_SHA" \
+              --title "$tag" \
+              --generate-notes \
+              main.js manifest.json styles.css
+          fi

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ embed notes, images, bases, bookmarks and quick text.
 Each card has a configurable width/height (in grid columns). The dashboard can
 either scroll or be locked to a single page.
 
+## Installation (BRAT)
+
+Hearth isn't in the community store yet, so install it as a beta plugin with
+[BRAT](https://github.com/TfTHacker/obsidian42-brat):
+
+1. Install **BRAT** from Community Plugins and enable it.
+2. Run the command **“BRAT: Add a beta plugin for testing”**.
+3. Enter the repository: `ondreu/Hearth` and confirm.
+4. BRAT downloads the latest release and installs Hearth. Enable it under
+   **Settings → Community plugins**.
+
+BRAT will keep Hearth up to date with each new release. New releases are cut
+automatically by GitHub Actions when a version tag (e.g. `0.1.0`) is pushed.
+
 ## Usage
 - Hearth opens automatically on startup and replaces empty new tabs (both
   toggleable in settings).


### PR DESCRIPTION
Lands the Hearth home-dashboard plugin (v1 foundation) and the release workflow on `main` so the plugin can be installed and auto-updated via BRAT.

## What's included
- Full plugin scaffold (TypeScript + esbuild), builds to `main.js`
- **Top section:** customizable title/logo, vault fuzzy search (ignores `.obsidian`) with keyboard nav, auto-detected file-type filter chips, new-note button, optional background (color/vault image/URL) with opacity & blur
- **Dashboard:** responsive card grid — embed (note/image/canvas/`.base` via MarkdownRenderer), bookmarks (core plugin), favorites, text/jot-down
- Opens on startup + replaces empty new tabs (both toggleable); ribbon icon, commands, full settings tab
- `.github/workflows/release.yml` — builds and publishes a GitHub Release with `manifest.json`, `main.js`, `styles.css` attached as individual assets (BRAT-compatible). Runs on version-tag push or manual dispatch.

Drag & resize of cards and advanced embeds are planned for the next iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTVbYsRtDyBCJtoMWaA31u)_