### PR TITLE
ci(release): fire on pre-release tags, verify manifest, pin latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,10 @@ name: Release Obsidian plugin
 on:
   push:
     tags:
-      # Run for version tags that match the manifest version, e.g. 0.1.0
+      # Stable version tags that match the manifest version, e.g. 0.1.0
       - "[0-9]+.[0-9]+.[0-9]+"
+      # Pre-release tags, e.g. 1.8.1-beta.1 / 1.8.1-alpha.2 / 1.8.1-rc.1
+      - "[0-9]+.[0-9]+.[0-9]+-*"
   # Allow cutting a release manually from the Actions tab / API.
   workflow_dispatch:
     inputs:
@@ -57,21 +59,41 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
+      - name: Verify tag matches manifest version
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          manifest="$(node -p "require('./manifest.json').version")"
+          if [ "$tag" != "$manifest" ]; then
+            echo "::error::Release tag '$tag' does not match manifest.json version '$manifest'."
+            echo "A mismatch blocks the plugin in the Obsidian store with"
+            echo "\"No release matches your manifest version\". Bump manifest.json"
+            echo "(and versions.json) to '$tag' before tagging, or re-tag to match."
+            exit 1
+          fi
+          echo "Tag matches manifest version: $manifest"
+
       - name: Publish release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${{ steps.tag.outputs.tag }}"
-          # Pre-release versions (e.g. 1.6.1-beta) must not become the repo's
-          # "latest" release — mark them as pre-releases so stable stays latest.
-          flags=""
+          # Pre-release versions (e.g. 1.8.1-beta.1, 1.8.1-alpha.2, 1.8.1-rc.1)
+          # must not become the repo's "latest" release — mark them as
+          # pre-releases so stable stays latest. Any semver pre-release carries
+          # a "-" after the x.y.z core, so match that. Stable releases are
+          # pinned as --latest explicitly rather than relying on GitHub's
+          # defaults, so a re-published pre-release can never steal "latest".
           case "$tag" in
-            *-beta|*-alpha|*-rc*) flags="--prerelease" ;;
+            *-*) flags="--prerelease --latest=false" ;;
+            *)   flags="--latest" ;;
           esac
           # Assets must be attached as individual files (not zipped) so BRAT can
           # fetch manifest.json, main.js and styles.css directly. Idempotent so
           # re-runs just refresh the assets.
           if gh release view "$tag" >/dev/null 2>&1; then
+            # Re-run: refresh assets and re-assert the prerelease/latest state so
+            # a manually-touched release can't linger in the wrong flavour.
+            gh release edit "$tag" $flags
             gh release upload "$tag" main.js manifest.json styles.css --clobber
           else
             gh release create "$tag" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,13 @@ is wasted:
   about timing. **As development slows down, I'll be able to take PRs far more
   readily**, and this guide will say so when that day comes.
 
