### PR TITLE
Add Base view selector for Embed cards

### DIFF
--- a/src/bases.ts
+++ b/src/bases.ts
@@ -1,0 +1,62 @@
+import { type App, parseYaml, TFile } from "obsidian";
+
+export interface BaseViewOption {
+	name: string;
+	/** Whether the view name can be appended directly as a wikilink subpath. */
+	embeddable: boolean;
+}
+
+export interface BaseViewListResult {
+	views: BaseViewOption[];
+	error?: "not-found" | "invalid-yaml" | "read-failed";
+}
+
+/** Whether an embed target points at a Bases (.base) file. */
+export function isBaseTarget(target: string | undefined): boolean {
+	return !!target && target.trim().toLowerCase().endsWith(".base");
+}
+
+/** Keep view names that would make an ambiguous or broken wikilink out of the
+ * generated `![[file.base#View]]` syntax out of persisted/generated embeds. */
+export function isEmbeddableBaseViewName(name: string | undefined): boolean {
+	const value = name?.trim();
+	return !!value && !/[#|\]\r\n]/.test(value);
+}
+
+/** Read a `.base` file and list its declared views in document order. Uses only
+ * public Vault APIs plus Obsidian's YAML parser; any malformed or missing data
+ * degrades to an empty list instead of breaking the settings modal. */
+export async function listBaseViews(app: App, target: string | undefined): Promise<BaseViewListResult> {
+	const path = target?.trim();
+	if (!path || !isBaseTarget(path)) return { views: [] };
+
+	const file = app.vault.getAbstractFileByPath(path);
+	if (!(file instanceof TFile) || file.extension.toLowerCase() !== "base") {
+		return { views: [], error: "not-found" };
+	}
+
+	let parsed: unknown;
+	try {
+		const raw = await app.vault.cachedRead(file);
+		parsed = parseYaml(raw) as unknown;
+	} catch {
+		return { views: [], error: "invalid-yaml" };
+	}
+
+	if (!parsed || typeof parsed !== "object") return { views: [] };
+	const viewsRaw = (parsed as Record<string, unknown>).views;
+	if (!Array.isArray(viewsRaw)) return { views: [] };
+
+	const seen = new Set<string>();
+	const views: BaseViewOption[] = [];
+	for (const rawView of viewsRaw) {
+		if (!rawView || typeof rawView !== "object") continue;
+		const name = (rawView as Record<string, unknown>).name;
+		if (typeof name !== "string") continue;
+		const trimmed = name.trim();
+		if (!trimmed || seen.has(trimmed)) continue;
+		seen.add(trimmed);
+		views.push({ name: trimmed, embeddable: isEmbeddableBaseViewName(trimmed) });
+	}
+	return { views };
+}

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -1,5 +1,5 @@
 import {
-	App,
+	type App,
 	Component,
 	debounce,
 	getAllTags,
@@ -16,7 +16,7 @@ import {
 } from "obsidian";
 import type { HomeView } from "./view";
 import type { BookmarkItem } from "./obsidian-ext";
-import {
+import type {
 	ClockConfig,
 	CommandItem,
 	DashboardCard,
@@ -35,9 +35,10 @@ import { cachedRates, loadRates } from "./currency";
 import { getDataviewApi } from "./dataview";
 import { isViewTypeHostable, mountLeafView } from "./leafview";
 import { EXCALIDRAW_PLUGIN_ID, iconForFile, isExcalidraw } from "./filetypes";
-import { QueryHit, runQuery, searchFileContents } from "./query";
+import { type QueryHit, runQuery, searchFileContents } from "./query";
 import { confirmAction, makeClickable } from "./ui";
 import { parseNaturalDate, formatRelativeDate } from "./dates";
+import { isEmbeddableBaseViewName } from "./bases";
 import { t } from "./i18n";
 
 /**
@@ -473,7 +474,7 @@ const activeEmbedView = new WeakMap<DashboardCard, number>();
  * Cards without a valid second view return a single-element list. */
 function embedViews(card: DashboardCard): EmbedView[] {
 	const views: EmbedView[] = [
-		{ target: card.target, scale: card.scale, editable: card.editable },
+		{ target: card.target, baseView: card.baseView, scale: card.scale, editable: card.editable },
 	];
 	if (card.secondView?.target?.trim()) views.push(card.secondView);
 	return views;
@@ -574,8 +575,12 @@ function renderEmbed(
 		void renderMarkdownFile(view, file, host, component);
 	} else {
 		// Images, canvas, .base and Excalidraw go through Obsidian's own
-		// transclusion embed, which handles those file types uniformly.
-		void MarkdownRenderer.render(view.app, `![[${target}]]`, host, target, component);
+		// transclusion embed, which handles those file types uniformly. Bases can
+		// optionally target a named view with Obsidian's documented #View subpath.
+		const baseView = active.baseView?.trim();
+		const embedTarget =
+			ext === "base" && isEmbeddableBaseViewName(baseView) ? `${target}#${baseView}` : target;
+		void MarkdownRenderer.render(view.app, `![[${embedTarget}]]`, host, target, component);
 
 		// Canvas and Excalidraw embeds are natively interactive (pan/zoom, and
 		// their own in-place edit toggle) — let them fill the card edge-to-edge

--- a/src/editors.ts
+++ b/src/editors.ts
@@ -1,14 +1,17 @@
-import { App, Modal, Notice, Setting } from "obsidian";
+import { type App, Modal, Notice, Setting } from "obsidian";
+import { listBaseViews, isBaseTarget } from "./bases";
 import { CommandPickerModal, FilePickerModal } from "./pickers";
-import { CardKind, ClockConfig, DashboardCard, EmbedView, LinkItem, TasksConfig } from "./types";
+import type {
+	CardKind,
+	ClockConfig,
+	DashboardCard,
+	EmbedView,
+	LinkItem,
+	TasksConfig,
+} from "./types";
 import { confirmAction } from "./ui";
 import { listLeafViewTypes } from "./leafview";
 import { t } from "./i18n";
-
-/** Whether an embed target points at a Bases (.base) file. */
-function isBaseTarget(target: string | undefined): boolean {
-	return !!target && target.trim().toLowerCase().endsWith(".base");
-}
 
 export interface CardSettingsOptions {
 	/** The global favorites list (shared by all favorites cards). */
@@ -72,10 +75,13 @@ export class CardSettingsModal extends Modal {
 			.setName(t().editors.cardTitle)
 			.setDesc(t().editors.cardTitleDesc)
 			.addText((txt) =>
-				txt.setPlaceholder(t().editors.cardTitlePlaceholder).setValue(card.title ?? "").onChange((v) => {
-					card.title = v;
-					this.opts.save();
-				}),
+				txt
+					.setPlaceholder(t().editors.cardTitlePlaceholder)
+					.setValue(card.title ?? "")
+					.onChange((v) => {
+						card.title = v;
+						this.opts.save();
+					}),
 			);
 
 		this.contentSection(contentEl);
@@ -89,7 +95,9 @@ export class CardSettingsModal extends Modal {
 				b.setButtonText(t().editors.removeCard).onClick(() => {
 					confirmAction(this.app, {
 						title: t().editors.removeCardTitle,
-						message: t().editors.removeCardMessage(this.card.title?.trim() || t().editors.thisCard),
+						message: t().editors.removeCardMessage(
+							this.card.title?.trim() || t().editors.thisCard,
+						),
 						confirmText: t().editors.removeCardConfirm,
 						onConfirm: () => {
 							this.opts.remove();
@@ -121,8 +129,7 @@ export class CardSettingsModal extends Modal {
 						.setPlaceholder(t().editors.embed.filePlaceholder)
 						.setValue(card.target ?? "")
 						.onChange((v) => {
-							card.target = v;
-							this.opts.save();
+							this.setPrimaryEmbedTarget(v);
 						}),
 				);
 				setting.addExtraButton((b) =>
@@ -131,34 +138,41 @@ export class CardSettingsModal extends Modal {
 						.setTooltip(t().editors.embed.pickFile)
 						.onClick(() => {
 							new FilePickerModal(this.app, (file) => {
-								card.target = file.path;
-								this.opts.save();
-								this.render();
+								this.setPrimaryEmbedTarget(file.path, true);
 							}).open();
 						}),
 				);
-			new Setting(containerEl)
-				.setName(t().editors.embed.zoom)
-				.setDesc(t().editors.embed.zoomDesc)
-				.addSlider((s) => {
-					s.setLimits(50, 200, 10)
-						.setValue(Math.round((card.scale ?? 1) * 100))
-						.setDynamicTooltip()
-						.onChange((v) => {
-							card.scale = v === 100 ? undefined : v / 100;
-							this.opts.save();
-						});
-				})
-				.addExtraButton((b) =>
-					b
-						.setIcon("rotate-ccw")
-						.setTooltip(t().settings.resetSlider)
-						.onClick(() => {
-							card.scale = undefined;
-							this.opts.save();
-							this.render();
-						}),
+				this.baseViewSetting(
+					containerEl,
+					card.target,
+					() => card.baseView,
+					(v) => {
+						card.baseView = v;
+						this.opts.save();
+					},
 				);
+				new Setting(containerEl)
+					.setName(t().editors.embed.zoom)
+					.setDesc(t().editors.embed.zoomDesc)
+					.addSlider((s) => {
+						s.setLimits(50, 200, 10)
+							.setValue(Math.round((card.scale ?? 1) * 100))
+							.setDynamicTooltip()
+							.onChange((v) => {
+								card.scale = v === 100 ? undefined : v / 100;
+								this.opts.save();
+							});
+					})
+					.addExtraButton((b) =>
+						b
+							.setIcon("rotate-ccw")
+							.setTooltip(t().settings.resetSlider)
+							.onClick(() => {
+								card.scale = undefined;
+								this.opts.save();
+								this.render();
+							}),
+					);
 				new Setting(containerEl)
 					.setName(t().editors.embed.editable)
 					.setDesc(t().editors.embed.editableDesc)
@@ -169,20 +183,23 @@ export class CardSettingsModal extends Modal {
 						}),
 					);
 				// Hide-base-header is only relevant to .base embeds; shown when either
-					// view targets one.
-					if (isBaseTarget(card.target) || isBaseTarget(card.secondView?.target)) {
-						new Setting(containerEl)
-							.setName(t().editors.embed.hideBaseHeader)
-							.setDesc(t().editors.embed.hideBaseHeaderDesc)
-							.addToggle((tg) =>
-								tg.setValue(card.hideBaseHeader ?? false).onChange((v) => {
-									card.hideBaseHeader = v || undefined;
-									this.opts.save();
-									this.opts.rerender();
-								}),
-							);
-					}
-					this.embedSecondView(containerEl);
+				// view targets one.
+				if (
+					isBaseTarget(card.target) ||
+					isBaseTarget(card.secondView?.target)
+				) {
+					new Setting(containerEl)
+						.setName(t().editors.embed.hideBaseHeader)
+						.setDesc(t().editors.embed.hideBaseHeaderDesc)
+						.addToggle((tg) =>
+							tg.setValue(card.hideBaseHeader ?? false).onChange((v) => {
+								card.hideBaseHeader = v || undefined;
+								this.opts.save();
+								this.opts.rerender();
+							}),
+						);
+				}
+				this.embedSecondView(containerEl);
 				break;
 			}
 			case "daily":
@@ -316,7 +333,78 @@ export class CardSettingsModal extends Modal {
 			});
 		});
 
-		new Setting(containerEl).setName(t().editors.leaf.note).setDesc(t().editors.leaf.noteDesc);
+		new Setting(containerEl)
+			.setName(t().editors.leaf.note)
+			.setDesc(t().editors.leaf.noteDesc);
+	}
+
+	private setPrimaryEmbedTarget(value: string, rerender = false): void {
+		const previousTarget = this.card.target?.trim() ?? "";
+		const nextTarget = value.trim();
+		const wasBase = isBaseTarget(previousTarget);
+		const isBase = isBaseTarget(nextTarget);
+		const targetChanged = nextTarget !== previousTarget;
+		this.card.target = value;
+		if (!isBase || targetChanged) this.card.baseView = undefined;
+		this.opts.save();
+		if (rerender || wasBase !== isBase || (isBase && targetChanged))
+			this.render();
+	}
+
+	private baseViewSetting(
+		containerEl: HTMLElement,
+		target: string | undefined,
+		getBaseView: () => string | undefined,
+		setBaseView: (value: string | undefined) => void,
+	): void {
+		if (!isBaseTarget(target)) return;
+
+		const setting = new Setting(containerEl)
+			.setName(t().editors.embed.baseView)
+			.setDesc(t().editors.embed.baseViewDesc);
+
+		setting.addDropdown((dropdown) => {
+			const selected = getBaseView()?.trim() ?? "";
+			dropdown.addOption("", t().editors.embed.baseViewDefault);
+			if (selected) dropdown.addOption(selected, selected);
+			dropdown.setValue(selected).onChange((value) => {
+				setBaseView(value || undefined);
+			});
+
+			void listBaseViews(this.app, target).then((result) => {
+				if (!setting.settingEl.isConnected) return;
+
+				const safeViews = result.views
+					.filter((view) => view.embeddable)
+					.map((view) => view.name);
+				while (dropdown.selectEl.firstChild)
+					dropdown.selectEl.removeChild(dropdown.selectEl.firstChild);
+				dropdown.addOption("", t().editors.embed.baseViewDefault);
+				for (const viewName of safeViews)
+					dropdown.addOption(viewName, viewName);
+
+				const current = getBaseView()?.trim() ?? "";
+				if (!result.error && current && !safeViews.includes(current)) {
+					setBaseView(undefined);
+					dropdown.setValue("");
+				} else {
+					dropdown.setValue(current);
+				}
+
+				const unsupportedCount = result.views.length - safeViews.length;
+				if (result.error === "not-found") {
+					setting.setDesc(t().editors.embed.baseViewFileMissing);
+				} else if (result.error) {
+					setting.setDesc(t().editors.embed.baseViewLoadError);
+				} else if (result.views.length === 0) {
+					setting.setDesc(t().editors.embed.baseViewNoViews);
+				} else if (unsupportedCount > 0) {
+					setting.setDesc(
+						t().editors.embed.baseViewUnsupported(unsupportedCount),
+					);
+				}
+			});
+		});
 	}
 
 	/** Second-view controls for an embed card: pick a second file to embed, and
@@ -325,7 +413,9 @@ export class CardSettingsModal extends Modal {
 	private embedSecondView(containerEl: HTMLElement): void {
 		const card = this.card;
 
-		new Setting(containerEl).setName(t().editors.embed.secondViewHeading).setHeading();
+		new Setting(containerEl)
+			.setName(t().editors.embed.secondViewHeading)
+			.setHeading();
 
 		const setting = new Setting(containerEl)
 			.setName(t().editors.embed.secondViewFile)
@@ -344,8 +434,7 @@ export class CardSettingsModal extends Modal {
 				.setTooltip(t().editors.embed.pickFile)
 				.onClick(() => {
 					new FilePickerModal(this.app, (file) => {
-						this.setSecondViewTarget(file.path);
-						this.render();
+						this.setSecondViewTarget(file.path, true);
 					}).open();
 				}),
 		);
@@ -366,6 +455,15 @@ export class CardSettingsModal extends Modal {
 		// sense once a second file is chosen.
 		if (card.secondView?.target) {
 			const view = card.secondView;
+			this.baseViewSetting(
+				containerEl,
+				view.target,
+				() => view.baseView,
+				(v: string | undefined) => {
+					view.baseView = v;
+					this.opts.save();
+				},
+			);
 			new Setting(containerEl)
 				.setName(t().editors.embed.zoom)
 				.setDesc(t().editors.embed.zoomDesc)
@@ -402,16 +500,23 @@ export class CardSettingsModal extends Modal {
 
 	/** Set (or clear) the second view's embed target, creating the config object
 	 * on first use and dropping it entirely when emptied. */
-	private setSecondViewTarget(value: string): void {
+	private setSecondViewTarget(value: string, rerender = false): void {
 		const target = value.trim();
+		const previousTarget = this.card.secondView?.target?.trim() ?? "";
+		const targetChanged = target !== previousTarget;
+		const wasBase = isBaseTarget(previousTarget);
+		const isBase = isBaseTarget(target);
 		if (!target) {
 			this.card.secondView = undefined;
 		} else {
 			const next: EmbedView = { ...(this.card.secondView ?? {}) };
 			next.target = target;
+			if (!isBase || targetChanged) next.baseView = undefined;
 			this.card.secondView = next;
 		}
 		this.opts.save();
+		if (rerender || wasBase !== isBase || (isBase && targetChanged))
+			this.render();
 	}
 
 	private dataviewEditor(containerEl: HTMLElement): void {
@@ -432,11 +537,17 @@ export class CardSettingsModal extends Modal {
 		const isJs = cfg.language === "js";
 		const query = new Setting(containerEl)
 			.setName(t().editors.dataview.query)
-			.setDesc(isJs ? t().editors.dataview.queryJsDesc : t().editors.dataview.queryDqlDesc);
+			.setDesc(
+				isJs
+					? t().editors.dataview.queryJsDesc
+					: t().editors.dataview.queryDqlDesc,
+			);
 		query.addTextArea((txt) => {
 			txt
 				.setPlaceholder(
-					isJs ? t().editors.dataview.queryJsPlaceholder : t().editors.dataview.queryDqlPlaceholder,
+					isJs
+						? t().editors.dataview.queryJsPlaceholder
+						: t().editors.dataview.queryDqlPlaceholder,
 				)
 				.setValue(cfg.query ?? "")
 				.onChange((v) => {
@@ -500,27 +611,31 @@ export class CardSettingsModal extends Modal {
 				}),
 			);
 		if (cfg.heatmap) {
-			new Setting(containerEl).setName(t().editors.calendar.heatmapCounts).addDropdown((d) => {
-				d.addOption("modified", t().editors.metricOptions.modified);
-				d.addOption("created", t().editors.metricOptions.created);
-				d.setValue(cfg.heatmapMetric ?? "modified").onChange((v) => {
-					cfg.heatmapMetric = v as NonNullable<typeof cfg.heatmapMetric>;
-					this.opts.save();
+			new Setting(containerEl)
+				.setName(t().editors.calendar.heatmapCounts)
+				.addDropdown((d) => {
+					d.addOption("modified", t().editors.metricOptions.modified);
+					d.addOption("created", t().editors.metricOptions.created);
+					d.setValue(cfg.heatmapMetric ?? "modified").onChange((v) => {
+						cfg.heatmapMetric = v as NonNullable<typeof cfg.heatmapMetric>;
+						this.opts.save();
+					});
 				});
-			});
 		}
 	}
 
 	private heatmapEditor(containerEl: HTMLElement): void {
 		const cfg = (this.card.heatmap ??= {});
-		new Setting(containerEl).setName(t().editors.heatmap.metric).addDropdown((d) => {
-			d.addOption("modified", t().editors.metricOptions.modified);
-			d.addOption("created", t().editors.metricOptions.created);
-			d.setValue(cfg.metric ?? "modified").onChange((v) => {
-				cfg.metric = v as NonNullable<typeof cfg.metric>;
-				this.opts.save();
+		new Setting(containerEl)
+			.setName(t().editors.heatmap.metric)
+			.addDropdown((d) => {
+				d.addOption("modified", t().editors.metricOptions.modified);
+				d.addOption("created", t().editors.metricOptions.created);
+				d.setValue(cfg.metric ?? "modified").onChange((v) => {
+					cfg.metric = v as NonNullable<typeof cfg.metric>;
+					this.opts.save();
+				});
 			});
-		});
 		const weeks = new Setting(containerEl)
 			.setName(t().editors.heatmap.weeks)
 			.setDesc(t().editors.heatmap.weeksDesc);
@@ -590,7 +705,11 @@ export class CardSettingsModal extends Modal {
 
 	/** Add a reset (rotate-ccw) extra button that clears a field back to its
 	 * default, then saves and redraws so the input reflects the restored value. */
-	private addResetButton(setting: Setting, tooltip: string, onReset: () => void): void {
+	private addResetButton(
+		setting: Setting,
+		tooltip: string,
+		onReset: () => void,
+	): void {
 		setting.addExtraButton((b) =>
 			b
 				.setIcon("rotate-ccw")
@@ -627,7 +746,10 @@ export class CardSettingsModal extends Modal {
 			});
 			txt.inputEl.type = "number";
 			txt.inputEl.addClass("hearth-count-input");
-			txt.inputEl.setAttribute("aria-label", t().editors.web.refreshIntervalAria);
+			txt.inputEl.setAttribute(
+				"aria-label",
+				t().editors.web.refreshIntervalAria,
+			);
 		});
 		this.addResetButton(setting, t().settings.resetField, () => {
 			card.refreshSec = undefined;
@@ -652,21 +774,29 @@ export class CardSettingsModal extends Modal {
 		links.forEach((link, index) => {
 			const row = new Setting(containerEl).setClass("hearth-link-setting");
 			row.addText((txt) =>
-				txt.setPlaceholder(t().editors.links.labelPlaceholder).setValue(link.label).onChange((v) => {
-					link.label = v;
-					this.opts.save();
-				}),
+				txt
+					.setPlaceholder(t().editors.links.labelPlaceholder)
+					.setValue(link.label)
+					.onChange((v) => {
+						link.label = v;
+						this.opts.save();
+					}),
 			);
 			row.addText((txt) =>
-				txt.setPlaceholder(t().editors.links.iconPlaceholder).setValue(link.icon).onChange((v) => {
-					link.icon = v;
-					this.opts.save();
-				}),
+				txt
+					.setPlaceholder(t().editors.links.iconPlaceholder)
+					.setValue(link.icon)
+					.onChange((v) => {
+						link.icon = v;
+						this.opts.save();
+					}),
 			);
 			row.addDropdown((d) => {
-				(Object.keys(t().editors.linkTypes) as LinkItem["type"][]).forEach((k) => {
-					d.addOption(k, t().editors.linkTypes[k]);
-				});
+				(Object.keys(t().editors.linkTypes) as LinkItem["type"][]).forEach(
+					(k) => {
+						d.addOption(k, t().editors.linkTypes[k]);
+					},
+				);
 				d.setValue(link.type).onChange((v) => {
 					link.type = v as LinkItem["type"];
 					this.opts.save();
@@ -685,7 +815,9 @@ export class CardSettingsModal extends Modal {
 					const current = link.target
 						? this.app.commands.listCommands().find((c) => c.id === link.target)
 						: undefined;
-					b.setButtonText(current ? current.name : t().editors.links.pickCommand);
+					b.setButtonText(
+						current ? current.name : t().editors.links.pickCommand,
+					);
 					b.onClick(() => {
 						new CommandPickerModal(this.app, (command) => {
 							link.target = command.id;
@@ -706,7 +838,9 @@ export class CardSettingsModal extends Modal {
 				row.addText((txt) =>
 					txt
 						.setPlaceholder(
-							link.type === "url" ? t().editors.links.targetUrl : t().editors.links.targetNote,
+							link.type === "url"
+								? t().editors.links.targetUrl
+								: t().editors.links.targetNote,
 						)
 						.setValue(link.target)
 						.onChange((v) => {
@@ -807,7 +941,8 @@ export class CardSettingsModal extends Modal {
 					}),
 			);
 			row.addText((txt) => {
-				txt.setPlaceholder(t().editors.commands.sizePlaceholder)
+				txt
+					.setPlaceholder(t().editors.commands.sizePlaceholder)
 					.setValue(cmd.size ? String(cmd.size) : "")
 					.onChange((v) => {
 						const n = parseInt(v, 10);
@@ -816,7 +951,10 @@ export class CardSettingsModal extends Modal {
 					});
 				txt.inputEl.type = "number";
 				txt.inputEl.addClass("hearth-count-input");
-				txt.inputEl.setAttribute("aria-label", t().editors.commands.tileSizeAria);
+				txt.inputEl.setAttribute(
+					"aria-label",
+					t().editors.commands.tileSizeAria,
+				);
 			});
 			row.addExtraButton((b) =>
 				b
@@ -847,7 +985,11 @@ export class CardSettingsModal extends Modal {
 		new Setting(containerEl).addButton((b) =>
 			b.setButtonText(t().editors.commands.addCommand).onClick(() => {
 				new CommandPickerModal(this.app, (command) => {
-					commands.push({ id: command.id, name: command.name, icon: command.icon });
+					commands.push({
+						id: command.id,
+						name: command.name,
+						icon: command.icon,
+					});
 					this.opts.save();
 					this.render();
 				}).open();
@@ -901,7 +1043,8 @@ export class CardSettingsModal extends Modal {
 							},
 							t().editors.tasks.pickBoard,
 							(file) => {
-								const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;
+								const fm =
+									this.app.metadataCache.getFileCache(file)?.frontmatter;
 								return !!fm && "kanban-plugin" in fm;
 							},
 						).open();
@@ -954,10 +1097,12 @@ export class CardSettingsModal extends Modal {
 				.setName(t().editors.tasks.convertScrape)
 				.setDesc(t().editors.tasks.convertScrapeDesc)
 				.addToggle((tg) =>
-					tg.setValue(cfg.convertMetadataToFrontmatter ?? false).onChange((v) => {
-						cfg.convertMetadataToFrontmatter = v || undefined;
-						this.opts.save();
-					}),
+					tg
+						.setValue(cfg.convertMetadataToFrontmatter ?? false)
+						.onChange((v) => {
+							cfg.convertMetadataToFrontmatter = v || undefined;
+							this.opts.save();
+						}),
 				);
 
 			new Setting(containerEl)
@@ -1002,25 +1147,39 @@ export class CardSettingsModal extends Modal {
 				.setName(t().editors.tasks.checkboxStatuses)
 				.setDesc(t().editors.tasks.checkboxStatusesDesc)
 				.addTextArea((ta) => {
-					ta.setValue(statusText).setPlaceholder(defaultStatusText).onChange((v) => {
-						const parsed = v
-							.split("\n")
-							.map((line) => {
-								const m = /^\s*\[(.)\]\s*(.*)$/.exec(line);
-								if (!m) return null;
-								let label = m[2].trim();
-								let done = false;
-								const dm = /\(done\)\s*$/i.exec(label);
-								if (dm) {
-									done = true;
-									label = label.slice(0, dm.index).trim();
-								}
-								return { symbol: m[1], label: label || m[1], done: done || undefined };
-							})
-							.filter((s): s is { symbol: string; label: string; done: boolean | undefined } => s !== null);
-						cfg.checkboxStatuses = parsed.length ? parsed : undefined;
-						this.opts.save();
-					});
+					ta.setValue(statusText)
+						.setPlaceholder(defaultStatusText)
+						.onChange((v) => {
+							const parsed = v
+								.split("\n")
+								.map((line) => {
+									const m = /^\s*\[(.)\]\s*(.*)$/.exec(line);
+									if (!m) return null;
+									let label = m[2].trim();
+									let done = false;
+									const dm = /\(done\)\s*$/i.exec(label);
+									if (dm) {
+										done = true;
+										label = label.slice(0, dm.index).trim();
+									}
+									return {
+										symbol: m[1],
+										label: label || m[1],
+										done: done || undefined,
+									};
+								})
+								.filter(
+									(
+										s,
+									): s is {
+										symbol: string;
+										label: string;
+										done: boolean | undefined;
+									} => s !== null,
+								);
+							cfg.checkboxStatuses = parsed.length ? parsed : undefined;
+							this.opts.save();
+						});
 					ta.inputEl.rows = 4;
 					ta.inputEl.addClass("hearth-tasks-statuses-input");
 				});
@@ -1078,15 +1237,22 @@ export class CardSettingsModal extends Modal {
 
 		if (
 			cfg.layout === "kanban" &&
-			(cfg.kanbanHidden?.length || cfg.kanbanOrder?.length || cfg.kanbanDoneColumns?.length)
+			(cfg.kanbanHidden?.length ||
+				cfg.kanbanOrder?.length ||
+				cfg.kanbanDoneColumns?.length)
 		) {
 			const parts: string[] = [];
-			if (cfg.kanbanHidden?.length) parts.push(t().editors.tasks.kanbanHidden(cfg.kanbanHidden.join(", ")));
+			if (cfg.kanbanHidden?.length)
+				parts.push(t().editors.tasks.kanbanHidden(cfg.kanbanHidden.join(", ")));
 			if (cfg.kanbanDoneColumns?.length)
-				parts.push(t().editors.tasks.kanbanDoneColumns(cfg.kanbanDoneColumns.join(", ")));
+				parts.push(
+					t().editors.tasks.kanbanDoneColumns(cfg.kanbanDoneColumns.join(", ")),
+				);
 			const reset = new Setting(containerEl)
 				.setName(t().editors.tasks.kanbanColumns)
-				.setDesc(parts.length ? parts.join(" ") : t().editors.tasks.kanbanCustomOrder);
+				.setDesc(
+					parts.length ? parts.join(" ") : t().editors.tasks.kanbanCustomOrder,
+				);
 			if (cfg.kanbanHidden?.length) {
 				reset.addButton((b) =>
 					b.setButtonText(t().editors.tasks.showAll).onClick(() => {
@@ -1141,16 +1307,18 @@ export class CardSettingsModal extends Modal {
 		});
 
 		new Setting(containerEl).setName(t().editors.tasks.folders).setHeading();
-		new Setting(containerEl).setName(t().editors.tasks.scope).addDropdown((d) => {
-			d.addOption("all", t().editors.tasks.scopeAll);
-			d.addOption("whitelist", t().editors.tasks.scopeWhitelist);
-			d.addOption("blacklist", t().editors.tasks.scopeBlacklist);
-			d.setValue(cfg.folderScope ?? "all").onChange((v) => {
-				cfg.folderScope = v as TasksConfig["folderScope"];
-				this.opts.save();
-				this.render();
+		new Setting(containerEl)
+			.setName(t().editors.tasks.scope)
+			.addDropdown((d) => {
+				d.addOption("all", t().editors.tasks.scopeAll);
+				d.addOption("whitelist", t().editors.tasks.scopeWhitelist);
+				d.addOption("blacklist", t().editors.tasks.scopeBlacklist);
+				d.setValue(cfg.folderScope ?? "all").onChange((v) => {
+					cfg.folderScope = v as TasksConfig["folderScope"];
+					this.opts.save();
+					this.render();
+				});
 			});
-		});
 
 		if ((cfg.folderScope ?? "all") !== "all") {
 			new Setting(containerEl)
@@ -1224,36 +1392,44 @@ export class CardSettingsModal extends Modal {
 	private clockEditor(containerEl: HTMLElement): void {
 		const cfg = (this.card.clock ??= {});
 
-		new Setting(containerEl).setName(t().editors.clock.style).addDropdown((d) => {
-			d.addOption("digital", t().editors.clock.styleDigital);
-			d.addOption("analog", t().editors.clock.styleAnalog);
-			d.setValue(cfg.mode ?? "digital").onChange((v) => {
-				cfg.mode = v as NonNullable<ClockConfig["mode"]>;
-				this.opts.save();
-				this.render();
+		new Setting(containerEl)
+			.setName(t().editors.clock.style)
+			.addDropdown((d) => {
+				d.addOption("digital", t().editors.clock.styleDigital);
+				d.addOption("analog", t().editors.clock.styleAnalog);
+				d.setValue(cfg.mode ?? "digital").onChange((v) => {
+					cfg.mode = v as NonNullable<ClockConfig["mode"]>;
+					this.opts.save();
+					this.render();
+				});
 			});
-		});
 
 		if (cfg.mode !== "analog") {
-			new Setting(containerEl).setName(t().editors.clock.hour24).addToggle((t) =>
-				t.setValue(cfg.use24Hour ?? false).onChange((v) => {
-					cfg.use24Hour = v;
+			new Setting(containerEl)
+				.setName(t().editors.clock.hour24)
+				.addToggle((t) =>
+					t.setValue(cfg.use24Hour ?? false).onChange((v) => {
+						cfg.use24Hour = v;
+						this.opts.save();
+					}),
+				);
+		}
+		new Setting(containerEl)
+			.setName(t().editors.clock.showSeconds)
+			.addToggle((t) =>
+				t.setValue(cfg.showSeconds ?? false).onChange((v) => {
+					cfg.showSeconds = v;
 					this.opts.save();
 				}),
 			);
-		}
-		new Setting(containerEl).setName(t().editors.clock.showSeconds).addToggle((t) =>
-			t.setValue(cfg.showSeconds ?? false).onChange((v) => {
-				cfg.showSeconds = v;
-				this.opts.save();
-			}),
-		);
-		new Setting(containerEl).setName(t().editors.clock.showGreeting).addToggle((t) =>
-			t.setValue(cfg.showGreeting !== false).onChange((v) => {
-				cfg.showGreeting = v;
-				this.opts.save();
-			}),
-		);
+		new Setting(containerEl)
+			.setName(t().editors.clock.showGreeting)
+			.addToggle((t) =>
+				t.setValue(cfg.showGreeting !== false).onChange((v) => {
+					cfg.showGreeting = v;
+					this.opts.save();
+				}),
+			);
 		new Setting(containerEl)
 			.setName(t().editors.clock.playful)
 			.setDesc(t().editors.clock.playfulDesc)
@@ -1272,29 +1448,34 @@ export class CardSettingsModal extends Modal {
 					this.opts.save();
 				}),
 			);
-		new Setting(containerEl).setName(t().editors.clock.date).addDropdown((d) => {
-			d.addOption("full", t().editors.clock.dateFull);
-			d.addOption("long", t().editors.clock.dateLong);
-			d.addOption("short", t().editors.clock.dateShort);
-			d.addOption("iso", t().editors.clock.dateIso);
-			d.addOption("weekday", t().editors.clock.dateWeekday);
-			d.addOption("custom", t().editors.clock.dateCustom);
-			d.addOption("none", t().editors.clock.dateNone);
-			d.setValue(cfg.dateMode ?? "full").onChange((v) => {
-				cfg.dateMode = v as NonNullable<ClockConfig["dateMode"]>;
-				this.opts.save();
-				this.render();
+		new Setting(containerEl)
+			.setName(t().editors.clock.date)
+			.addDropdown((d) => {
+				d.addOption("full", t().editors.clock.dateFull);
+				d.addOption("long", t().editors.clock.dateLong);
+				d.addOption("short", t().editors.clock.dateShort);
+				d.addOption("iso", t().editors.clock.dateIso);
+				d.addOption("weekday", t().editors.clock.dateWeekday);
+				d.addOption("custom", t().editors.clock.dateCustom);
+				d.addOption("none", t().editors.clock.dateNone);
+				d.setValue(cfg.dateMode ?? "full").onChange((v) => {
+					cfg.dateMode = v as NonNullable<ClockConfig["dateMode"]>;
+					this.opts.save();
+					this.render();
+				});
 			});
-		});
 		if (cfg.dateMode === "custom") {
 			new Setting(containerEl)
 				.setName(t().editors.clock.customFormat)
 				.setDesc(t().editors.clock.customFormatDesc)
 				.addText((txt) =>
-					txt.setPlaceholder(t().editors.clock.customFormatPlaceholder).setValue(cfg.dateFormat ?? "").onChange((v) => {
-						cfg.dateFormat = v;
-						this.opts.save();
-					}),
+					txt
+						.setPlaceholder(t().editors.clock.customFormatPlaceholder)
+						.setValue(cfg.dateFormat ?? "")
+						.onChange((v) => {
+							cfg.dateFormat = v;
+							this.opts.save();
+						}),
 				);
 		}
 	}
@@ -1398,15 +1579,17 @@ export class CardSettingsModal extends Modal {
 			.setDesc(t().editors.size.headingDesc);
 
 		row.addText((txt) => {
-			txt.setValue(String(Math.round((card.fw ?? 0.25) * 100))).onChange((v) => {
-				const n = parseInt(v, 10);
-				if (Number.isNaN(n)) return;
-				const fw = Math.max(2, Math.min(n, 100)) / 100;
-				card.fw = fw;
-				// Keep the card inside the board when it grows past the right edge.
-				card.fx = Math.max(0, Math.min(card.fx ?? 0, 1 - fw));
-				this.opts.save();
-			});
+			txt
+				.setValue(String(Math.round((card.fw ?? 0.25) * 100)))
+				.onChange((v) => {
+					const n = parseInt(v, 10);
+					if (Number.isNaN(n)) return;
+					const fw = Math.max(2, Math.min(n, 100)) / 100;
+					card.fw = fw;
+					// Keep the card inside the board when it grows past the right edge.
+					card.fx = Math.max(0, Math.min(card.fx ?? 0, 1 - fw));
+					this.opts.save();
+				});
 			txt.inputEl.type = "number";
 			txt.inputEl.addClass("hearth-count-input");
 			txt.inputEl.setAttribute("aria-label", t().editors.size.widthAria);

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -9,7 +9,8 @@ import {
 	type Dashboard,
 	type DashboardCard,
 	type DataviewConfig,
-	type EmbedView,
+
+
 	type HeatmapConfig,
 	type HomeSettings,
 	type LeafViewConfig,
@@ -22,6 +23,7 @@ import {
 	type TasksConfig,
 	activeDashboard,
 } from "./types";
+import { isEmbeddableBaseViewName } from "./bases";
 import { t } from "./i18n";
 
 /** Current dashboard-layout export schema version. v2 carries every dashboard
@@ -161,6 +163,25 @@ function str(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }
 
+function sanitizeBaseViewName(raw: unknown): string | undefined {
+	if (typeof raw !== "string") return undefined;
+	const name = raw.trim();
+	return isEmbeddableBaseViewName(name) ? name : undefined;
+}
+
+function sanitizeEmbedView(raw: unknown): DashboardCard["secondView"] | undefined {
+	if (!raw || typeof raw !== "object") return undefined;
+	const r = raw as Record<string, unknown>;
+	const target = str(r.target);
+	if (target === undefined) return undefined;
+	const view: NonNullable<DashboardCard["secondView"]> = { target };
+	const baseView = sanitizeBaseViewName(r.baseView);
+	if (baseView !== undefined) view.baseView = baseView;
+	if (typeof r.scale === "number") view.scale = r.scale;
+	if (typeof r.editable === "boolean") view.editable = r.editable;
+	return view;
+}
+
 function sanitizeLink(raw: unknown): LinkItem | null {
 	if (!raw || typeof raw !== "object") return null;
 	const r = raw as Record<string, unknown>;
@@ -218,6 +239,10 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 	if (title !== undefined) card.title = title;
 	const target = str(r.target);
 	if (target !== undefined) card.target = target;
+	const baseView = sanitizeBaseViewName(r.baseView);
+	if (baseView !== undefined) card.baseView = baseView;
+	const secondView = sanitizeEmbedView(r.secondView);
+	if (secondView) card.secondView = secondView;
 	const url = str(r.url);
 	if (url !== undefined) card.url = url;
 	const text = str(r.text);
@@ -230,6 +255,7 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 	if (typeof r.scale === "number") card.scale = r.scale;
 	if (typeof r.refreshSec === "number") card.refreshSec = r.refreshSec;
 	if (typeof r.editable === "boolean") card.editable = r.editable;
+	if (typeof r.hideBaseHeader === "boolean") card.hideBaseHeader = r.hideBaseHeader;
 	if (typeof r.tileSize === "number") card.tileSize = r.tileSize;
 	if (typeof r.tileAutoFlow === "boolean") card.tileAutoFlow = r.tileAutoFlow;
 	if (typeof r.showOpenButton === "boolean") card.showOpenButton = r.showOpenButton;
@@ -491,15 +517,6 @@ function sanitizeLeafView(r: Record<string, unknown>): LeafViewConfig {
 	const viewType = str(r.viewType);
 	if (viewType !== undefined) cfg.viewType = viewType;
 	return cfg;
-}
-
-function sanitizeEmbedView(r: Record<string, unknown>): EmbedView {
-	const view: EmbedView = {};
-	const target = str(r.target);
-	if (target !== undefined) view.target = target;
-	if (typeof r.scale === "number") view.scale = r.scale;
-	if (typeof r.editable === "boolean") view.editable = r.editable;
-	return view;
 }
 
 function sanitizeBackground(raw: unknown): BackgroundConfig | undefined {

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -9,8 +9,6 @@ import {
 	type Dashboard,
 	type DashboardCard,
 	type DataviewConfig,
-
-
 	type HeatmapConfig,
 	type HomeSettings,
 	type LeafViewConfig,
@@ -155,7 +153,12 @@ function num(value: unknown, fallback: number): number {
 	return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
-function clampNum(value: unknown, min: number, max: number, fallback: number): number {
+function clampNum(
+	value: unknown,
+	min: number,
+	max: number,
+	fallback: number,
+): number {
 	return Math.max(min, Math.min(max, Math.round(num(value, fallback))));
 }
 
@@ -169,7 +172,9 @@ function sanitizeBaseViewName(raw: unknown): string | undefined {
 	return isEmbeddableBaseViewName(name) ? name : undefined;
 }
 
-function sanitizeEmbedView(raw: unknown): DashboardCard["secondView"] | undefined {
+function sanitizeEmbedView(
+	raw: unknown,
+): DashboardCard["secondView"] | undefined {
 	if (!raw || typeof raw !== "object") return undefined;
 	const r = raw as Record<string, unknown>;
 	const target = str(r.target);
@@ -204,7 +209,9 @@ function sanitizeLink(raw: unknown): LinkItem | null {
 function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 	if (!raw || typeof raw !== "object") return null;
 	const r = raw as Record<string, unknown>;
-	const kind = CARD_KINDS.includes(r.kind as CardKind) ? (r.kind as CardKind) : null;
+	const kind = CARD_KINDS.includes(r.kind as CardKind)
+		? (r.kind as CardKind)
+		: null;
 	if (!kind) return null;
 
 	const card: DashboardCard = {
@@ -255,17 +262,23 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 	if (typeof r.scale === "number") card.scale = r.scale;
 	if (typeof r.refreshSec === "number") card.refreshSec = r.refreshSec;
 	if (typeof r.editable === "boolean") card.editable = r.editable;
-	if (typeof r.hideBaseHeader === "boolean") card.hideBaseHeader = r.hideBaseHeader;
+	if (typeof r.hideBaseHeader === "boolean")
+		card.hideBaseHeader = r.hideBaseHeader;
 	if (typeof r.tileSize === "number") card.tileSize = r.tileSize;
 	if (typeof r.tileAutoFlow === "boolean") card.tileAutoFlow = r.tileAutoFlow;
-	if (typeof r.showOpenButton === "boolean") card.showOpenButton = r.showOpenButton;
-	if (typeof r.hideBaseHeader === "boolean") card.hideBaseHeader = r.hideBaseHeader;
-	if (typeof r.sandboxTrusted === "boolean") card.sandboxTrusted = r.sandboxTrusted;
+	if (typeof r.showOpenButton === "boolean")
+		card.showOpenButton = r.showOpenButton;
+	if (typeof r.hideBaseHeader === "boolean")
+		card.hideBaseHeader = r.hideBaseHeader;
+	if (typeof r.sandboxTrusted === "boolean")
+		card.sandboxTrusted = r.sandboxTrusted;
 	if (typeof r.pinned === "boolean") card.pinned = r.pinned;
 	if (typeof r.cardOpacity === "number") card.cardOpacity = r.cardOpacity;
 	if (typeof r.cardBlur === "number") card.cardBlur = r.cardBlur;
 	if (Array.isArray(r.links)) {
-		card.links = r.links.map(sanitizeLink).filter((l): l is LinkItem => l !== null);
+		card.links = r.links
+			.map(sanitizeLink)
+			.filter((l): l is LinkItem => l !== null);
 	}
 	if (Array.isArray(r.commands)) {
 		card.commands = r.commands
@@ -282,13 +295,17 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 		card.calendar = sanitizeCalendar(r.calendar as Record<string, unknown>);
 	}
 	if (r.savedSearch && typeof r.savedSearch === "object") {
-		card.savedSearch = sanitizeSavedSearch(r.savedSearch as Record<string, unknown>);
+		card.savedSearch = sanitizeSavedSearch(
+			r.savedSearch as Record<string, unknown>,
+		);
 	}
 	if (r.heatmap && typeof r.heatmap === "object") {
 		card.heatmap = sanitizeHeatmap(r.heatmap as Record<string, unknown>);
 	}
 	if (r.calculator && typeof r.calculator === "object") {
-		card.calculator = sanitizeCalculator(r.calculator as Record<string, unknown>);
+		card.calculator = sanitizeCalculator(
+			r.calculator as Record<string, unknown>,
+		);
 	}
 	if (r.dataview && typeof r.dataview === "object") {
 		card.dataview = sanitizeDataview(r.dataview as Record<string, unknown>);
@@ -297,7 +314,7 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 		card.leafView = sanitizeLeafView(r.leafView as Record<string, unknown>);
 	}
 	if (r.secondView && typeof r.secondView === "object") {
-		card.secondView = sanitizeEmbedView(r.secondView as Record<string, unknown>);
+		card.secondView = sanitizeEmbedView(r.secondView);
 	}
 
 	return card;
@@ -323,7 +340,8 @@ function sanitizeClock(r: Record<string, unknown>): ClockConfig {
 	if (typeof r.use24Hour === "boolean") clock.use24Hour = r.use24Hour;
 	if (typeof r.showSeconds === "boolean") clock.showSeconds = r.showSeconds;
 	if (typeof r.showGreeting === "boolean") clock.showGreeting = r.showGreeting;
-	if (typeof r.playfulGreetings === "boolean") clock.playfulGreetings = r.playfulGreetings;
+	if (typeof r.playfulGreetings === "boolean")
+		clock.playfulGreetings = r.playfulGreetings;
 	const greeting = str(r.greetingText);
 	if (greeting !== undefined) clock.greetingText = greeting;
 	const dateFormat = str(r.dateFormat);
@@ -341,10 +359,29 @@ function strArray(value: unknown): string[] | undefined {
 	return value.filter((v): v is string => typeof v === "string");
 }
 
-const TASK_SORT_KEYS = ["smart", "due", "priority", "created", "alpha"] as const;
-const TASK_SORT_FIELDS = ["due", "scheduled", "priority", "created", "alpha", "status"] as const;
+const TASK_SORT_KEYS = [
+	"smart",
+	"due",
+	"priority",
+	"created",
+	"alpha",
+] as const;
+const TASK_SORT_FIELDS = [
+	"due",
+	"scheduled",
+	"priority",
+	"created",
+	"alpha",
+	"status",
+] as const;
 const TASK_PRIORITY_LEVELS = ["high", "medium", "low", "none"] as const;
-const TASK_DUE_FILTERS = ["overdue", "today", "week", "hasDate", "noDate"] as const;
+const TASK_DUE_FILTERS = [
+	"overdue",
+	"today",
+	"week",
+	"hasDate",
+	"noDate",
+] as const;
 
 function sanitizeCheckboxStatuses(
 	value: unknown,
@@ -357,11 +394,16 @@ function sanitizeCheckboxStatuses(
 			const symbol = str(r.symbol);
 			const label = str(r.label);
 			if (symbol === undefined || label === undefined) return null;
-			const st: { symbol: string; label: string; done?: boolean } = { symbol, label };
+			const st: { symbol: string; label: string; done?: boolean } = {
+				symbol,
+				label,
+			};
 			if (typeof r.done === "boolean") st.done = r.done;
 			return st;
 		})
-		.filter((s): s is { symbol: string; label: string; done?: boolean } => s !== null);
+		.filter(
+			(s): s is { symbol: string; label: string; done?: boolean } => s !== null,
+		);
 	return out;
 }
 
@@ -371,7 +413,10 @@ function sanitizeSortRules(value: unknown): TaskSortRule[] | undefined {
 		.map((raw): TaskSortRule | null => {
 			if (!raw || typeof raw !== "object") return null;
 			const r = raw as Record<string, unknown>;
-			if (!TASK_SORT_FIELDS.includes(r.field as (typeof TASK_SORT_FIELDS)[number])) return null;
+			if (
+				!TASK_SORT_FIELDS.includes(r.field as (typeof TASK_SORT_FIELDS)[number])
+			)
+				return null;
 			const rule: TaskSortRule = { field: r.field as TaskSortRule["field"] };
 			if (typeof r.reverse === "boolean") rule.reverse = r.reverse;
 			return rule;
@@ -387,7 +432,8 @@ function sanitizeKanbanColumnSort(
 	for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
 		if (!raw || typeof raw !== "object") continue;
 		const r = raw as Record<string, unknown>;
-		const entry: { key?: (typeof TASK_SORT_KEYS)[number]; reverse?: boolean } = {};
+		const entry: { key?: (typeof TASK_SORT_KEYS)[number]; reverse?: boolean } =
+			{};
 		if (TASK_SORT_KEYS.includes(r.key as (typeof TASK_SORT_KEYS)[number])) {
 			entry.key = r.key as (typeof TASK_SORT_KEYS)[number];
 		}
@@ -406,7 +452,9 @@ function sanitizeTaskFilter(value: unknown): TaskFilterConfig | undefined {
 	if (Array.isArray(r.priorities)) {
 		cfg.priorities = r.priorities.filter(
 			(p): p is (typeof TASK_PRIORITY_LEVELS)[number] =>
-				TASK_PRIORITY_LEVELS.includes(p as (typeof TASK_PRIORITY_LEVELS)[number]),
+				TASK_PRIORITY_LEVELS.includes(
+					p as (typeof TASK_PRIORITY_LEVELS)[number],
+				),
 		);
 	}
 	if (TASK_DUE_FILTERS.includes(r.due as (typeof TASK_DUE_FILTERS)[number])) {
@@ -419,16 +467,23 @@ function sanitizeTaskFilter(value: unknown): TaskFilterConfig | undefined {
 
 function sanitizeTasks(r: Record<string, unknown>): TasksConfig {
 	const cfg: TasksConfig = {};
-	if (r.source === "checkbox" || r.source === "tasknotes" || r.source === "kanban") {
+	if (
+		r.source === "checkbox" ||
+		r.source === "tasknotes" ||
+		r.source === "kanban"
+	) {
 		cfg.source = r.source;
 	}
 	const kanbanFile = str(r.kanbanFile);
 	if (kanbanFile !== undefined) cfg.kanbanFile = kanbanFile;
-	if (typeof r.kanbanExtended === "boolean") cfg.kanbanExtended = r.kanbanExtended;
-	if (typeof r.checkboxExtended === "boolean") cfg.checkboxExtended = r.checkboxExtended;
+	if (typeof r.kanbanExtended === "boolean")
+		cfg.kanbanExtended = r.kanbanExtended;
+	if (typeof r.checkboxExtended === "boolean")
+		cfg.checkboxExtended = r.checkboxExtended;
 	if (typeof r.taskQuickView === "boolean") cfg.taskQuickView = r.taskQuickView;
 	const convertNoteTemplate = str(r.convertNoteTemplate);
-	if (convertNoteTemplate !== undefined) cfg.convertNoteTemplate = convertNoteTemplate;
+	if (convertNoteTemplate !== undefined)
+		cfg.convertNoteTemplate = convertNoteTemplate;
 	if (typeof r.convertMetadataToFrontmatter === "boolean") {
 		cfg.convertMetadataToFrontmatter = r.convertMetadataToFrontmatter;
 	}
@@ -443,7 +498,11 @@ function sanitizeTasks(r: Record<string, unknown>): TasksConfig {
 	if (sortRules) cfg.sortRules = sortRules;
 	const kanbanColumnSort = sanitizeKanbanColumnSort(r.kanbanColumnSort);
 	if (kanbanColumnSort) cfg.kanbanColumnSort = kanbanColumnSort;
-	if (r.folderScope === "all" || r.folderScope === "whitelist" || r.folderScope === "blacklist") {
+	if (
+		r.folderScope === "all" ||
+		r.folderScope === "whitelist" ||
+		r.folderScope === "blacklist"
+	) {
 		cfg.folderScope = r.folderScope;
 	}
 	const folders = strArray(r.folders);
@@ -466,7 +525,8 @@ function sanitizeTasks(r: Record<string, unknown>): TasksConfig {
 
 function sanitizeCalendar(r: Record<string, unknown>): CalendarConfig {
 	const cfg: CalendarConfig = {};
-	if (typeof r.showWeekNumbers === "boolean") cfg.showWeekNumbers = r.showWeekNumbers;
+	if (typeof r.showWeekNumbers === "boolean")
+		cfg.showWeekNumbers = r.showWeekNumbers;
 	if (typeof r.heatmap === "boolean") cfg.heatmap = r.heatmap;
 	if (r.heatmapMetric === "modified" || r.heatmapMetric === "created") {
 		cfg.heatmapMetric = r.heatmapMetric;
@@ -492,8 +552,10 @@ function sanitizeHeatmap(r: Record<string, unknown>): HeatmapConfig {
 
 function sanitizeCalculator(r: Record<string, unknown>): CalculatorConfig {
 	const cfg: CalculatorConfig = {};
-	if (r.angleUnit === "deg" || r.angleUnit === "rad") cfg.angleUnit = r.angleUnit;
-	if (r.keypad === "basic" || r.keypad === "scientific" || r.keypad === "none") cfg.keypad = r.keypad;
+	if (r.angleUnit === "deg" || r.angleUnit === "rad")
+		cfg.angleUnit = r.angleUnit;
+	if (r.keypad === "basic" || r.keypad === "scientific" || r.keypad === "none")
+		cfg.keypad = r.keypad;
 	const lastInput = str(r.lastInput);
 	if (lastInput !== undefined) cfg.lastInput = lastInput;
 	return cfg;
@@ -532,11 +594,17 @@ function sanitizeBackground(raw: unknown): BackgroundConfig | undefined {
 	};
 }
 
-function sanitizeDashboard(raw: unknown, s: HomeSettings, index: number): Dashboard | null {
+function sanitizeDashboard(
+	raw: unknown,
+	s: HomeSettings,
+	index: number,
+): Dashboard | null {
 	if (!raw || typeof raw !== "object") return null;
 	const r = raw as Record<string, unknown>;
 	const cards = Array.isArray(r.cards)
-		? r.cards.map((c, i) => sanitizeCard(c, i)).filter((c): c is DashboardCard => c !== null)
+		? r.cards
+				.map((c, i) => sanitizeCard(c, i))
+				.filter((c): c is DashboardCard => c !== null)
 		: [];
 	const dash: Dashboard = {
 		id: str(r.id) ?? newDashboardId(),
@@ -546,23 +614,44 @@ function sanitizeDashboard(raw: unknown, s: HomeSettings, index: number): Dashbo
 	const icon = str(r.icon);
 	if (icon !== undefined && icon.trim()) dash.icon = icon;
 	const iconLucide = str(r.iconLucide);
-	if (iconLucide !== undefined && iconLucide.trim()) dash.iconLucide = iconLucide;
+	if (iconLucide !== undefined && iconLucide.trim())
+		dash.iconLucide = iconLucide;
 	if (typeof r.gridColumns === "number") {
-		dash.gridColumns = clampNum(r.gridColumns, RANGE.gridColumns.min, RANGE.gridColumns.max, s.gridColumns);
+		dash.gridColumns = clampNum(
+			r.gridColumns,
+			RANGE.gridColumns.min,
+			RANGE.gridColumns.max,
+			s.gridColumns,
+		);
 	}
 	if (typeof r.rowHeight === "number") {
-		dash.rowHeight = clampNum(r.rowHeight, RANGE.rowHeight.min, RANGE.rowHeight.max, s.rowHeight);
+		dash.rowHeight = clampNum(
+			r.rowHeight,
+			RANGE.rowHeight.min,
+			RANGE.rowHeight.max,
+			s.rowHeight,
+		);
 	}
 	if (typeof r.fitToPage === "boolean") dash.fitToPage = r.fitToPage;
 	if (typeof r.showSearch === "boolean") dash.showSearch = r.showSearch;
 	if (typeof r.maxWidth === "number") {
-		dash.maxWidth = clampNum(r.maxWidth, RANGE.maxWidth.min, RANGE.maxWidth.max, s.maxWidth);
+		dash.maxWidth = clampNum(
+			r.maxWidth,
+			RANGE.maxWidth.min,
+			RANGE.maxWidth.max,
+			s.maxWidth,
+		);
 	}
 	if (typeof r.cardOpacity === "number") {
 		dash.cardOpacity = Math.max(0, Math.min(1, r.cardOpacity));
 	}
 	if (typeof r.cardBlur === "number") {
-		dash.cardBlur = clampNum(r.cardBlur, RANGE.cardBlur.min, RANGE.cardBlur.max, s.cardBlur);
+		dash.cardBlur = clampNum(
+			r.cardBlur,
+			RANGE.cardBlur.min,
+			RANGE.cardBlur.max,
+			s.cardBlur,
+		);
 	}
 	const bg = sanitizeBackground(r.background);
 	if (bg) dash.background = bg;
@@ -590,7 +679,10 @@ export function importLayout(s: HomeSettings, json: string): string | null {
 /** Apply the dashboard/layout portion of a parsed export onto `s`. Returns an
  * error message on failure, or null on success. Supports the v2 multi-dashboard
  * format and the legacy v1 single-`cards` format. */
-function applyLayout(s: HomeSettings, data: Record<string, unknown>): string | null {
+function applyLayout(
+	s: HomeSettings,
+	data: Record<string, unknown>,
+): string | null {
 	// v2: a full multi-dashboard layout.
 	if (Array.isArray(data.dashboards)) {
 		const dashboards = data.dashboards
@@ -605,7 +697,9 @@ function applyLayout(s: HomeSettings, data: Record<string, unknown>): string | n
 		}
 		const activeId = str(data.activeDashboardId);
 		s.activeDashboardId =
-			activeId && dashboards.some((d) => d.id === activeId) ? activeId : dashboards[0].id;
+			activeId && dashboards.some((d) => d.id === activeId)
+				? activeId
+				: dashboards[0].id;
 		applyGlobals(s, data);
 		return null;
 	}
@@ -660,14 +754,31 @@ export function importSettings(s: HomeSettings, json: string): string | null {
 
 /** Apply the global (non-per-board) settings carried by a layout, clamped. */
 function applyGlobals(s: HomeSettings, data: Record<string, unknown>): void {
-	s.gridColumns = clampNum(data.gridColumns, RANGE.gridColumns.min, RANGE.gridColumns.max, s.gridColumns);
+	s.gridColumns = clampNum(
+		data.gridColumns,
+		RANGE.gridColumns.min,
+		RANGE.gridColumns.max,
+		s.gridColumns,
+	);
 	if (typeof data.rowHeight === "number") {
-		s.rowHeight = clampNum(data.rowHeight, RANGE.rowHeight.min, RANGE.rowHeight.max, s.rowHeight);
+		s.rowHeight = clampNum(
+			data.rowHeight,
+			RANGE.rowHeight.min,
+			RANGE.rowHeight.max,
+			s.rowHeight,
+		);
 	}
-	s.maxWidth = clampNum(data.maxWidth, RANGE.maxWidth.min, RANGE.maxWidth.max, s.maxWidth);
+	s.maxWidth = clampNum(
+		data.maxWidth,
+		RANGE.maxWidth.min,
+		RANGE.maxWidth.max,
+		s.maxWidth,
+	);
 	if (typeof data.fitToPage === "boolean") s.fitToPage = data.fitToPage;
 	if (Array.isArray(data.favorites)) {
-		s.favorites = data.favorites.filter((p): p is string => typeof p === "string");
+		s.favorites = data.favorites.filter(
+			(p): p is string => typeof p === "string",
+		);
 	}
 }
 
@@ -681,14 +792,19 @@ function sanitizeMobileActionButton(raw: unknown): MobileActionButton | null {
 		label: str(r.label) ?? "",
 		icon: str(r.icon) ?? "",
 	};
-	if (r.type === "command" || r.type === "note" || r.type === "url") btn.type = r.type;
+	if (r.type === "command" || r.type === "note" || r.type === "url")
+		btn.type = r.type;
 	const target = str(r.target);
 	if (target !== undefined) btn.target = target;
 	// Fold a legacy `commandId` (from a pre-1.9.0 backup) into `target` rather
 	// than re-persisting the deprecated field, using the same rule as
 	// migrateSettings so an imported backup never reintroduces `commandId`.
 	const commandId = str(r.commandId);
-	if ((btn.target === undefined || btn.target === "") && commandId !== undefined && commandId !== "") {
+	if (
+		(btn.target === undefined || btn.target === "") &&
+		commandId !== undefined &&
+		commandId !== ""
+	) {
 		btn.target = commandId;
 	}
 	return btn;
@@ -705,17 +821,28 @@ function applySettings(s: HomeSettings, data: Record<string, unknown>): void {
 	if (logo !== undefined) s.logo = logo;
 	const searchPlaceholder = str(data.searchPlaceholder);
 	if (searchPlaceholder !== undefined) s.searchPlaceholder = searchPlaceholder;
-	if (typeof data.showNewNoteButton === "boolean") s.showNewNoteButton = data.showNewNoteButton;
-	if (data.newNoteButtonMode === "newNote" || data.newNoteButtonMode === "searchOnline") {
+	if (typeof data.showNewNoteButton === "boolean")
+		s.showNewNoteButton = data.showNewNoteButton;
+	if (
+		data.newNoteButtonMode === "newNote" ||
+		data.newNoteButtonMode === "searchOnline"
+	) {
 		s.newNoteButtonMode = data.newNoteButtonMode;
 	}
-	if (typeof data.searchContents === "boolean") s.searchContents = data.searchContents;
+	if (typeof data.searchContents === "boolean")
+		s.searchContents = data.searchContents;
 	if (data.searchEngine === "builtin" || data.searchEngine === "omnisearch") {
 		s.searchEngine = data.searchEngine;
 	}
 
 	// Background
-	const bgKinds: BackgroundKind[] = ["none", "default", "color", "image", "url"];
+	const bgKinds: BackgroundKind[] = [
+		"none",
+		"default",
+		"color",
+		"image",
+		"url",
+	];
 	if (bgKinds.includes(data.backgroundKind as BackgroundKind)) {
 		s.backgroundKind = data.backgroundKind as BackgroundKind;
 	}
@@ -729,16 +856,21 @@ function applySettings(s: HomeSettings, data: Record<string, unknown>): void {
 	}
 
 	// Behaviour
-	if (typeof data.openOnStartup === "boolean") s.openOnStartup = data.openOnStartup;
-	if (typeof data.replaceNewTabs === "boolean") s.replaceNewTabs = data.replaceNewTabs;
-	if (typeof data.mobileSearchOnly === "boolean") s.mobileSearchOnly = data.mobileSearchOnly;
-	if (typeof data.showMobileActionBar === "boolean") s.showMobileActionBar = data.showMobileActionBar;
+	if (typeof data.openOnStartup === "boolean")
+		s.openOnStartup = data.openOnStartup;
+	if (typeof data.replaceNewTabs === "boolean")
+		s.replaceNewTabs = data.replaceNewTabs;
+	if (typeof data.mobileSearchOnly === "boolean")
+		s.mobileSearchOnly = data.mobileSearchOnly;
+	if (typeof data.showMobileActionBar === "boolean")
+		s.showMobileActionBar = data.showMobileActionBar;
 	if (Array.isArray(data.mobileActionButtons)) {
 		s.mobileActionButtons = data.mobileActionButtons
 			.map(sanitizeMobileActionButton)
 			.filter((b): b is MobileActionButton => b !== null);
 	}
-	if (typeof data.disableExternalCalls === "boolean") s.disableExternalCalls = data.disableExternalCalls;
+	if (typeof data.disableExternalCalls === "boolean")
+		s.disableExternalCalls = data.disableExternalCalls;
 
 	// Appearance
 	if (typeof data.compact === "boolean") s.compact = data.compact;
@@ -746,12 +878,19 @@ function applySettings(s: HomeSettings, data: Record<string, unknown>): void {
 		s.cardOpacity = Math.max(0, Math.min(1, data.cardOpacity));
 	}
 	if (typeof data.cardBlur === "number") {
-		s.cardBlur = clampNum(data.cardBlur, RANGE.cardBlur.min, RANGE.cardBlur.max, s.cardBlur);
+		s.cardBlur = clampNum(
+			data.cardBlur,
+			RANGE.cardBlur.min,
+			RANGE.cardBlur.max,
+			s.cardBlur,
+		);
 	}
 
 	// Search filters
 	if (Array.isArray(data.hiddenFilters)) {
-		s.hiddenFilters = data.hiddenFilters.filter((f): f is string => typeof f === "string");
+		s.hiddenFilters = data.hiddenFilters.filter(
+			(f): f is string => typeof f === "string",
+		);
 	}
 
 	// Tasks / TaskNotes field mappings

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -468,6 +468,14 @@ export const en = {
 			fileDesc: "A note, image, canvas or .base file in your vault.",
 			filePlaceholder: "File path to embed",
 			pickFile: "Pick a file",
+			baseView: "Base view",
+			baseViewDesc: "Choose a view from this .base file, or use the default view.",
+			baseViewDefault: "Default view",
+			baseViewFileMissing: "The selected .base file could not be found.",
+			baseViewLoadError: "Could not read the .base file views. The default view will be used.",
+			baseViewNoViews: "No named views were found in this .base file. The default view will be used.",
+			baseViewUnsupported: (count: number) =>
+				`${count} view${count === 1 ? "" : "s"} with unsupported wikilink characters were hidden.`,
 			zoom: "Zoom",
 			zoomDesc:
 				"Scale the embedded content. Applies when you close this dialog.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,6 +311,8 @@ export interface MobileActionButton {
 export interface EmbedView {
 	/** Vault path of the file to embed (.md, image, .base, ...). */
 	target?: string;
+	/** Bases view name to embed when target is a .base file; omitted means default view. */
+	baseView?: string;
 	/** Zoom factor for the embedded content (1 = 100%); omitted means no scaling. */
 	scale?: number;
 	/** Edit the embedded note's text in place instead of read-only (Markdown only). */
@@ -350,6 +352,9 @@ export interface DashboardCard {
 	// ---- Content (per kind) ----
 	/** kind === "embed": vault path of the file to embed (.md, image, .base, ...). */
 	target?: string;
+	/** kind === "embed": Bases view name to embed when target is a .base file;
+	 * omitted means the default view. */
+	baseView?: string;
 	/** kind === "web": the web page URL to embed in an iframe. */
 	url?: string;
 	/** kind === "web": allow the framed page same-origin access. Off by default


### PR DESCRIPTION
## Why

Embed cards can already embed `.base` files, but they always render the default Base view. Obsidian itself supports embedding a specific Base view with `![[File.base#View]]`, so Hearth users should be able to choose the intended view directly from the Embed card settings instead of being limited to the default one.

This is useful when a Base contains multiple views for different workflows, such as a table view, a cards view, or filtered views for specific contexts.

## What changed

- Added a Base view selector for Embed cards when the selected file is a `.base` file.
- The selector lists available views from the `.base` file.
- Leaving the selector empty keeps the current default behavior: `![[File.base]]`.
- Selecting a view renders the embed with a subpath: `![[File.base#View]]`.
- Added support for both the primary embed target and the optional second view target.
- Preserved the selected view through layout import/export sanitization.
- Added defensive handling for invalid/missing Base files and view names that would create unsafe wikilinks.

## Implementation notes

The view list is read from the `.base` file YAML using public Vault APIs and Obsidian's YAML parser. It does not rely on private Bases internals or metadata cache fields.

## Validation

- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Manually tested in Obsidian with an Embed card targeting a `.base` file and selecting a specific view.
