### PR TITLE
chore: unpin obsidian devDependency back to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"esbuild": "^0.28.1",
 				"eslint": "^9.39.5",
 				"eslint-plugin-obsidianmd": "^0.4.1",
-				"obsidian": "1.8.7",
+				"obsidian": "latest",
 				"tslib": "^2.6.2",
 				"typescript": "^5.4.0",
 				"typescript-eslint": "^8.63.0"
@@ -3907,9 +3907,9 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.8.7",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
-			"integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+			"integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3917,8 +3917,8 @@
 				"moment": "2.29.4"
 			},
 			"peerDependencies": {
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0"
+				"@codemirror/state": "6.5.0",
+				"@codemirror/view": "6.38.6"
 			}
 		},
 		"node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"esbuild": "^0.28.1",
 		"eslint": "^9.39.5",
 		"eslint-plugin-obsidianmd": "^0.4.1",
-		"obsidian": "1.8.7",
+		"obsidian": "latest",
 		"tslib": "^2.6.2",
 		"typescript": "^5.4.0",
 		"typescript-eslint": "^8.63.0"


### PR DESCRIPTION
## What changes

Reverts the `obsidian` devDependency from the pinned `"1.8.7"` (introduced in the build-hardening PR) back to `"latest"`, matching the Obsidian sample-plugin convention. `package-lock.json` regenerated — `obsidian` now resolves to `1.13.1`. **`src/` untouched, nothing fixed.**

```diff
-		"obsidian": "1.8.7",
+		"obsidian": "latest",
```

## Why

Pinning the typings to `minAppVersion` conflated two different things:

- **`minAppVersion: 1.8.7`** (manifest) — the *oldest Obsidian the plugin runs on at runtime*.
- **`obsidian` devDependency** — the *API surface we compile against* at build time.

Pinning the typings down doesn't grant runtime compatibility with 1.8.7 — it just hides the ~23 real deprecations that exist in current Obsidian and will eventually be removed. The sample plugin uses `latest` for exactly this reason. Build reproducibility is guaranteed by `npm ci` + `package-lock.json` (which pins the concrete resolved version), not by a range string in `package.json`.

## How to test

```bash
npm ci        # obsidian resolves to 1.13.1 from the lockfile
npm run build # passes
npm run lint  # exits 1, 42 problems (baseline restored)
```

## (a) New lint summary

**42 problems — 5 errors, 37 warnings**, 9 of 32 files.

| Rule | Total | Err | Warn | Auto-fix |
| --- | ---: | ---: | ---: | ---: |
| `@typescript-eslint/no-deprecated` | 29 | 0 | 29 | 0 |
| `obsidianmd/prefer-create-el` | 6 | 0 | 6 | 5 |
| `@typescript-eslint/no-base-to-string` | 3 | 3 | 0 | 0 |
| `obsidianmd/no-static-styles-assignment` | 2 | 2 | 0 | 0 |
| `obsidianmd/settings-tab/prefer-setting-definitions` | 1 | 0 | 1 | 0 |
| `obsidianmd/prefer-window-timers` | 1 | 0 | 1 | 1 |

## (b) Every `no-deprecated` finding

Grouped for readability; all 29 rows below. The `@since` values are read straight from `node_modules/obsidian/obsidian.d.ts`.

**Rule of thumb:** anything whose replacement needs an API newer than `minAppVersion` (1.8.7) is **NOT** fixed — it goes on the "raise minAppVersion" list (same trap as `prefer-setting-definitions`).

