### PR TITLE
Add per-dashboard search visibility toggle

### DIFF
--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -1,9 +1,9 @@
 import { Menu, Modal, Setting, setIcon } from "obsidian";
 import type { HomeView } from "./view";
 import {
-	BackgroundConfig,
-	BackgroundKind,
-	Dashboard,
+	type BackgroundConfig,
+	type BackgroundKind,
+	type Dashboard,
 	DEFAULT_SETTINGS,
 	newDashboardId,
 	cloneCard,
@@ -118,6 +118,7 @@ function showDashboardMenu(view: HomeView, dash: Dashboard, evt: MouseEvent): vo
 				if (dash.rowHeight != null) copy.rowHeight = dash.rowHeight;
 				if (dash.fitToPage != null) copy.fitToPage = dash.fitToPage;
 				if (dash.maxWidth != null) copy.maxWidth = dash.maxWidth;
+				if (dash.showSearch != null) copy.showSearch = dash.showSearch;
 				if (dash.cardOpacity != null) copy.cardOpacity = dash.cardOpacity;
 				if (dash.cardBlur != null) copy.cardBlur = dash.cardBlur;
 				if (dash.background) copy.background = { ...dash.background };
@@ -156,9 +157,9 @@ function showDashboardMenu(view: HomeView, dash: Dashboard, evt: MouseEvent): vo
 	menu.showAtMouseEvent(evt);
 }
 
-/** Per-dashboard settings: name, switcher icon, and optional overrides for grid
- * columns, row height and background. Overrides fall back to the global
- * settings when left off. */
+/** Per-dashboard settings: name, switcher icon, dashboard chrome, and optional
+ * overrides for grid columns, row height and background. Overrides fall back to
+ * the global settings when left off. */
 class DashboardSettingsModal extends Modal {
 	private view: HomeView;
 	private dash: Dashboard;
@@ -214,6 +215,16 @@ class DashboardSettingsModal extends Modal {
 						dash.iconLucide = v.trim() || undefined;
 						this.commit();
 					}),
