### PR TITLE
fix: use window.setTimeout for object-URL cleanup

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -79,7 +79,7 @@ export function downloadTextFile(filename: string, content: string, mime = "appl
 	a.click();
 	a.remove();
 	// Revoke on the next tick so the download has had a chance to start.
-	activeWindow.setTimeout(() => URL.revokeObjectURL(url), 0);
+	window.setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 /** Open the OS file picker for a single file and resolve with its text content,


### PR DESCRIPTION
Stage 3, rule 2 of the lint cleanup: **`obsidianmd/prefer-window-timers`** (1 warning → 0).

## What the rule guards

Obsidian plugins should schedule timers on the `window` object (`window.setTimeout` / `window.setInterval`) rather than the ambient global or `activeWindow`. The `window`-scoped variants return numeric handles and behave predictably; scheduling on `activeWindow` ties the timer to whichever window is currently focused, which can be a popout that closes out from under the timer.

## The single finding

`ui.ts:82`, in `downloadTextFile`:

```diff
 	a.click();
 	a.remove();
 	// Revoke on the next tick so the download has had a chance to start.
-	activeWindow.setTimeout(() => URL.revokeObjectURL(url), 0);
+	window.setTimeout(() => URL.revokeObjectURL(url), 0);
```

## Why this one is safe (context matters)

Hearth deliberately uses `activeWindow` / `activeDocument` elsewhere for popout-window support (introduced in 1.6.0), so this rule is *not* blindly correct everywhere. But this specific call is a 0 ms cleanup that only revokes a blob object URL:

- `a.click()` runs **synchronously** on the line above, so the download has already started before the timer is even scheduled.
- Revoking the URL one tick later works regardless of which window's event loop runs it.
- Using the main `window` is in fact **more robust**: a main-window timer can't be orphaned if the user closes a popout window before the next tick.

No behaviour change users can observe. The other `activeWindow`/`activeDocument` usages (which are correct for popout support) are untouched.

## How to test

```bash
npm run lint       # prefer-window-timers: 0
npm run typecheck  # passes
npm run build      # passes
```

Manual: export settings/layout to a JSON file (the code path using `downloadTextFile`) — the file still downloads and the object URL is still revoked.

## Scope note

`src/` change only, one line. The rule is auto-fixable, but I applied it by hand to keep the diff surgical and avoid `eslint --fix` also touching the `prefer-create-el` sites reserved for a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJEbTGcEfSPAN4qvi7A8aG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJEbTGcEfSPAN4qvi7A8aG)_