| # | Deprecated API | Suggested replacement | Replacement since | file:line | Decision |
| ---: | --- | --- | --- | --- | --- |
| 1 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | dashboards.ts:318 | ✅ FIX (safe at 1.8.7) |
| 2 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | dashboards.ts:394 | ✅ FIX (safe at 1.8.7) |
| 3 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | editors.ts:146 | ✅ FIX (safe at 1.8.7) |
| 4 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | editors.ts:375 | ✅ FIX (safe at 1.8.7) |
| 5 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | editors.ts:530 | ✅ FIX (safe at 1.8.7) |
| 6 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | editors.ts:776 | ✅ FIX (safe at 1.8.7) |
| 7 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | editors.ts:1348 | ✅ FIX (safe at 1.8.7) |
| 8 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | editors.ts:1374 | ✅ FIX (safe at 1.8.7) |
| 12 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | settings.ts:350 | ✅ FIX (safe at 1.8.7) |
| 14 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | settings.ts:485 | ✅ FIX (safe at 1.8.7) |
| 15 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | settings.ts:499 | ✅ FIX (safe at 1.8.7) |
| 26 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | settings.ts:821 | ✅ FIX (safe at 1.8.7) |
| 27 | `setDynamicTooltip` | remove the call — slider value is now always shown inline | no new API (behaviour since 0.9.7) | settings.ts:835 | ✅ FIX (safe at 1.8.7) |
| 9 | `commandId` | n/a — Hearth's **own** `@deprecated` field (`src/types.ts:300`), read as a fallback for pre-`type`/`target` buttons | n/a (not an Obsidian API) | layout.ts:670 | ⛔ DO NOT FIX (intentional back-compat) |
| 10 | `commandId` | n/a — Hearth's own field, fallback for old buttons | n/a (not an Obsidian API) | mobileactions.ts:30 | ⛔ DO NOT FIX |
| 16 | `commandId` | n/a — Hearth's own field, fallback for old buttons | n/a (not an Obsidian API) | settings.ts:609 | ⛔ DO NOT FIX |
| 18 | `commandId` | n/a — Hearth's own field, fallback for old buttons | n/a (not an Obsidian API) | settings.ts:614 | ⛔ DO NOT FIX |
| 19 | `commandId` | n/a — Hearth's own field, fallback for old buttons | n/a (not an Obsidian API) | settings.ts:629 | ⛔ DO NOT FIX |
| 21 | `commandId` | n/a — Hearth's own field, fallback for old buttons | n/a (not an Obsidian API) | settings.ts:645 | ⛔ DO NOT FIX |
| 11 | `display` | `getSettingDefinitions()` | **1.13.0** | settings.ts:136 | ⏸ DEFER (needs minAppVersion bump) |
| 13 | `display` | `getSettingDefinitions()` | **1.13.0** | settings.ts:448 | ⏸ DEFER |
| 17 | `display` | `getSettingDefinitions()` | **1.13.0** | settings.ts:611 | ⏸ DEFER |
| 20 | `display` | `getSettingDefinitions()` | **1.13.0** | settings.ts:632 | ⏸ DEFER |
| 22 | `display` | `getSettingDefinitions()` | **1.13.0** | settings.ts:671 | ⏸ DEFER |
| 23 | `display` | `getSettingDefinitions()` | **1.13.0** | settings.ts:690 | ⏸ DEFER |
| 24 | `display` | `getSettingDefinitions()` | **1.13.0** | settings.ts:700 | ⏸ DEFER |
| 25 | `display` | `getSettingDefinitions()` | **1.13.0** | settings.ts:711 | ⏸ DEFER |
| 28 | `display` | `getSettingDefinitions()` | **1.13.0** | settings.ts:960 | ⏸ DEFER |
| 29 | `setWarning` | `setDestructive()` / `setDestructive().setCta()` | **1.13.0** | ui.ts:47 | ⏸ DEFER (needs minAppVersion bump) |

### Summary of the 29 `no-deprecated`

| Group | Count | Decision |
| --- | ---: | --- |
| `setDynamicTooltip` (SliderComponent) | 13 | ✅ **Fixable now** — deprecated since 0.9.7, now a no-op; just delete the call. Behaviour identical at 1.8.7. |
| `commandId` (Hearth's own field) | 6 | ⛔ **Leave alone** — deliberately read to keep old mobile-action buttons working. Not an Obsidian API. |
| `SettingTab.display` | 9 | ⏸ **Defer** — replacement `getSettingDefinitions()` is 1.13.0-only. |
| `setWarning` (ButtonComponent) | 1 | ⏸ **Defer** — replacement `setDestructive()` is 1.13.0-only. |

So of 29 `no-deprecated`: **13 fixable at 1.8.7**, **6 intentional (won't fix)**, **10 blocked on a minAppVersion bump**.

## Notes for the "raise minAppVersion" list

When `minAppVersion` is eventually bumped to ≥ 1.13.0, these become fixable in one pass:
- 9× `SettingTab.display` → `getSettingDefinitions()`
- 1× `setWarning` → `setDestructive()`
- 1× `obsidianmd/settings-tab/prefer-setting-definitions` warning (same migration, already noted in Stage 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJEbTGcEfSPAN4qvi7A8aG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJEbTGcEfSPAN4qvi7A8aG)_