### PR TITLE
fix: use Obsidian DOM helpers for element/SVG/fragment creation

### DIFF
--- a/src/cards.ts
+++ b/src/cards.ts
@@ -5853,12 +5853,13 @@ function formatClockDate(now: Date, mode: NonNullable<ClockConfig["dateMode"]>, 
 	}
 }
 
-function svgEl(parent: Element, tag: string, attrs: Record<string, string>, cls?: string): SVGElement {
-	const el = parent.ownerDocument.createElementNS("http://www.w3.org/2000/svg", tag);
-	for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
-	if (cls) el.setAttribute("class", cls);
-	parent.appendChild(el);
-	return el;
+function svgEl(
+	parent: Element,
+	tag: keyof SVGElementTagNameMap,
+	attrs: Record<string, string>,
+	cls?: string,
+): SVGElement {
+	return parent.createSvg(tag, { attr: attrs, cls });
 }
 
 /** Draw an analogue clock face and return a tick() to rotate its hands. */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -79,7 +79,7 @@ export class HomeSettingTab extends PluginSettingTab {
 	/** Tell the user Omnisearch isn't available and offer a one-click jump to it
 	 * in Obsidian's Community-plugins browser (via the `show-plugin` URI). */
 	private promptInstallOmnisearch(): void {
-		const frag = activeDocument.createDocumentFragment();
+		const frag = createFragment();
 		frag.appendText(t().settings.appearance.omnisearchMissing + " ");
 		const link = frag.createEl("a", {
 			text: t().settings.appearance.omnisearchInstallLink,

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -71,11 +71,8 @@ export function confirmAction(
 export function downloadTextFile(filename: string, content: string, mime = "application/json"): void {
 	const blob = new Blob([content], { type: mime });
 	const url = URL.createObjectURL(blob);
-	const a = activeDocument.createElement("a");
-	a.href = url;
-	a.download = filename;
+	const a = activeDocument.body.createEl("a", { attr: { href: url, download: filename } });
 	a.hide();
-	activeDocument.body.appendChild(a);
 	a.click();
 	a.remove();
 	// Revoke on the next tick so the download has had a chance to start.
@@ -86,7 +83,7 @@ export function downloadTextFile(filename: string, content: string, mime = "appl
  * or null if the user cancelled or the file couldn't be read. */
 export function pickTextFile(accept = "application/json,.json"): Promise<string | null> {
 	return new Promise((resolve) => {
-		const input = activeDocument.createElement("input");
+		const input = activeDocument.body.createEl("input");
 		input.type = "file";
 		input.accept = accept;
 		input.hide();
@@ -104,7 +101,6 @@ export function pickTextFile(accept = "application/json,.json"): Promise<string 
 		});
 		// Fires when the dialog is dismissed without choosing a file.
 		input.addEventListener("cancel", () => finish(null));
-		activeDocument.body.appendChild(input);
 		input.click();
 	});
 }


### PR DESCRIPTION
Stage 3, rule 4 of the lint cleanup: **`obsidianmd/prefer-create-el`** (6 → **2**).

## What the rule guards

Obsidian ships DOM helpers (`createEl`, `createSvg`, `createFragment`, and the `parent.createEl(...)` receiver form) that create elements with attributes/classes/children in one call and, on a parent, append them in the parent's document. The rule steers plugins off raw `createElement`/`createElementNS`/`createDocumentFragment` toward these helpers for brevity and popout-window correctness.

## ⚠️ The autofix does not compile — fixed by hand

The rule's suggested autofix is `activeWindow.createEl(...)`. Against these typings that **fails to build**:

```
src/ui.ts(74,25): error TS2339: Property 'createEl' does not exist on type 'Window'.
```

`createEl`/`createFragment`/`createSvg` are declared on the **`Element`** interface and as **global functions** — not on the `Window` interface — and `activeWindow` is typed `Window`. Applying the autofix also unleashed 73 `@typescript-eslint/no-unsafe-*` errors (the calls resolve to an error type). So every fix here is manual, using the receiver idiom the rest of the codebase already uses everywhere (~250 call sites), which creates in the parent's document (popout-safe) and appends.

## The 4 findings fixed

None of the six involve `innerHTML` or any HTML-string parsing — they are all element/fragment *creation* calls, so there is no markup that an autofix could silently drop.

- **`ui.ts:74`** — download `<a>`: `activeDocument.body.createEl("a", { attr: { href, download } })`. Attributes are set in the creation call, so the anchor never exists in the DOM without its `href`. Drops the explicit `appendChild`.
- **`ui.ts:89`** — file-picker `<input>`: `activeDocument.body.createEl("input")`. Drops the explicit `appendChild`.
- **`settings.ts:82`** — Omnisearch-missing `Notice`: `createFragment()` (a fragment has no document affinity; this is the standard idiom).
- **`cards.ts:5857`** — analog-clock `svgEl()` helper: `parent.createSvg(tag, { attr: attrs, cls })`, with `tag` narrowed to `keyof SVGElementTagNameMap` (all callers pass literal SVG tag names). Same attributes, class, and parent append as before.

## Why 2 findings remain (header.ts, intentional)

The two `header.ts` button findings are **left as-is**. Fixing them can't be a mechanical swap — the two functions return a *detached* button that the caller appends, and the receiver idiom always appends, so a fix means changing both function signatures and their caller. That's a refactor, not a lint fix, and doesn't belong in this PR. Two low-value warnings are preferable to reshaping working code for a stylistic rule.

## How to test

```bash
npm run lint       # prefer-create-el: 2 (both in header.ts); no new no-unsafe-* errors
npm run typecheck  # passes
npm run build      # passes
```

Manual smoke test (unchanged behaviour):
- **Export layout** → the `.json` still downloads (the `<a>` path).
- **Import layout** → the OS file picker still opens and imports (the `<input>` path).
- **Analog clock card** → the clock face and hands still render (the `createSvg` path).

## Scope note

`src/` only. `prefer-create-el` intentionally ends at 2, not 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJEbTGcEfSPAN4qvi7A8aG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJEbTGcEfSPAN4qvi7A8aG)_