+## Cutting a release
+
+Releases are maintainer-only and go out **exclusively by pushing a git tag** —
+never by hand through the GitHub UI. The versioning rules (plain semver `x.y.z`,
+betas as `1.8.1-beta.1`, never four-segment versions) and the full checklist
+live in [`RELEASING.md`](RELEASING.md).
+
 ## Filing an issue
 
 Use [GitHub Issues](https://github.com/ondreu/Hearth/issues). A quick search

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,56 @@
+# Releasing Hearth
+
+Releases are cut **exclusively by pushing a git tag**. The
+[`Release Obsidian plugin`](.github/workflows/release.yml) workflow builds the
+plugin, attaches `main.js`, `manifest.json` and `styles.css` to a GitHub
+Release, and marks pre-releases correctly so the Obsidian community store keeps
+serving the right build to the right people.
+
+> **Never create a release by hand through the GitHub UI.** A manual release
+> skips the tag→manifest check, is created as "latest" by default, and — as has
+> happened — can push a beta to every stable user. Tags only.
+
+## Versioning
+
+Obsidian requires plain [semver](https://semver.org/) `x.y.z` versions. The tag,
+`manifest.json` `version`, and the `versions.json` key must all be identical.
+
+- **Stable:** `1.8.1`
+- **Beta / pre-release:** `1.8.1-beta.1`, then `1.8.1-beta.2`, …
+  (also `-alpha.N` and `-rc.N`).
+
+A pre-release like `1.8.1-beta.1` sorts **before** `1.8.1` under semver. That is
+exactly what we want: beta testers on `1.8.1-beta.N` are automatically offered
+the upgrade to `1.8.1` the moment it ships.
+
+### ⛔ Never use four-segment versions
+
+Tags like `1.8.1.4-beta` are **not valid semver** and Obsidian rejects them
+(`x.y.z` only). They also don't match the release workflow's tag trigger, so the
+workflow never runs, `--prerelease` is never applied, and the release silently
+becomes "latest" for all users. Use `1.8.1-beta.4`, not `1.8.1.4-beta`.
+
+## Release checklist
+
+1. **Bump the version in both files** — they must match the tag exactly:
+   - `manifest.json` → `"version": "1.8.1-beta.1"`
+   - `versions.json` → add `"1.8.1-beta.1": "<minAppVersion>"`
+2. Commit the bump (e.g. `chore: release 1.8.1-beta.1`).
+3. **Tag and push** — the tag name **is** the version, with no `v` prefix:
+   ```sh
+   git tag 1.8.1-beta.1
+   git push origin 1.8.1-beta.1
+   ```
+4. The workflow then:
+   - verifies the tag matches `manifest.json` (**fails** on mismatch, so the
+     store never sees the dreaded
+     *"No release matches your manifest version"* error),
+   - builds and attaches the assets,
+   - marks `-beta` / `-alpha` / `-rc` tags as **pre-release** (never "latest"),
+     and pins stable tags as **latest**.
+
+## If something goes out wrong
+
+Don't delete old tags. If a bad release landed, cut a new, correctly-versioned
+tag — the workflow's pre-release/latest handling and manifest check will keep
+the store consistent from there.


### PR DESCRIPTION
## Why

Beta tags used a four-segment form (`1.8.1.4-beta`) that doesn't match the release workflow's tag trigger (`[0-9]+.[0-9]+.[0-9]+`). The workflow never ran, so `--prerelease` was never applied. Releases cut by hand became **"latest"**, and the Obsidian store served the beta to all ~971 users. This had to be fixed manually by re-marking releases.

## Changes

**`.github/workflows/release.yml`**
- **Trigger:** added `[0-9]+.[0-9]+.[0-9]+-*` alongside the stable pattern so pre-release tags fire the workflow.
- **`--prerelease`:** the case now matches any semver pre-release (`*-*`), covering `-beta.1` / `-alpha.2` / `-rc.1`, not just bare `-beta`/`-alpha`.
- **`--latest`:** stable releases are pinned `--latest` explicitly (pre-releases get `--prerelease --latest=false`) rather than relying on GitHub defaults. Re-runs now `gh release edit` to re-assert the state so a manually-touched release can't linger in the wrong flavour.
- **Manifest check:** a new step fails the build when the tag doesn't exactly match `manifest.json` `version`, catching the store's *"No release matches your manifest version"* error in CI instead of in production.

**`RELEASING.md`** (new)
- Versioning: stable `1.8.1`, beta `1.8.1-beta.1` (valid semver, sorts **before** `1.8.1` so beta testers get the stable upgrade).
- Never use four-segment versions — Obsidian requires `x.y.z`.
- Bump `manifest.json` **and** `versions.json` before tagging.
- Releases go out **exclusively by tag**, never by hand through the GitHub UI.

**`CONTRIBUTING.md`**
- Added a "Cutting a release" section linking to `RELEASING.md`.

Old tags left untouched; no changes under `src/`.

## Note

The head branch and `main` currently have unrelated git histories, so the diff shown here is larger than the release-workflow change alone. The substantive change is the single commit `ci(release): trigger on pre-release tags, verify manifest, pin latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMpVU3pQDanEf2HBsNZiAw)_