### PR TITLE
fix: hide transient elements via el.hide() instead of inline style

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -74,7 +74,7 @@ export function downloadTextFile(filename: string, content: string, mime = "appl
 	const a = activeDocument.createElement("a");
 	a.href = url;
 	a.download = filename;
-	a.style.display = "none";
+	a.hide();
 	activeDocument.body.appendChild(a);
 	a.click();
 	a.remove();
@@ -89,7 +89,7 @@ export function pickTextFile(accept = "application/json,.json"): Promise<string 
 		const input = activeDocument.createElement("input");
 		input.type = "file";
 		input.accept = accept;
-		input.style.display = "none";
+		input.hide();
 		let settled = false;
 		const finish = (value: string | null) => {
 			if (settled) return;


### PR DESCRIPTION
Stage 3, rule 3 of the lint cleanup: **`obsidianmd/no-static-styles-assignment`** (2 errors → 0).

## What the rule guards

It flags direct `element.style.<prop> = …` assignments. Inline styles can't be themed or overridden by the user's theme/snippets, and they scatter presentation across the JS instead of keeping it in CSS. The rule wants styling done via CSS classes (or `setCssProps`/`setCssStyles` for values that must change dynamically).

## The two findings

Both are `display = "none"` on a **transient, throwaway** element that's appended to `<body>`, activated, and immediately removed:

- `ui.ts:77` — the synthesized `<a download>` in `downloadTextFile`
- `ui.ts:92` — the `<input type=file>` in `pickTextFile`

```diff
 	const a = activeDocument.createElement("a");
 	a.href = url;
 	a.download = filename;
-	a.style.display = "none";
+	a.hide();
```
```diff
 	input.type = "file";
 	input.accept = accept;
-	input.style.display = "none";
+	input.hide();
```

## Why `el.hide()` rather than a new CSS class

The value here is static (`display: none`), so a CSS class would satisfy the rule — but Obsidian already provides `el.hide()` / `el.show()`, and **the rest of the codebase already uses it** to hide elements (`search.ts`, `cards.ts`). Using it here:

- matches existing conventions,
- needs no new `styles.css` rule for a one-off hidden helper,
- is behaviour-identical (`hide()` sets `display: none`),
- keeps the change to two lines.

These are utility elements that never render visibly (they exist only to trigger a browser download / file dialog), so there's genuinely nothing for a theme to style — `hide()` is the right tool.

## How to test

```bash
npm run lint       # no-static-styles-assignment: 0
npm run typecheck  # passes
npm run build      # passes
```

Manual: export settings to JSON (download path) and import settings from JSON (file-picker path) — both still work; neither helper element ever flashes on screen.

## Scope note

`src/` change only, two lines. Not auto-fixable (the rule reports these as non-fixable), so applied by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJEbTGcEfSPAN4qvi7A8aG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJEbTGcEfSPAN4qvi7A8aG)_