### PR TITLE
Add hover visibility options for dashboard controls

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,14 +1,25 @@
-import { Component, debounce, Menu, setIcon, TAbstractFile } from "obsidian";
+import {
+	Component,
+	debounce,
+	Menu,
+	setIcon,
+	type TAbstractFile,
+} from "obsidian";
 import { confirmAction } from "./ui";
 import { t } from "./i18n";
 import type { HomeView } from "./view";
-import { activeEmbedViewEditable, mountEmbedViewSwitcher, renderCardBody, watchedCardPath } from "./cards";
+import {
+	activeEmbedViewEditable,
+	mountEmbedViewSwitcher,
+	renderCardBody,
+	watchedCardPath,
+} from "./cards";
 import { CARD_TEMPLATES, cardFromTemplate, templateName } from "./templates";
 import { CardSettingsModal } from "./editors";
 import {
 	activeCards,
 	cloneCard,
-	DashboardCard,
+	type DashboardCard,
 	effectiveCardOpacity,
 	effectiveColumns,
 	effectiveFitToPage,
@@ -27,7 +38,7 @@ import {
 	ensureFreeform,
 	ensureLayout,
 	fitVerticalScale,
-	GridLayout,
+	type GridLayout,
 	GRID_GAP,
 	layoutHeight,
 	placeFreeform,
@@ -254,7 +265,13 @@ function watchedCardEditable(card: DashboardCard): boolean {
 
 /** Card kinds whose content is derived from the whole vault and should refresh
  * live on vault/metadata changes. */
-const LIVE_KINDS = new Set<DashboardCard["kind"]>(["tasks", "stats", "calendar", "search", "heatmap"]);
+const LIVE_KINDS = new Set<DashboardCard["kind"]>([
+	"tasks",
+	"stats",
+	"calendar",
+	"search",
+	"heatmap",
+]);
 
 /** Redraw an embed/daily card's body when the file it tracks changes on disk.
  * create/delete/rename always redraw; modify only when `redrawOnModify` (a
@@ -274,18 +291,26 @@ function watchCardFile(
 		return path != null && (file.path === path || oldPath === path);
 	};
 	const { vault } = view.app;
-	parent.registerEvent(vault.on("modify", (file) => {
-		if (redrawOnModify() && affects(file)) redraw();
-	}));
-	parent.registerEvent(vault.on("create", (file) => {
-		if (affects(file)) redraw();
-	}));
-	parent.registerEvent(vault.on("delete", (file) => {
-		if (affects(file)) redraw();
-	}));
-	parent.registerEvent(vault.on("rename", (file, oldPath) => {
-		if (affects(file, oldPath)) redraw();
-	}));
+	parent.registerEvent(
+		vault.on("modify", (file) => {
+			if (redrawOnModify() && affects(file)) redraw();
+		}),
+	);
+	parent.registerEvent(
+		vault.on("create", (file) => {
+			if (affects(file)) redraw();
+		}),
+	);
+	parent.registerEvent(
+		vault.on("delete", (file) => {
+			if (affects(file)) redraw();
+		}),
+	);
+	parent.registerEvent(
+		vault.on("rename", (file, oldPath) => {
+			if (affects(file, oldPath)) redraw();
+		}),
+	);
 }
 
 /** Save the current settings and rebuild the view (used after structural
@@ -337,7 +362,9 @@ function renderCardControls(
 	remove.addEventListener("click", () => {
 		confirmAction(view.app, {
 			title: t().dashboard.removeCardTitle,
-			message: t().dashboard.removeCardMessage(card.title?.trim() || t().dashboard.thisCard),
+			message: t().dashboard.removeCardMessage(
+				card.title?.trim() || t().dashboard.thisCard,
+			),
 			confirmText: t().dashboard.removeCardConfirm,
 			onConfirm: () => {
 				removeCard(view.plugin.settings, card);
@@ -375,8 +402,7 @@ function openCardSettings(view: HomeView, card: DashboardCard): void {
 
 function renderToolbar(view: HomeView, container: HTMLElement): void {
 	const bar = container.createDiv("hearth-toolbar");
-	// At rest the bar holds only the compact Arrange toggle; flag it so CSS can
-	// float it into the gap above the grid instead of reserving a whole row.
+	// Track arrange mode so the toolbar can switch between its compact and full controls.
 	bar.toggleClass("is-arranging", view.arrangeMode);
 
 	if (view.arrangeMode) {
@@ -387,9 +413,9 @@ function renderToolbar(view: HomeView, container: HTMLElement): void {
 		add.addEventListener("click", (evt) => {
 			const menu = new Menu();
 			for (const template of CARD_TEMPLATES) {
-					// Skip plugin-gated templates (e.g. Dataview) unless available.
-					if (template.available && !template.available(view.app)) continue;
-					menu.addItem((item) =>
+				// Skip plugin-gated templates (e.g. Dataview) unless available.
+				if (template.available && !template.available(view.app)) continue;
+				menu.addItem((item) =>
 					item
 						.setTitle(templateName(template))
 						.setIcon(template.icon)
@@ -425,11 +451,15 @@ function renderToolbar(view: HomeView, container: HTMLElement): void {
 		);
 		hideHdr.createSpan({
 			cls: "hearth-tool-label",
-			text: view.hideHeaderInArrange ? t().dashboard.showTitles : t().dashboard.hideTitles,
+			text: view.hideHeaderInArrange
+				? t().dashboard.showTitles
+				: t().dashboard.hideTitles,
 		});
 		hideHdr.setAttribute(
 			"aria-label",
-			view.hideHeaderInArrange ? t().dashboard.showCardHeaders : t().dashboard.hideCardHeaders,
+			view.hideHeaderInArrange
+				? t().dashboard.showCardHeaders
+				: t().dashboard.hideCardHeaders,
 		);
 		hideHdr.addEventListener("click", () => {
 			view.hideHeaderInArrange = !view.hideHeaderInArrange;
@@ -437,14 +467,26 @@ function renderToolbar(view: HomeView, container: HTMLElement): void {
 		});
 	}
 
-	const arrange = bar.createEl("button", { cls: "hearth-tool-btn" });
+	const arrangeZone = bar.createDiv("hearth-arrange-zone");
+	arrangeZone.toggleClass(
+		"is-auto-hide",
+		!view.arrangeMode &&
+			view.plugin.settings.arrangeButtonVisibility === "hover",
+	);
+	const arrange = arrangeZone.createEl("button", { cls: "hearth-tool-btn" });
 	arrange.toggleClass("is-active", view.arrangeMode);
 	// Outside arrange mode keep it as a small, unobtrusive icon button; while
 	// arranging, show the labelled "Done arranging" action.
 	arrange.toggleClass("is-icon", !view.arrangeMode);
-	setIcon(arrange.createSpan("hearth-tool-icon"), view.arrangeMode ? "check" : "move");
+	setIcon(
+		arrange.createSpan("hearth-tool-icon"),
+		view.arrangeMode ? "check" : "move",
+	);
 	if (view.arrangeMode) {
-		arrange.createSpan({ cls: "hearth-tool-label", text: t().dashboard.doneArranging });
+		arrange.createSpan({
+			cls: "hearth-tool-label",
+			text: t().dashboard.doneArranging,
+		});
 	}
 	arrange.setAttribute(
 		"aria-label",

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -1,9 +1,9 @@
 import { Menu, Modal, Setting, setIcon } from "obsidian";
 import type { HomeView } from "./view";
 import {
-	BackgroundConfig,
-	BackgroundKind,
-	Dashboard,
+	type BackgroundConfig,
+	type BackgroundKind,
+	type Dashboard,
 	DEFAULT_SETTINGS,
 	newDashboardId,
 	cloneCard,
@@ -24,7 +24,9 @@ const DEFAULT_DASH_BG_BLUR = DEFAULT_SETTINGS.backgroundBlur;
  */
 export function renderDashboardSwitcher(view: HomeView, container: HTMLElement): void {
 	const s = view.plugin.settings;
-	const bar = container.createDiv("hearth-dash-switcher");
+	const zone = container.createDiv("hearth-dash-switcher-zone");
+	zone.toggleClass("is-auto-hide", s.dashboardSwitcherVisibility === "hover");
+	const bar = zone.createDiv("hearth-dash-switcher");
 
 	s.dashboards.forEach((d, i) => {
 		const lucide = d.iconLucide?.trim();
@@ -53,8 +55,12 @@ export function renderDashboardSwitcher(view: HomeView, container: HTMLElement):
 		btn.addEventListener("dragstart", (e) => {
 			e.dataTransfer?.setData("text/plain", String(i));
 			btn.addClass("is-dragging");
+			bar.addClass("is-dragging");
 		});
-		btn.addEventListener("dragend", () => btn.removeClass("is-dragging"));
+		btn.addEventListener("dragend", () => {
+			btn.removeClass("is-dragging");
+			bar.removeClass("is-dragging");
+		});
 		btn.addEventListener("dragover", (e) => {
 			e.preventDefault();
 			btn.addClass("is-drop-target");
@@ -63,6 +69,7 @@ export function renderDashboardSwitcher(view: HomeView, container: HTMLElement):
 		btn.addEventListener("drop", (e) => {
 			e.preventDefault();
 			btn.removeClass("is-drop-target");
+			bar.removeClass("is-dragging");
 			const from = parseInt(e.dataTransfer?.getData("text/plain") ?? "", 10);
 			if (Number.isNaN(from) || from === i) return;
 			const [moved] = s.dashboards.splice(from, 1);

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -32,19 +32,24 @@ export const en = {
 	// ---- Notices (transient toasts) ------------------------------------
 	notices: {
 		couldNotCreateNote: "Hearth: could not create a new note.",
-		enableExcalidraw: "Hearth: enable the Excalidraw plugin to create drawings.",
-		excalidrawCommandMissing: 'Hearth: couldn\'t find Excalidraw\'s "new drawing" command.',
+		enableExcalidraw:
+			"Hearth: enable the Excalidraw plugin to create drawings.",
+		excalidrawCommandMissing:
+			"Hearth: couldn't find Excalidraw's \"new drawing\" command.",
 		enableAudioRecorder: "Hearth: enable the core Audio recorder plugin.",
 		couldNotRecordVoice: "Hearth: couldn't start voice recording.",
 		enableDailyNotes: "Hearth: enable the core Daily notes plugin.",
 		couldNotOpenDaily: "Hearth: couldn't open today's daily note.",
 		commandNotFound: (id: string) => `Hearth: command not found: ${id}`,
-		couldNotCreateNoteForDay: (day: string) => `Hearth: couldn't create a note for ${day}.`,
+		couldNotCreateNoteForDay: (day: string) =>
+			`Hearth: couldn't create a note for ${day}.`,
 		taskNotesCreateFailed: "Hearth: couldn't run TaskNotes: Create new task.",
 		taskChangedOnDisk: "Hearth: that task changed on disk — refreshed.",
 		couldNotUpdateTaskStatus: "Hearth: couldn't update the task status.",
-		couldNotCompleteRecurring: "Hearth: couldn't mark the recurring task instance complete.",
-		couldNotUndoRecurring: "Hearth: couldn't undo the recurring task completion.",
+		couldNotCompleteRecurring:
+			"Hearth: couldn't mark the recurring task instance complete.",
+		couldNotUndoRecurring:
+			"Hearth: couldn't undo the recurring task completion.",
 		couldNotAddKanbanCard: "Hearth: couldn't add the card to the Kanban board.",
 		couldNotConvertCard: "Hearth: couldn't convert the card into a note.",
 		layoutExported: "Hearth: layout exported.",
@@ -137,7 +142,8 @@ export const en = {
 			title: "Dashboard settings",
 			name: "Name",
 			switcherIcon: "Switcher icon",
-			switcherIconDesc: "An emoji or short text shown on the switcher button. Empty = number.",
+			switcherIconDesc:
+				"An emoji or short text shown on the switcher button. Empty = number.",
 			switcherLucide: "Switcher Lucide icon",
 			switcherLucideDesc:
 				"A Lucide icon id (e.g. “home”, “star”, “layout-dashboard”). Takes precedence over the emoji above.",
@@ -154,7 +160,8 @@ export const en = {
 			cardBlur: "Card blur",
 			done: "Done",
 			overriding: "Overriding the global default.",
-			usingGlobal: (value: number | string) => `Using global default (${value}).`,
+			usingGlobal: (value: number | string) =>
+				`Using global default (${value}).`,
 			background: "Background",
 			backgroundDesc: "Override the global background for this dashboard.",
 			backgroundValue: "Background value",
@@ -202,8 +209,11 @@ export const en = {
 			searchBarDesc: "How the search field looks and what it does.",
 			grid: "Grid & spacing",
 			gridDesc: "How the card grid is sized and spaced.",
+			dashboardControls: "Dashboard controls",
+			dashboardControlsDesc: "Visibility for controls around the dashboard.",
 			cardSurface: "Card surface",
-			cardSurfaceDesc: "Transparency and frosted-glass blur applied to every card.",
+			cardSurfaceDesc:
+				"Transparency and frosted-glass blur applied to every card.",
 			startup: "Startup & tabs",
 			startupDesc: "When and where the home view opens.",
 			mobileMode: "Mobile mode",
@@ -218,7 +228,8 @@ export const en = {
 			githubDesc: "Browse the source, star the project, or read the changelog.",
 			githubButton: "Open GitHub",
 			reportIssue: "Report an issue",
-			reportIssueDesc: "Hit a bug or have a feature idea? Open an issue on GitHub.",
+			reportIssueDesc:
+				"Hit a bug or have a feature idea? Open an issue on GitHub.",
 			reportIssueButton: "Report issue",
 			kofi: "Support Hearth",
 			kofiDesc:
@@ -230,8 +241,7 @@ export const en = {
 		},
 		appearance: {
 			heading: "Appearance",
-			headingDesc:
-				"Title, logo, search bar and overall content width.",
+			headingDesc: "Title, logo, search bar and overall content width.",
 			showTitle: "Show title",
 			showTitleDesc: "Display the big title/logo at the top.",
 			title: "Title",
@@ -276,7 +286,8 @@ export const en = {
 			valueImageDesc: "A vault image path, e.g. Attachments/bg.png.",
 			valueUrlDesc: "A direct image URL.",
 			opacity: "Opacity",
-			opacityDesc: "How much the background shows through. Lower is more subtle.",
+			opacityDesc:
+				"How much the background shows through. Lower is more subtle.",
 			blur: "Blur",
 			blurDesc: "Background blur in pixels.",
 			labels: {
@@ -338,7 +349,8 @@ export const en = {
 			dueField: "Due date field",
 			dueFieldDesc: "Frontmatter field read for a task's due date.",
 			priorityField: "Priority field",
-			priorityFieldDesc: "Frontmatter field read for a task's priority indicator.",
+			priorityFieldDesc:
+				"Frontmatter field read for a task's priority indicator.",
 			doneValue: "“Done” status value",
 			doneValueDesc: "The status value that marks a TaskNotes task complete.",
 		},
@@ -352,9 +364,21 @@ export const en = {
 			headingDesc:
 				"Sizing and transparency of the card grid. Cards themselves are added and configured on the board.",
 			fitToPage: "Fit to page",
-			fitToPageDesc: "Keep the dashboard to one screen instead of allowing scroll.",
+			fitToPageDesc:
+				"Keep the dashboard to one screen instead of allowing scroll.",
 			compact: "Compact spacing",
-			compactDesc: "Tighten card padding and top margin to enlarge the usable area.",
+			compactDesc:
+				"Tighten card padding and top margin to enlarge the usable area.",
+			arrangeButtonVisibility: "Arrange button visibility",
+			arrangeButtonVisibilityDesc:
+				"Choose whether the arrange/edit button is always visible or revealed when hovering its area.",
+			dashboardSwitcherVisibility: "Dashboard switcher visibility",
+			dashboardSwitcherVisibilityDesc:
+				"Choose whether the top-left dashboard buttons are always visible or revealed when hovering their area.",
+			visibilityOptions: {
+				always: "Always visible",
+				hover: "Show on hover",
+			},
 			cardOpacity: "Card opacity",
 			cardOpacityDesc:
 				"Transparent card backgrounds so the dashboard background shows through.",
@@ -402,7 +426,8 @@ export const en = {
 		type: "Type",
 		typeDesc: "What this card shows.",
 		cardTitle: "Title",
-		cardTitleDesc: "Shown in the card's header. Leave empty for a headerless card.",
+		cardTitleDesc:
+			"Shown in the card's header. Leave empty for a headerless card.",
 		cardTitlePlaceholder: "Title",
 		resetSize: "Reset to default size",
 		removeCard: "Remove card",
@@ -442,9 +467,11 @@ export const en = {
 			filePlaceholder: "File path to embed",
 			pickFile: "Pick a file",
 			zoom: "Zoom",
-			zoomDesc: "Scale the embedded content. Applies when you close this dialog.",
+			zoomDesc:
+				"Scale the embedded content. Applies when you close this dialog.",
 			editable: "Editable",
-			editableDesc: "Edit the embedded note's text in place (Markdown notes only).",
+			editableDesc:
+				"Edit the embedded note's text in place (Markdown notes only).",
 			hideBaseHeader: "Hide base header",
 			hideBaseHeaderDesc:
 				"For embedded .base files, hide the Bases view's own toolbar (view switcher and filter/property controls) so only the results show.",
@@ -456,7 +483,8 @@ export const en = {
 		},
 		daily: {
 			editable: "Editable",
-			editableDesc: "Edit today's note in place instead of read-only. Saves to the vault.",
+			editableDesc:
+				"Edit today's note in place instead of read-only. Saves to the vault.",
 			openButton: "Open button",
 			openButtonDesc: "Show a button to open today's note in the editor.",
 			info: "Daily notes",
@@ -471,7 +499,8 @@ export const en = {
 				"Allow the page same-origin access (cookies, storage). Only enable " +
 				"for sites you trust — it relaxes the iframe sandbox.",
 			autoRefresh: "Auto-refresh",
-			autoRefreshDesc: "Re-render this card every N seconds to pick up changes. 0 = off.",
+			autoRefreshDesc:
+				"Re-render this card every N seconds to pick up changes. 0 = off.",
 			refreshIntervalAria: "Refresh interval in seconds",
 		},
 		recent: {
@@ -620,7 +649,8 @@ export const en = {
 				"Add, e.g., “canceled” to count cancelled tasks as complete too.",
 			doneStatusesPlaceholder: "done\ncanceled",
 			showCompleted: "Show completed",
-			showCompletedKanbanDesc: "Completed tasks always appear in the Done column on a Kanban board.",
+			showCompletedKanbanDesc:
+				"Completed tasks always appear in the Done column on a Kanban board.",
 			maxTasks: "Max tasks shown",
 			maxTasksDesc: "Sorted by due date (overdue/soonest first), then by file.",
 			folders: "Folders",
@@ -667,7 +697,8 @@ export const en = {
 			degrees: "Degrees",
 			radians: "Radians",
 			keypad: "Keypad",
-			keypadDesc: "Show an on-screen keypad on the card: basic (digits and operations) or scientific (adds functions, powers and constants).",
+			keypadDesc:
+				"Show an on-screen keypad on the card: basic (digits and operations) or scientific (adds functions, powers and constants).",
 			keypadNone: "Hidden",
 			keypadBasic: "Basic",
 			keypadScientific: "Scientific",
@@ -686,7 +717,8 @@ export const en = {
 			queryJsDesc:
 				"DataviewJS code, as inside a ```dataviewjs block (without the fences). " +
 				"The dv API is in scope. Runs arbitrary JavaScript — only use code you trust.",
-			queryDqlPlaceholder: "TABLE file.mtime AS \"Modified\" FROM #project SORT file.mtime DESC",
+			queryDqlPlaceholder:
+				'TABLE file.mtime AS "Modified" FROM #project SORT file.mtime DESC',
 			queryJsPlaceholder: "dv.list(dv.pages('#project').file.link)",
 		},
 		leaf: {
@@ -708,9 +740,11 @@ export const en = {
 			clearAccent: "Clear accent",
 			clearBackground: "Clear background",
 			cardOpacity: "Card opacity",
-			cardOpacityDesc: "Transparent card surface (overrides the dashboard default).",
+			cardOpacityDesc:
+				"Transparent card surface (overrides the dashboard default).",
 			cardBlur: "Card blur",
-			cardBlurDesc: "Frosted-glass blur behind this card (overrides the dashboard default). Needs opacity below 100%.",
+			cardBlurDesc:
+				"Frosted-glass blur behind this card (overrides the dashboard default). Needs opacity below 100%.",
 			useDashboardDefault: "Use dashboard default",
 		},
 		size: {
@@ -727,7 +761,8 @@ export const en = {
 		},
 		copy: {
 			heading: "Copy to dashboard",
-			headingDesc: "Add a duplicate of this card to the end of another dashboard.",
+			headingDesc:
+				"Add a duplicate of this card to the end of another dashboard.",
 			copy: "Copy",
 			copyTooltip: "Copy this card to the selected dashboard",
 		},
@@ -750,14 +785,17 @@ export const en = {
 			recentEmpty: "No recent files",
 			linksEmpty: "Add links in settings",
 			commandsEmpty: "Add commands in card settings",
-			tasksEnable: "Enable the TaskNotes plugin, or switch source to checkboxes",
+			tasksEnable:
+				"Enable the TaskNotes plugin, or switch source to checkboxes",
 			tasksEmpty: "No open tasks",
 			tasksNoMatch: "No tasks match the filter",
-			kanbanNoBoard: "No Kanban board found — pick a board note in card settings, or create one with the Kanban plugin",
+			kanbanNoBoard:
+				"No Kanban board found — pick a board note in card settings, or create one with the Kanban plugin",
 			dataviewEnable: "Enable the Dataview plugin to run queries",
 			dataviewNoQuery: "Set a Dataview query in card settings",
 			leafPickView: "Pick a plugin view in card settings",
-			leafViewMissing: "This view isn't available — enable the plugin that provides it",
+			leafViewMissing:
+				"This view isn't available — enable the plugin that provides it",
 		},
 		embed: {
 			editHint: "Double-click to edit",
@@ -787,7 +825,8 @@ export const en = {
 			nextMonth: "Next month",
 			backToToday: "Back to today",
 			dayEdited: (date: string, count: number) => `${date}: ${count} edited`,
-			dayMetric: (date: string, count: number, metric: string) => `${date}: ${count} ${metric}`,
+			dayMetric: (date: string, count: number, metric: string) =>
+				`${date}: ${count} ${metric}`,
 		},
 		stats: {
 			notes: "Notes",
@@ -826,7 +865,8 @@ export const en = {
 			save: "Save",
 			cancel: "Cancel",
 			setDoneColumn: (label: string) => `Mark "${label}" as a done column`,
-			unsetDoneColumn: (label: string) => `Stop "${label}" auto-completing cards`,
+			unsetDoneColumn: (label: string) =>
+				`Stop "${label}" auto-completing cards`,
 			dueDate: "Due date",
 			startDate: "Start date",
 			scheduledDate: "Scheduled date",
@@ -835,7 +875,12 @@ export const en = {
 			recurrenceNever: "Never",
 			recurrenceEvery: "every",
 			recurrenceInterval: "Repeat interval",
-			recurrenceUnits: { day: "Daily", week: "Weekly", month: "Monthly", year: "Yearly" },
+			recurrenceUnits: {
+				day: "Daily",
+				week: "Weekly",
+				month: "Monthly",
+				year: "Yearly",
+			},
 			taskCount: (n: number) => (n === 1 ? "1 task" : `${n} tasks`),
 			description: "Description",
 			descriptionPlaceholder: "Notes… (plain text)",
@@ -859,7 +904,8 @@ export const en = {
 			sortCustom: "Custom",
 			sortCustomOption: "Custom sort…",
 			sortTitle: "Custom sort",
-			sortHint: "Sort tasks by these rules in order — the first is the primary sort, each next one breaks ties.",
+			sortHint:
+				"Sort tasks by these rules in order — the first is the primary sort, each next one breaks ties.",
 			sortFields: {
 				due: "Due date",
 				scheduled: "Scheduled date",
@@ -924,7 +970,8 @@ export const en = {
 			year: "year",
 		},
 		everyOne: (unit: string) => `Repeats every ${unit}`,
-		everyMany: (count: number, unit: string) => `Repeats every ${count} ${unit}s`,
+		everyMany: (count: number, unit: string) =>
+			`Repeats every ${count} ${unit}s`,
 	},
 
 	// ---- Clock greetings -----------------------------------------------

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,8 +1,8 @@
-import { App, ButtonComponent, Notice, Platform, PluginSettingTab, setIcon, Setting, SliderComponent, TextComponent, TFile } from "obsidian";
+import { type App, type ButtonComponent, Notice, Platform, PluginSettingTab, setIcon, Setting, type SliderComponent, type TextComponent, TFile } from "obsidian";
 import type HearthPlugin from "./main";
 import { FILE_TYPE_GROUPS, fileTypeLabel } from "./filetypes";
 import { CommandPickerModal } from "./pickers";
-import { BackgroundKind, DEFAULT_SETTINGS, defaultMobileActionButtons, HomeSettings, MobileActionButton } from "./types";
+import { type BackgroundKind, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, type MobileActionButton } from "./types";
 import { exportLayout, exportSettings, importLayout, importSettings } from "./layout";
 import { confirmAction, downloadTextFile, pickTextFile } from "./ui";
 import { isOmnisearchAvailable, OMNISEARCH_PLUGIN_ID } from "./omnisearch";
@@ -156,6 +156,9 @@ export class HomeSettingTab extends PluginSettingTab {
 				break;
 			case "dashboard":
 				this.section(body, s.sections.grid, s.sections.gridDesc, (b) => this.gridSection(b));
+				this.section(body, s.sections.dashboardControls, s.sections.dashboardControlsDesc, (b) =>
+					this.dashboardControlsSection(b),
+				);
 				this.section(body, s.sections.cardSurface, s.sections.cardSurfaceDesc, (b) =>
 					this.cardSurfaceSection(b),
 				);
@@ -802,6 +805,39 @@ export class HomeSettingTab extends PluginSettingTab {
 					await this.save();
 				}),
 			);
+	}
+
+	// ---- Dashboard: UI controls -----------------------------------------
+
+	private dashboardControlsSection(containerEl: HTMLElement): void {
+		const s = this.plugin.settings;
+		const labels = t().settings.dashboard.visibilityOptions;
+
+		new Setting(containerEl)
+			.setName(t().settings.dashboard.arrangeButtonVisibility)
+			.setDesc(t().settings.dashboard.arrangeButtonVisibilityDesc)
+			.addDropdown((d) => {
+				d.addOption("always", labels.always)
+					.addOption("hover", labels.hover)
+					.setValue(s.arrangeButtonVisibility === "hover" ? "hover" : "always")
+					.onChange(async (v) => {
+						s.arrangeButtonVisibility = v as HomeSettings["arrangeButtonVisibility"];
+						await this.save();
+					});
+			});
+
+		new Setting(containerEl)
+			.setName(t().settings.dashboard.dashboardSwitcherVisibility)
+			.setDesc(t().settings.dashboard.dashboardSwitcherVisibilityDesc)
+			.addDropdown((d) => {
+				d.addOption("always", labels.always)
+					.addOption("hover", labels.hover)
+					.setValue(s.dashboardSwitcherVisibility === "hover" ? "hover" : "always")
+					.onChange(async (v) => {
+						s.dashboardSwitcherVisibility = v as HomeSettings["dashboardSwitcherVisibility"];
+						await this.save();
+					});
+			});
 	}
 
 	// ---- Dashboard: card surface (opacity / blur) -----------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -496,6 +496,8 @@ export interface Dashboard {
 	cardBlur?: number;
 }
 
+export type ChromeVisibility = "always" | "hover";
+
 export interface HomeSettings {
 	// ---- Header ----
 	title: string;
@@ -541,6 +543,10 @@ export interface HomeSettings {
 	// ---- Appearance (layout density) ----
 	/** Tighten card and top-of-page spacing to enlarge the usable area. */
 	compact: boolean;
+	/** Visibility for the arrange/edit mode entry button. */
+	arrangeButtonVisibility: ChromeVisibility;
+	/** Visibility for the top-left dashboard switcher buttons. */
+	dashboardSwitcherVisibility: ChromeVisibility;
 	/** Card background opacity (0 = fully transparent, 1 = fully opaque). */
 	cardOpacity: number;
 	/** Card surface backdrop blur in pixels — the frosted-glass strength behind
@@ -617,6 +623,8 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	disableExternalCalls: false,
 
 	compact: false,
+	arrangeButtonVisibility: "always",
+	dashboardSwitcherVisibility: "always",
 	cardOpacity: 0.5,
 	// Frosted glass on by default: a translucent card surface with a gentle blur
 	// of the background behind it. Pairs with the 0.5 opacity above.

--- a/styles.css
+++ b/styles.css
@@ -1797,13 +1797,51 @@
 	height: 15px;
 }
 
+.hearth-arrange-zone {
+	display: flex;
+	align-items: center;
+}
+
+.hearth-arrange-zone.is-auto-hide .hearth-tool-btn {
+	opacity: 0;
+	pointer-events: none;
+	transform: translateX(8px);
+}
+
+.hearth-arrange-zone.is-auto-hide:hover .hearth-tool-btn,
+.hearth-arrange-zone.is-auto-hide:focus-within .hearth-tool-btn {
+	opacity: 1;
+	pointer-events: auto;
+	transform: translateX(0);
+}
+
 /* ---- Dashboard switcher (top-left) ---------------------------------- */
+
+.hearth-dash-switcher-zone {
+	display: flex;
+	align-items: center;
+}
 
 .hearth-dash-switcher {
 	display: flex;
 	align-items: center;
 	gap: 6px;
 	margin-bottom: -16px;
+	transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.hearth-dash-switcher-zone.is-auto-hide .hearth-dash-switcher {
+	opacity: 0;
+	pointer-events: none;
+	transform: translateY(-4px);
+}
+
+.hearth-dash-switcher-zone.is-auto-hide:hover .hearth-dash-switcher,
+.hearth-dash-switcher-zone.is-auto-hide:focus-within .hearth-dash-switcher,
+.hearth-dash-switcher-zone.is-auto-hide .hearth-dash-switcher.is-dragging {
+	opacity: 1;
+	pointer-events: auto;
+	transform: translateY(0);
 }
 
 .hearth-dash-btn {

--- a/styles.css
+++ b/styles.css
@@ -151,7 +151,9 @@
 	background: var(--background-primary);
 	border: 1px solid var(--background-modifier-border);
 	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
-	transition: border-color 120ms ease, box-shadow 120ms ease;
+	transition:
+		border-color 120ms ease,
+		box-shadow 120ms ease;
 }
 
 .hearth-search-bar:focus-within {
@@ -191,7 +193,9 @@
 	cursor: pointer;
 	font-size: 0.95rem;
 	white-space: nowrap;
-	transition: background 120ms ease, border-color 120ms ease;
+	transition:
+		background 120ms ease,
+		border-color 120ms ease;
 }
 
 .hearth-newnote:hover {
@@ -202,7 +206,6 @@
 .hearth-newnote-icon {
 	display: flex;
 }
-
 
 /* ---- Search results dropdown --------------------------------------- */
 
@@ -407,13 +410,19 @@
 	border-radius: 14px;
 	border: 1px solid var(--background-modifier-border);
 	/* --card-opacity (0..1) tints the card surface without dimming content. */
-	background: color-mix(in srgb, var(--background-primary) calc(var(--card-opacity, 1) * 100%), transparent);
+	background: color-mix(
+		in srgb,
+		var(--background-primary) calc(var(--card-opacity, 1) * 100%),
+		transparent
+	);
 	/* Drop shadow via a variable so merged edges can drop it (see below) and
 	 * hover can lift it without re-declaring the whole shadow. */
 	--hearth-card-lift: 0 2px 12px rgba(0, 0, 0, 0.06);
 	box-shadow: var(--hearth-card-lift);
 	overflow: hidden;
-	transition: box-shadow 120ms ease, transform 120ms ease;
+	transition:
+		box-shadow 120ms ease,
+		transform 120ms ease;
 }
 
 /* Frosted glass: a SINGLE shared blur layer per grid, not a backdrop-filter on
@@ -883,7 +892,9 @@
 	cursor: pointer;
 	white-space: nowrap;
 	box-shadow: none;
-	transition: background 120ms ease, color 120ms ease;
+	transition:
+		background 120ms ease,
+		color 120ms ease;
 }
 
 .hearth-ribbon-tab:hover {
@@ -918,8 +929,12 @@
 }
 
 @keyframes hearth-tab-fade {
-	from { opacity: 0; }
-	to { opacity: 1; }
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
 }
 
 /* ---- Settings tab: About panel --------------------------------------
@@ -1158,7 +1173,9 @@
 	border: 1px solid var(--background-modifier-border);
 	background: var(--background-secondary);
 	cursor: pointer;
-	transition: border-color 120ms ease, background 120ms ease;
+	transition:
+		border-color 120ms ease,
+		background 120ms ease;
 }
 
 .hearth-fav-card:hover {
@@ -1357,7 +1374,11 @@
 	background: var(--background-secondary);
 	cursor: pointer;
 	text-align: center;
-	transition: border-color 120ms ease, background 120ms ease, transform 120ms ease, box-shadow 120ms ease;
+	transition:
+		border-color 120ms ease,
+		background 120ms ease,
+		transform 120ms ease,
+		box-shadow 120ms ease;
 }
 
 /* Per-tile width/height: converted to grid column/row spans inline by
@@ -1470,14 +1491,22 @@
 .hearth-link-tile.is-obscured {
 	outline: 2px solid var(--color-red, #f55);
 	outline-offset: 2px;
-	box-shadow: 0 0 12px 2px color-mix(in srgb, var(--color-red, #f55) 55%, transparent);
+	box-shadow: 0 0 12px 2px
+		color-mix(in srgb, var(--color-red, #f55) 55%, transparent);
 	border-color: var(--color-red, #f55);
 	animation: hearth-tile-obscured-pulse 1.6s ease-in-out infinite;
 }
 
 @keyframes hearth-tile-obscured-pulse {
-	0%, 100% { box-shadow: 0 0 8px 1px color-mix(in srgb, var(--color-red, #f55) 40%, transparent); }
-	50% { box-shadow: 0 0 16px 3px color-mix(in srgb, var(--color-red, #f55) 65%, transparent); }
+	0%,
+	100% {
+		box-shadow: 0 0 8px 1px
+			color-mix(in srgb, var(--color-red, #f55) 40%, transparent);
+	}
+	50% {
+		box-shadow: 0 0 16px 3px
+			color-mix(in srgb, var(--color-red, #f55) 65%, transparent);
+	}
 }
 
 .hearth-link-label {
@@ -1802,6 +1831,10 @@
 	align-items: center;
 }
 
+.hearth-arrange-zone.is-auto-hide {
+	padding: 16px;
+}
+
 .hearth-arrange-zone.is-auto-hide .hearth-tool-btn {
 	opacity: 0;
 	pointer-events: none;
@@ -1822,12 +1855,18 @@
 	align-items: center;
 }
 
+.hearth-dash-switcher-zone.is-auto-hide {
+	padding: 16px 0;
+}
+
 .hearth-dash-switcher {
 	display: flex;
 	align-items: center;
 	gap: 6px;
 	margin-bottom: -16px;
-	transition: opacity 120ms ease, transform 120ms ease;
+	transition:
+		opacity 120ms ease,
+		transform 120ms ease;
 }
 
 .hearth-dash-switcher-zone.is-auto-hide .hearth-dash-switcher {
@@ -1945,7 +1984,9 @@
 	cursor: pointer;
 	font-size: 0.92rem;
 	white-space: nowrap;
-	transition: background 120ms ease, border-color 120ms ease;
+	transition:
+		background 120ms ease,
+		border-color 120ms ease;
 }
 
 .hearth-mobile-action:hover {
@@ -2068,10 +2109,18 @@
  * corner only flattens when a neighbour actually reaches it, so two cards that
  * share an edge only along part of its length keep the rounded corners that
  * don't touch anything. */
-.hearth-card.merge-tl { border-top-left-radius: 0; }
-.hearth-card.merge-tr { border-top-right-radius: 0; }
-.hearth-card.merge-bl { border-bottom-left-radius: 0; }
-.hearth-card.merge-br { border-bottom-right-radius: 0; }
+.hearth-card.merge-tl {
+	border-top-left-radius: 0;
+}
+.hearth-card.merge-tr {
+	border-top-right-radius: 0;
+}
+.hearth-card.merge-bl {
+	border-bottom-left-radius: 0;
+}
+.hearth-card.merge-br {
+	border-bottom-right-radius: 0;
+}
 
 .hearth-card.has-accent {
 	border-color: var(--card-accent);
@@ -2090,10 +2139,18 @@
  * background fills the now-borderless edge (box-sizing is border-box).
  * Deliberately placed after the accent rules so a touching edge goes
  * borderless even on accent-coloured cards. */
-.hearth-card.merge-top { border-top-color: transparent; }
-.hearth-card.merge-bottom { border-bottom-color: transparent; }
-.hearth-card.merge-left { border-left-color: transparent; }
-.hearth-card.merge-right { border-right-color: transparent; }
+.hearth-card.merge-top {
+	border-top-color: transparent;
+}
+.hearth-card.merge-bottom {
+	border-bottom-color: transparent;
+}
+.hearth-card.merge-left {
+	border-left-color: transparent;
+}
+.hearth-card.merge-right {
+	border-right-color: transparent;
+}
 
 /* Drop the drop-shadow on any card that shares a full edge with a neighbour.
  * The base shadow (0 2px 12px) is offset 2px downward, so a card stacked above
@@ -2236,8 +2293,12 @@
 	height: 8px;
 	cursor: ns-resize;
 }
-.hearth-resize-handle.is-n { top: 0; }
-.hearth-resize-handle.is-s { bottom: 0; }
+.hearth-resize-handle.is-n {
+	top: 0;
+}
+.hearth-resize-handle.is-s {
+	bottom: 0;
+}
 
 .hearth-resize-handle.is-e,
 .hearth-resize-handle.is-w {
@@ -2246,8 +2307,12 @@
 	width: 8px;
 	cursor: ew-resize;
 }
-.hearth-resize-handle.is-e { right: 0; }
-.hearth-resize-handle.is-w { left: 0; }
+.hearth-resize-handle.is-e {
+	right: 0;
+}
+.hearth-resize-handle.is-w {
+	left: 0;
+}
 
 /* Corners (sit above the edge strips) */
 .hearth-resize-handle.is-ne,
@@ -2258,17 +2323,37 @@
 	height: 16px;
 	z-index: 7;
 }
-.hearth-resize-handle.is-nw { top: 0; left: 0; cursor: nwse-resize; }
-.hearth-resize-handle.is-se { bottom: 0; right: 0; cursor: nwse-resize; }
-.hearth-resize-handle.is-ne { top: 0; right: 0; cursor: nesw-resize; }
-.hearth-resize-handle.is-sw { bottom: 0; left: 0; cursor: nesw-resize; }
+.hearth-resize-handle.is-nw {
+	top: 0;
+	left: 0;
+	cursor: nwse-resize;
+}
+.hearth-resize-handle.is-se {
+	bottom: 0;
+	right: 0;
+	cursor: nwse-resize;
+}
+.hearth-resize-handle.is-ne {
+	top: 0;
+	right: 0;
+	cursor: nesw-resize;
+}
+.hearth-resize-handle.is-sw {
+	bottom: 0;
+	left: 0;
+	cursor: nesw-resize;
+}
 
 /* Bigger, easier-to-grab resize targets on touch devices. */
 @media (pointer: coarse) {
 	.hearth-resize-handle.is-n,
-	.hearth-resize-handle.is-s { height: 14px; }
+	.hearth-resize-handle.is-s {
+		height: 14px;
+	}
 	.hearth-resize-handle.is-e,
-	.hearth-resize-handle.is-w { width: 14px; }
+	.hearth-resize-handle.is-w {
+		width: 14px;
+	}
 	.hearth-resize-handle.is-ne,
 	.hearth-resize-handle.is-nw,
 	.hearth-resize-handle.is-se,
@@ -2330,7 +2415,12 @@
  * stable --accent-h/s/l vars (not --interactive-accent-hsl, which is
  * comma-separated on some Obsidian versions and would break slash-alpha). */
 .hearth-calendar-day.has-heat {
-	background-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), calc(var(--heat, 0) * 0.22));
+	background-color: hsla(
+		var(--accent-h),
+		var(--accent-s),
+		var(--accent-l),
+		calc(var(--heat, 0) * 0.22)
+	);
 }
 
 /* ---- Tasks: TaskNotes quick-add button ------------------------------ */
@@ -2377,7 +2467,10 @@
 	cursor: pointer;
 	opacity: 0;
 	pointer-events: auto;
-	transition: opacity 140ms ease, background 140ms ease, border-color 140ms ease;
+	transition:
+		opacity 140ms ease,
+		background 140ms ease,
+		border-color 140ms ease;
 }
 
 /* Reveal the "new task" button whenever the whole card is hovered (not just
@@ -2805,7 +2898,11 @@ body.hearth-dv-resizing {
 	font-weight: 600;
 	cursor: pointer;
 	pointer-events: auto;
-	transition: opacity 140ms ease, background 140ms ease, color 140ms ease, border-color 140ms ease;
+	transition:
+		opacity 140ms ease,
+		background 140ms ease,
+		color 140ms ease,
+		border-color 140ms ease;
 }
 
 .hearth-tasks-sort:hover,
@@ -2888,7 +2985,10 @@ body.hearth-dv-resizing {
 	color: var(--text-normal);
 	font-size: 0.78rem;
 	cursor: pointer;
-	transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
+	transition:
+		background 140ms ease,
+		color 140ms ease,
+		border-color 140ms ease;
 }
 
 .hearth-taskfilter-chip:hover {
@@ -2992,7 +3092,9 @@ body.hearth-dv-resizing {
 	font-weight: 600;
 	line-height: 1.5;
 	cursor: pointer;
-	transition: background 140ms ease, color 140ms ease;
+	transition:
+		background 140ms ease,
+		color 140ms ease;
 }
 
 .hearth-embed-switch-btn:hover {
@@ -3040,7 +3142,12 @@ body.hearth-dv-resizing {
 }
 
 .hearth-heatmap-cell.has-heat {
-	background-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), calc(0.15 + var(--heat, 0) * 0.2125));
+	background-color: hsla(
+		var(--accent-h),
+		var(--accent-s),
+		var(--accent-l),
+		calc(0.15 + var(--heat, 0) * 0.2125)
+	);
 	cursor: pointer;
 }
 
@@ -3136,7 +3243,8 @@ body.hearth-dv-resizing {
    for colour-blind users or at a glance. */
 .hearth-task-priority.is-highest .hearth-task-priority-dot {
 	background: var(--color-pink, #d01e5b);
-	box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-pink, #d01e5b) 35%, transparent);
+	box-shadow: 0 0 0 2px
+		color-mix(in srgb, var(--color-pink, #d01e5b) 35%, transparent);
 }
 
 .hearth-task-priority.is-high .hearth-task-priority-dot {


### PR DESCRIPTION
## Why

Some dashboard layouts are designed to be minimal or highly visual, and always-visible controls can add visual noise when they are not actively being used.

Hearth already provides dashboard customization options for layout and appearance, so this adds a small amount of control over the surrounding dashboard controls without changing the default experience.

## What changed

- Added a global visibility setting for the arrange/edit button.
- Added a global visibility setting for the dashboard switcher.
- Both controls now support:
  - Always visible
  - Show on hover
- Defaults remain `Always visible` to preserve the current behavior.
- Hover mode reveals controls when hovering their area and also supports keyboard focus with `:focus-within`.

## Notes

The dashboard switcher uses a hover area around the whole switcher so the group can be revealed without breaking per-button interactions such as title hover, context menu, click, or drag/drop.

## Validation

- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Manually tested in Obsidian:
  - arrange/edit button hover reveal
  - dashboard switcher hover reveal
  - dashboard button hover titles
  - context menu
  - dashboard drag/drop
  - arrange mode controls