+			);
+
+		new Setting(contentEl)
+			.setName(t().dashboards.modal.showSearch)
+			.setDesc(t().dashboards.modal.showSearchDesc)
+			.addToggle((tg) =>
+				tg.setValue(dash.showSearch ?? true).onChange((v) => {
+					dash.showSearch = v ? undefined : false;
+					this.commit();
+				}),
 			);
 
 		this.overrideSlider(

--- a/src/header.ts
+++ b/src/header.ts
@@ -1,7 +1,8 @@
-import { Component, Platform, setIcon } from "obsidian";
+import { type Component, Platform, setIcon } from "obsidian";
 import type { HomeView } from "./view";
 import { SearchSection } from "./search";
 import { HEARTH_ICON_ID } from "./icon";
+import { effectiveShowSearch } from "./types";
 import { t } from "./i18n";
 
 /** The search engine used by the “Search online” button action.
@@ -34,6 +35,8 @@ export function renderHeader(view: HomeView, container: HTMLElement, component: 
 		}
 		titleRow.createSpan({ cls: "hearth-title-text", text: s.title });
 	}
+
+	if (!effectiveShowSearch(s)) return;
 
 	const search = new SearchSection(view);
 

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -1,25 +1,25 @@
 import {
-	BackgroundConfig,
-	BackgroundKind,
-	CalculatorConfig,
-	CalendarConfig,
-	CardKind,
-	ClockConfig,
-	CommandItem,
-	Dashboard,
-	DashboardCard,
-	DataviewConfig,
-	EmbedView,
-	HeatmapConfig,
-	HomeSettings,
-	LeafViewConfig,
-	LinkItem,
-	MobileActionButton,
+	type BackgroundConfig,
+	type BackgroundKind,
+	type CalculatorConfig,
+	type CalendarConfig,
+	type CardKind,
+	type ClockConfig,
+	type CommandItem,
+	type Dashboard,
+	type DashboardCard,
+	type DataviewConfig,
+	type EmbedView,
+	type HeatmapConfig,
+	type HomeSettings,
+	type LeafViewConfig,
+	type LinkItem,
+	type MobileActionButton,
 	newDashboardId,
-	SavedSearchConfig,
-	TaskFilterConfig,
-	TaskSortRule,
-	TasksConfig,
+	type SavedSearchConfig,
+	type TaskFilterConfig,
+	type TaskSortRule,
+	type TasksConfig,
 	activeDashboard,
 } from "./types";
 import { t } from "./i18n";
@@ -537,6 +537,7 @@ function sanitizeDashboard(raw: unknown, s: HomeSettings, index: number): Dashbo
 		dash.rowHeight = clampNum(r.rowHeight, RANGE.rowHeight.min, RANGE.rowHeight.max, s.rowHeight);
 	}
 	if (typeof r.fitToPage === "boolean") dash.fitToPage = r.fitToPage;
+	if (typeof r.showSearch === "boolean") dash.showSearch = r.showSearch;
 	if (typeof r.maxWidth === "number") {
 		dash.maxWidth = clampNum(r.maxWidth, RANGE.maxWidth.min, RANGE.maxWidth.max, s.maxWidth);
 	}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -142,6 +142,8 @@ export const en = {
 			switcherLucideDesc:
 				"A Lucide icon id (e.g. “home”, “star”, “layout-dashboard”). Takes precedence over the emoji above.",
 			lucidePlaceholder: "home",
+			showSearch: "Show search section",
+			showSearchDesc: "Show the search and command bar with its results and filter buttons on this dashboard.",
 			contentWidth: "Content width",
 			fitToPage: "Fit to page",
 			fitToPageDesc: "Override scrolling for this board.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -494,6 +494,8 @@ export interface Dashboard {
 	/** Override the card surface backdrop blur (px) for this board (undefined =
 	 * global). */
 	cardBlur?: number;
+	/** Show the dashboard search/command section (undefined = visible). */
+	showSearch?: boolean;
 }
 
 export interface HomeSettings {
@@ -768,6 +770,11 @@ export function effectiveRowHeight(s: HomeSettings): number {
 /** Effective "fit to page" for the active board (per-dashboard override or global). */
 export function effectiveFitToPage(s: HomeSettings): boolean {
 	return activeDashboard(s).fitToPage ?? s.fitToPage;
+}
+
+/** Whether the active board should show the search/command section. */
+export function effectiveShowSearch(s: HomeSettings): boolean {
+	return activeDashboard(s).showSearch ?? true;
 }
 
 /** Effective content max-width for the active board (per-dashboard override or global). */

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,11 +1,11 @@
-import { Component, ItemView, Platform, WorkspaceLeaf } from "obsidian";
+import { Component, ItemView, Platform, type WorkspaceLeaf } from "obsidian";
 import type HearthPlugin from "./main";
 import { renderHeader } from "./header";
 import { renderDashboard } from "./dashboard";
 import { renderDashboardSwitcher } from "./dashboards";
 import { renderMobileActionBar } from "./mobileactions";
 import { applyBackground } from "./background";
-import { effectiveFitToPage, effectiveMaxWidth, renderCards } from "./types";
+import { effectiveFitToPage, effectiveMaxWidth, effectiveShowSearch, renderCards } from "./types";
 import { HEARTH_ICON_ID } from "./icon";
 import { t } from "./i18n";
 
@@ -130,8 +130,10 @@ export class HomeView extends ItemView {
 
 		if (!mobileOnly) renderDashboardSwitcher(this, inner);
 
-		const header = inner.createDiv("hearth-header");
-		renderHeader(this, header, child);
+		if (this.plugin.settings.showTitle || effectiveShowSearch(this.plugin.settings)) {
+			const header = inner.createDiv("hearth-header");
+			renderHeader(this, header, child);
+		}
 
 		if (!mobileOnly) {
 			const dashboard = inner.createDiv("hearth-dashboard");


### PR DESCRIPTION
## Why

Some dashboards are meant to be more visual or minimal, and the search/command section can take up prominent space even when it is not needed for that specific dashboard.

Hearth already allows hiding the title globally, but the search section is always shown. This makes it harder to create cleaner dashboard layouts where search is not part of the intended experience.

## What changed

- Added a per-dashboard setting to show or hide the search section.
- The setting defaults to visible for existing dashboards.
- When disabled, the search/command bar, results area, and filter buttons are hidden.
- The title/logo behavior remains unchanged.
- The setting is preserved when duplicating dashboards and when importing/exporting layouts.

## Why per-dashboard

This is dashboard-specific rather than global because different dashboards can serve different purposes. One dashboard may benefit from quick search, while another may be designed as a focused visual/home layout.

## Validation

- `npm run typecheck`
- `npm run build`
- Manually tested in Obsidian by toggling "Show search section" from dashboard settings.
