### PR TITLE
chore: harden build and add changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install & build
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Verify build output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,226 @@
+# Changelog
+
+All notable changes to Hearth are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to a numeric-only versioning scheme
+(`MAJOR.MINOR.PATCH`) as required by Obsidian's plugin manifest. Beta builds
+carry a fourth `.N-beta` segment and are omitted here; each entry aggregates its
+preceding beta series.
+
+History begins at 1.5.0. For releases before 1.5.0, see the
+[GitHub Releases](https://github.com/ondreu/Hearth/releases) page.
+
+## [1.8.0] - 2026-07-11
+
+A cards-and-appearance release aggregating the whole 1.7.1 beta series.
+
+### Added
+
+- **Dataview card** — runs a DQL or DataviewJS query and renders the results
+  through [Dataview](https://github.com/blacksmithgu/obsidian-dataview)'s own
+  renderers (tables, lists and task lists look native and refresh live), with
+  auto-fitting, drag-resizable table columns.
+- **Plugin view card** (beta) — hosts any plugin's — or a core — side-panel view
+  (calendar, outline, tag pane, kanban…) right on the dashboard via a detached
+  workspace leaf that never touches your saved layout.
+- **Frosted glass** — a backdrop blur behind translucent cards at global,
+  per-dashboard and per-card levels, drawn on one shared layer so merged cards
+  read as a single seamless sheet. Now the default look for fresh installs.
+- **About** settings tab.
+- Embed cards can carry a **second view** with a switcher, and can **hide a
+  base's header**.
+- Tasks card gains a **list filter**, a **custom multi-rule sort**, and
+  multi-value **TaskNotes "complete" statuses**.
+
+### Changed
+
+- **Settings tab reorganized** into a category ribbon (Appearance · Search ·
+  Dashboard · Behaviour · Integrations · Backup · About) with a description on
+  every setting.
+- Embed **zoom now reflows** to fit its card.
+
+## [1.7.0] - 2026-07-10
+
+A major Tasks-card release, plus search and release-notes additions
+(everything from the 1.6.8 beta series).
+
+### Added
+
+- **Kanban plugin boards** — the Tasks card can read and edit
+  [Kanban](https://github.com/obsidian-community/obsidian-kanban) boards (each
+  heading a column, each checkbox a card) as a list or a drag-and-drop board
+  that rewrites the note in Kanban's own format.
+- **Full obsidian-tasks metadata** — start (🛫), scheduled (⏳), due (📅) and
+  done (✅) dates, a 5-level priority (🔺⏫🔼🔽⏬, each a distinct colour) and
+  recurrence (🔁), shown as compact indicators with a right-click editor and
+  add-card pickers — from Kanban cards and plain Markdown checkboxes alike.
+- **Custom task states** (`[symbol] Label`) that each become a draggable board
+  column, plus **done columns** and per-column **sort** (Smart / Due / Priority
+  / Created / Alphabetical).
+- **Quick view** — clicking a task opens a compact editor for metadata and
+  description in place.
+- **Convert to note** / **create as note** — turn a card into its own linked
+  note (optionally from a template, scraping metadata into frontmatter), or
+  create new cards as notes outright.
+- **Omnisearch** — the search bar can optionally be powered by
+  [Omnisearch](https://github.com/scambier/obsidian-omnisearch) when installed.
+- **"What's new" dialog** — surfaces release notes from a continuous,
+  accumulating changelog after each update.
+
+### Changed
+
+- Double-click **column rename**, clickable links, per-card descriptions, and
+  card deletion on boards.
+- Recurring tasks complete **per-occurrence** like TaskNotes.
+- Scroll-mode boards grow as you drag a card past the bottom.
+
+## [1.6.7] - 2026-07-09
+
+### Fixed
+
+- Maintenance and bug-fix release
+  ([1.6.6…1.6.7](https://github.com/ondreu/Hearth/compare/1.6.6...1.6.7)).
+
+## [1.6.6] - 2026-07-08
+
+### Fixed
+
+- Maintenance and bug-fix release
+  ([1.6.5…1.6.6](https://github.com/ondreu/Hearth/compare/1.6.5...1.6.6)).
+
+## [1.6.5] - 2026-07-07
+
+### Fixed
+
+- Maintenance and bug-fix release
+  ([1.6.4…1.6.5](https://github.com/ondreu/Hearth/compare/1.6.4...1.6.5)).
+
+## [1.6.4] - 2026-07-07
+
+### Fixed
+
+- Maintenance and bug-fix release
+  ([1.6.3…1.6.4](https://github.com/ondreu/Hearth/compare/1.6.3...1.6.4)).
+
+## [1.6.3] - 2026-07-07
+
+### Fixed
+
+- Maintenance and bug-fix release
+  ([1.6.2…1.6.3](https://github.com/ondreu/Hearth/compare/1.6.2...1.6.3)).
+
+## [1.6.2] - 2026-07-07
+
+### Fixed
+
+- Maintenance and bug-fix release
+  ([1.6.1…1.6.2](https://github.com/ondreu/Hearth/compare/1.6.1...1.6.2)).
+
+## [1.6.1] - 2026-07-07
+
+### Fixed
+
+- Maintenance and bug-fix release
+  ([1.5.2…1.6.1](https://github.com/ondreu/Hearth/compare/1.5.2...1.6.1)).
+
+## [1.6.0] - 2026-07-06
+
+### Added
+
+- **Natural-language task dates** — type due/scheduled dates in plain language
+  (`📅 tomorrow`, `📅 next friday`, `📅 in 3 days`…).
+- **Free-form tiles** — tiles can be placed anywhere and may overlap; drag & drop
+  with a dashed drop-target ghost and an overlap glow. Auto-shift is an opt-in
+  beta per card.
+- **Mobile search** — search optimized for mobile.
+- **Edge-merging cards** — adjacent cards merge their borders and sharpen their
+  touching corners so they read as one continuous tile.
+- **Relative date labels for tasks** — Today / Tomorrow / Yesterday / Friday /
+  Next Friday / "15 Jul".
+- **Recurring-task completion checkbox** — undoable, rendered before the task
+  text; Kanban recurring checkbox inline with the task text.
+- **Hide titles** — hides card headers (not the dashboard header).
+
+### Changed
+
+- Daily/embed cards now use a single scrollbar; the embed scrolls instead of the
+  card body.
+- Daily note: floating open button on the card; header hidden by default in
+  arrange mode.
+- Manifest version is numeric-only (`1.6.0`) to satisfy Obsidian plugin review.
+- Replaced direct `element.style.X = …` assignments with `setCssStyles()` / CSS
+  classes; use `activeDocument` instead of `document` for popout-window
+  compatibility; replaced CSS `:has(...)` selectors with explicit body modifier
+  classes (`.is-embed-host`, `.is-jot-host`).
+
+### Fixed
+
+- Daily/embed horizontal scroll (clip x-overflow, wrap text).
+- Tile drag offset (transform-based); overlap glow always on.
+- Added the `u` flag to regexes containing surrogate-pair emoji (Tasks-plugin
+  markers).
+
+## [1.5.2] - 2026-07-05
+
+### Fixed
+
+- Maintenance and bug-fix release
+  ([1.5.1…1.5.2](https://github.com/ondreu/Hearth/compare/1.5.1...1.5.2)).
+
+## [1.5.1] - 2026-07-05
+
+### Fixed
+
+- Maintenance and bug-fix release
+  ([1.5.0…1.5.1](https://github.com/ondreu/Hearth/compare/1.5.0...1.5.1)).
+
+## [1.5.0] - 2026-07-05
+
+A redesigned dashboard experience, plus recurring tasks and many polish fixes.
+
+### Added
+
+- **CSS-grid tiles** — Links/launchpad and Commands tiles live on a fine CSS
+  grid (44 px cells, 4 px snap) with independent column and row spans. Drag a
+  tile to reorder; drag the corner grip to resize. Default tile is 2×2.
+- **Ambient default background** — a soft, blurred backdrop ships out of the box.
+- **Recurring TaskNotes tasks** — tasks with a `recurrence` RRULE show a ↻ badge
+  next to the next-occurrence date, tinted with the accent colour, with a
+  plain-English schedule tooltip ("Repeats every week"). Overdue recurring tasks
+  tint like one-offs.
+- **Overhauled starter dashboard** — a redesigned default layout with exact
+  coordinates.
+
+### Changed
+
+- **Smarter task sorting** — due → scheduled → priority → created.
+- **Kanban drop outlines** — dragged cards preview where they'll land.
+- **Calendar today outline** — today's cell stays visible under the heatmap tint.
+- **Search layout polish** — autocomplete click-outside, restored field width,
+  larger tile grip.
+- **Fit-to-page default-on** — fresh installs lock to one screen; stuck cards
+  auto-recover onto the board on render.
+
+### Fixed
+
+- Card drag overlay behaves correctly over tile cards.
+- Tile grip visibility and contrast improved.
+- Calendar arrow targets now work in dark themes.
+- "Other" file-type filter hides when there are no unmatched files.
+- Default background uses a CDN URL (raw.githubusercontent was blocked by
+  Obsidian's CSP).
+
+[1.8.0]: https://github.com/ondreu/Hearth/compare/1.7.0...1.8.0
+[1.7.0]: https://github.com/ondreu/Hearth/compare/1.6.7...1.7.0
+[1.6.7]: https://github.com/ondreu/Hearth/compare/1.6.6...1.6.7
+[1.6.6]: https://github.com/ondreu/Hearth/compare/1.6.5...1.6.6
+[1.6.5]: https://github.com/ondreu/Hearth/compare/1.6.4...1.6.5
+[1.6.4]: https://github.com/ondreu/Hearth/compare/1.6.3...1.6.4
+[1.6.3]: https://github.com/ondreu/Hearth/compare/1.6.2...1.6.3
+[1.6.2]: https://github.com/ondreu/Hearth/compare/1.6.1...1.6.2
+[1.6.1]: https://github.com/ondreu/Hearth/compare/1.5.2...1.6.1
+[1.6.0]: https://github.com/ondreu/Hearth/compare/1.5.2...1.6.0
+[1.5.2]: https://github.com/ondreu/Hearth/compare/1.5.1...1.5.2
+[1.5.1]: https://github.com/ondreu/Hearth/compare/1.5.0...1.5.1
+[1.5.0]: https://github.com/ondreu/Hearth/releases/tag/1.5.0

--- a/README.md
+++ b/README.md
@@ -447,72 +447,9 @@ genuinely appreciated and helps keep the updates coming.
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/B7K822EW68)
 
-## Shipped:
+## Changelog
 
-> **v1.8.0** — a cards-and-appearance release aggregating the whole 1.7.1 beta
-> series. Two new cards headline it: a **Dataview card** that runs a DQL or
-> DataviewJS query and renders the results through
-> **[Dataview](https://github.com/blacksmithgu/obsidian-dataview)**'s own
-> renderers (tables, lists and task lists look native and refresh live, with
-> auto-fitting, drag-resizable table columns), and a beta **Plugin view card**
-> that hosts any plugin's — or a core — **side-panel view** (calendar, outline,
-> tag pane, kanban…) right on the dashboard via a detached workspace leaf that
-> never touches your saved layout. Cards gain **frosted glass** — a backdrop
-> blur behind translucent cards at global, per-dashboard and per-card levels,
-> drawn on one shared layer so merged cards read as a single seamless sheet —
-> and it's now the **default look** for fresh installs. The **settings tab is
-> reorganized** into a category ribbon (Appearance · Search · Dashboard ·
-> Behaviour · Integrations · Backup · About) with a description on every setting
-> and a new **About** tab. Embed cards can carry a **second view** with a
-> switcher and **hide a base's header**, embed **zoom now reflows** to fit its
-> card, and the Tasks card grows a **list filter**, a **custom multi-rule sort**,
-> and multi-value **TaskNotes "complete" statuses**.
-
-> **v1.7.0** — a major Tasks-card release, plus search and release-notes
-> additions (everything from the 1.6.8 beta series). The Tasks card can now read
-> and edit **[Kanban](https://github.com/obsidian-community/obsidian-kanban)
-> plugin boards** — each heading a column, each checkbox a card — as a list or a
-> drag-and-drop board that rewrites the note in Kanban's own format. Cards
-> understand the full **obsidian-tasks metadata**: start (🛫), scheduled (⏳),
-> due (📅) and done (✅) dates, a 5-level priority (🔺⏫🔼🔽⏬, each a distinct
-> colour) and recurrence (🔁), shown as compact indicators with a right-click
-> editor and add-card pickers — read from Kanban cards and plain **Markdown
-> checkboxes** alike, and you can define your own **custom task states**
-> (`[symbol] Label`) that each become a draggable board column. Clicking a task
-> opens a compact **quick view** for editing metadata and description in place;
-> **convert to note** turns a card into its own linked note (optionally from a
-> template, scraping metadata into frontmatter and moving the description into
-> the note), or new cards can be **created as notes** outright. Boards gain
-> **done columns**, double-click **column rename**, clickable links, per-card
-> descriptions, card deletion, an always-visible **sort** control (Smart / Due /
-> Priority / Created / Alphabetical) that lives on each column, and recurring
-> tasks that complete **per-occurrence** like TaskNotes. The search bar can
-> optionally be powered by
-> **[Omnisearch](https://github.com/scambier/obsidian-omnisearch)** when it's
-> installed, scroll-mode boards grow as you drag a card past the bottom, and a
-> **"What's new" dialog** now surfaces release notes from a continuous,
-> accumulating changelog after each update.
-
-> **v1.6** — task due dates show as short relative labels ("Today", "Tomorrow",
-> "Yesterday", "Friday", "Next Friday", "15 Jul"), free-form launchpad tiles
-> you can drop anywhere on the card (not just the top-to-bottom flow), centred
-> mobile search, and edge-merging cards: two cards snapped together lose their
-> shared border and sharpen their touching corners so they read as one
-> continuous tile. Task due dates also accept natural-language input (`📅
-> tomorrow`, `📅 next friday`, `📅 in 3 days`…). Launchpad tiles are now pure
-> free-form: they can be placed anywhere and may overlap — a hidden tile glows
-> so the overlap is easy to spot and fix. An optional **Auto-shift tiles**
-> (beta) per-card toggle makes tiles shove each other aside live while
-> dragging (phone-widget style). In arrange mode the per-card headers can be
-> toggled off so each card's full body is visible.
-
-> **v1.5** — a redesigned dashboard experience: a CSS-grid tile layout with
-> independent column/row spans and drag-to-reorder, an ambient default
-> background, an overhauled starter dashboard, recurring TaskNotes tasks with
-> a ↻ badge and human-readable recurrence tooltip, smarter task sorting
-> (due → scheduled → priority → created), kanban drop outlines, calendar
-> today outline under the heatmap, search layout polish, and many fit-to-page
-> and card-drag fixes.
+Release history lives in [CHANGELOG.md](CHANGELOG.md).
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "hearth",
-	"version": "1.8.0",
+	"version": "1.8.1.4-beta",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hearth",
-			"version": "1.8.0",
+			"version": "1.8.1.4-beta",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^20.11.0",
 				"esbuild": "^0.28.1",
-				"obsidian": "*",
+				"obsidian": "1.8.7",
 				"tslib": "^2.6.2",
 				"typescript": "^5.4.0"
 			}
@@ -589,9 +589,9 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
-			"integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
+			"version": "1.8.7",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
+			"integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -599,8 +599,8 @@
 				"moment": "2.29.4"
 			},
 			"peerDependencies": {
-				"@codemirror/state": "6.5.0",
-				"@codemirror/view": "6.38.6"
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
 			}
 		},
 		"node_modules/style-mod": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"devDependencies": {
 		"@types/node": "^20.11.0",
 		"esbuild": "^0.28.1",
-		"obsidian": "latest",
+		"obsidian": "1.8.7",
 		"tslib": "^2.6.2",
 		"typescript": "^5.4.0"
 	}


### PR DESCRIPTION
## What changes

Three build-hardening / documentation changes, no runtime code touched:

1. **Pin `obsidian` dependency** — `package.json` moves the `obsidian` devDependency from `"latest"` to `"1.8.7"`, matching `minAppVersion` in `manifest.json`. `package-lock.json` regenerated accordingly (was resolving to 1.13.1).
2. **`npm ci` in release workflow** — `.github/workflows/release.yml` now uses `npm ci` instead of `npm install` for the install-&-build step.
3. **`CHANGELOG.md`** — new file in [Keep a Changelog](https://keepachangelog.com/) format, backfilled from GitHub Releases from 1.5.0 up. The README `## Shipped:` prose section is removed and replaced with a link to the changelog.

## Why

- `"obsidian": "latest"` means every fresh `npm install` can silently pull a newer API surface (currently 1.13.1) than the plugin actually targets (`minAppVersion` 1.8.7). Pinning to `1.8.7` makes builds reproducible and keeps the compiled API in sync with the minimum Obsidian version users actually run. `1.8.7` is published on npm and the build/typecheck pass against it.
- `npm install` can mutate the lockfile and resolve versions not captured in `package-lock.json`; `npm ci` installs exactly what the lockfile pins, so release artifacts are reproducible. (CI already used `npm ci`; this brings the release workflow in line.)
- A structured, machine-readable changelog is easier to maintain and link to than free prose embedded in the README, and it separates release history from the product pitch.

## How to test

```bash
npm ci            # installs obsidian 1.8.7 from the lockfile
npm run typecheck # passes
npm run build     # passes, emits main.js
```

- Confirm `package-lock.json` resolves `obsidian` to `1.8.7`.
- Confirm the README no longer has a `## Shipped:` section and instead links to `CHANGELOG.md`.

## Notes

- Only **stable** releases are listed in the changelog; beta builds (`.N-beta`) are aggregated into their following stable entry, as noted in the file header.
- Several patch releases (1.5.1, 1.5.2, 1.6.1–1.6.7) had no release notes on GitHub, so they're recorded as maintenance releases with a compare link rather than invented content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJEbTGcEfSPAN4qvi7A8aG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJEbTGcEfSPAN4qvi7A8aG)_