### PR TITLE
feat: eager one-way migration of legacy mobile-action commandId → target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ preceding beta series.
 History begins at 1.5.0. For releases before 1.5.0, see the
 [GitHub Releases](https://github.com/ondreu/Hearth/releases) page.
 
+## [Unreleased]
+
+### Changed
+
+- **Mobile action buttons: the legacy `commandId` field is migrated to
+  `target`.** Buttons created before the unified command/note/URL model stored
+  their action in a deprecated `commandId` field that was only read as a
+  fallback. On load, such buttons are now migrated in place to the current
+  `target` field and the result is written back to storage, so the legacy field
+  finally leaves your `settings.json`. **This migration is one-way:** if you
+  upgrade and then downgrade Hearth below this version, any mobile action button
+  whose action was stored *only* as `commandId` loses its action (the button
+  appears blank and must be reassigned). Buttons edited or created in a recent
+  version are unaffected.
+
 ## [1.8.0] - 2026-07-11
 
 A cards-and-appearance release aggregating the whole 1.7.1 beta series.

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -666,8 +666,13 @@ function sanitizeMobileActionButton(raw: unknown): MobileActionButton | null {
 	if (r.type === "command" || r.type === "note" || r.type === "url") btn.type = r.type;
 	const target = str(r.target);
 	if (target !== undefined) btn.target = target;
+	// Fold a legacy `commandId` (from a pre-1.9.0 backup) into `target` rather
+	// than re-persisting the deprecated field, using the same rule as
+	// migrateSettings so an imported backup never reintroduces `commandId`.
 	const commandId = str(r.commandId);
-	if (commandId !== undefined) btn.commandId = commandId;
+	if ((btn.target === undefined || btn.target === "") && commandId !== undefined && commandId !== "") {
+		btn.target = commandId;
+	}
 	return btn;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -236,7 +236,12 @@ export default class HearthPlugin extends Plugin {
 			this.settings as unknown as Record<string, unknown>,
 			DEFAULT_SETTINGS as unknown as Record<string, unknown>,
 		);
-		migrateSettings(this.settings, raw);
+		// A one-way migration (e.g. the commandId → target fold) mutates settings
+		// in memory only; without flushing it here the legacy data would survive
+		// in storage and the migration would re-run every start, never actually
+		// retiring the deprecated field. Persist immediately when that happens.
+		const migrated = migrateSettings(this.settings, raw);
+		if (migrated) await this.saveSettings();
 	}
 
 	async saveSettings() {

--- a/src/mobileactions.ts
+++ b/src/mobileactions.ts
@@ -25,8 +25,15 @@ export function renderMobileActionBar(view: HomeView, parent: HTMLElement): void
 	}
 }
 
-/** The button's target, falling back to the legacy `commandId` field. */
+/** The button's target. `migrateSettings` folds the legacy `commandId` into
+ * `target` at load time, so this reads `target` alone; the `?? btn.commandId`
+ * below is a transitional safety net for any button not yet migrated in memory.
+ * Remove in 1.11.0 or later — two minor releases after 1.9.0, once the
+ * migration has run for everyone — together with the `commandId` field. */
 export function actionTarget(btn: MobileActionButton): string {
+	// The `?? btn.commandId` read intentionally trips no-deprecated (the repo
+	// forbids silencing that rule): the warning is the visible marker for this
+	// transitional fallback and disappears when the field is removed in 1.11.0.
 	return btn.target ?? btn.commandId ?? "";
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -606,12 +606,11 @@ export class HomeSettingTab extends PluginSettingTab {
 					// Target semantics differ per type, so clear a stale target when
 					// switching kinds.
 					btn.target = "";
-					btn.commandId = undefined;
 					void this.save();
 					this.display();
 				});
 			});
-			const currentTarget = btn.target ?? btn.commandId ?? "";
+			const currentTarget = btn.target ?? "";
 			if ((btn.type ?? "command") === "command") {
 				// Show a proper button labelled with the picked command (or a
 				// prompt when none is set yet) instead of a tiny icon, so which
@@ -626,7 +625,6 @@ export class HomeSettingTab extends PluginSettingTab {
 						new CommandPickerModal(this.app, (command) => {
 							btn.type = "command";
 							btn.target = command.id;
-							btn.commandId = undefined;
 							if (!btn.label.trim()) btn.label = command.name;
 							void this.save();
 							this.display();
@@ -642,7 +640,6 @@ export class HomeSettingTab extends PluginSettingTab {
 						.setValue(currentTarget)
 						.onChange(async (v) => {
 							btn.target = v;
-							btn.commandId = undefined;
 							await this.save();
 						}),
 				);

--- a/src/types.ts
+++ b/src/types.ts
@@ -295,8 +295,11 @@ export interface MobileActionButton {
 	type?: "command" | "note" | "url";
 	/** Command id, vault path, or URL depending on `type`. */
 	target?: string;
-	/** @deprecated Legacy command id from before `type`/`target` existed. Still
-	 * read as a fallback when `target` is unset so old buttons keep working. */
+	/** @deprecated Legacy command id from before `type`/`target` existed.
+	 * `migrateSettings` folds it into `target` on load (one-way); the fallback
+	 * read in `actionTarget` is a transitional safety net.
+	 * Remove in 1.11.0 or later — two minor releases after 1.9.0, once the
+	 * migration has run for everyone — together with that fallback. */
 	commandId?: string;
 }
 
@@ -700,9 +703,9 @@ function starterCards(): DashboardCard[] {
 	];
 }
 
-/** The mobile action bar's default buttons. Each `commandId` is a command
- * Hearth registers itself, so replacing one via the command picker works
- * exactly like swapping in any other plugin's command. */
+/** The mobile action bar's default buttons. Each `target` is a command Hearth
+ * registers itself, so replacing one via the command picker works exactly like
+ * swapping in any other plugin's command. */
 export function defaultMobileActionButtons(): MobileActionButton[] {
 	return [
 		{ id: "action-new-note", label: "New note", icon: "plus", type: "command", target: "hearth:new-note" },
@@ -883,8 +886,13 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
  * Bring loaded settings up to date: wrap the legacy single-board `cards` array
  * (or the starter set) into the multi-dashboard model and backfill any new
  * fields. Idempotent — safe to run on every load.
+ *
+ * Returns `true` when it performed a destructive/one-way migration whose result
+ * must be flushed back to storage (currently only the `commandId` → `target`
+ * fold), so the caller knows to persist. The purely additive back-fills above
+ * remain in-memory until the next ordinary save, exactly as before.
  */
-export function migrateSettings(s: HomeSettings, raw: Record<string, unknown>): void {
+export function migrateSettings(s: HomeSettings, raw: Record<string, unknown>): boolean {
 	if (!Array.isArray(s.dashboards) || s.dashboards.length === 0) {
 		const legacy = Array.isArray(raw.cards) ? (raw.cards as DashboardCard[]) : null;
 		s.dashboards = [
@@ -913,9 +921,48 @@ export function migrateSettings(s: HomeSettings, raw: Record<string, unknown>): 
 	if (!Array.isArray(raw.mobileActionButtons)) {
 		s.mobileActionButtons = defaultMobileActionButtons();
 	}
+	// One-way migration (added 1.9.0): fold the legacy per-button `commandId`
+	// into the unified `target` field so the deprecated fallback can be retired.
+	// This does NOT round-trip — a user who upgrades and then downgrades below
+	// 1.9.0 loses any button whose action was stored only as `commandId`. See
+	// CHANGELOG.
+	// Remove in 1.11.0 or later — two minor releases after 1.9.0, once the
+	// migration has run for everyone — together with the `commandId` field on
+	// MobileActionButton and the fallback read in actionTarget().
+	let migratedCommandId = false;
+	if (Array.isArray(s.mobileActionButtons)) {
+		for (const btn of s.mobileActionButtons) {
+			// Reading (and below, deleting) `commandId` intentionally trips
+			// no-deprecated — the repo forbids silencing that rule, so the
+			// warnings stay visible until the field is removed in 1.11.0. That is
+			// expected: a migration must touch the field it is retiring.
+			const legacy = btn.commandId;
+			if (legacy === undefined) continue;
+			// Only lift the value into `target` when `target` is unset: a button
+			// that already carries a `target` (a newer version or a manual edit)
+			// is authoritative, so its stale `commandId` is dropped without loss.
+			// We do NOT check whether the command still resolves — at load time
+			// other plugins' commands may not be registered yet, so a "missing"
+			// command can simply be not-yet-loaded, and deleting the value would
+			// be data loss. Preserving the string verbatim keeps exactly today's
+			// fallback behaviour.
+			if ((btn.target === undefined || btn.target === "") && legacy !== "") {
+				btn.target = legacy;
+			}
+			// Guard (never lose the value): drop `commandId` only once `target`
+			// actually holds the button's action — or the legacy value was empty,
+			// so there is nothing to preserve. This also lets the migration fully
+			// converge, so it stops re-firing (and re-saving) on later loads.
+			if ((btn.target !== undefined && btn.target !== "") || legacy === "") {
+				delete btn.commandId;
+				migratedCommandId = true;
+			}
+		}
+	}
 	// The short-lived "split" pill mode was replaced by a plain single button
 	// whose action is chosen here; fall back to the original New-note behaviour.
 	if ((s.newNoteButtonMode as string) === "split") s.newNoteButtonMode = "newNote";
 	// Drop the obsolete single-board field so it can't shadow the dashboards.
 	delete (s as unknown as { cards?: unknown }).cards;
+	return migratedCommandId;
 }


### PR DESCRIPTION
## What & why

Mobile action buttons created before the unified command/note/URL model stored their action in the `@deprecated` `commandId` field (`types.ts`), read only as a fallback by `actionTarget()` (`mobileactions.ts:30`, `btn.target ?? btn.commandId`). There was **no eager migration** — `migrateSettings()` migrated ~10 other legacy fields but not this one. The only existing migration was lazy and partial: `settings.ts` set `target` / cleared `commandId` **only when the user manually re-edited that specific button**, and `sanitizeMobileActionButton()` (`layout.ts`) actively **re-wrote** `commandId` on every settings backup import.

Net effect: anyone who never re-edited their buttons kept `commandId` in `settings.json` forever — a permanent back-compat debt. This PR resolves it with a proper eager migration rather than by silencing the linter.

## Changes

- **`migrateSettings()` (`types.ts`)** — folds each button's `commandId` into `target` in place. Now returns `boolean` (did a one-way migration run?).
- **`loadSettings()` (`main.ts`)** — persists immediately when the migration reports it ran (see *Persistence* below).
- **`sanitizeMobileActionButton()` (`layout.ts`)** — folds `commandId` into `target` on backup **import** instead of re-persisting the deprecated field (point **d** — otherwise migration and import would fight). Old backups still restore correctly; they just never reintroduce `commandId`.
- **`settings.ts`** — dropped the now-redundant manual `commandId = undefined` clearing on edit (migration guarantees in-memory buttons no longer carry it).
- **`CHANGELOG.md`** — documents the one-way behaviour.

## (a) This migration is ONE-WAY — data loss on downgrade

After upgrading, a button whose action was stored **only** as `commandId` has that field deleted from storage once folded into `target`. **If you then downgrade Hearth below this version, that button loses its action** (appears blank, must be reassigned), because the old code reads `commandId` and it's gone. Buttons edited/created in a recent version (already `target`-based) are unaffected. Stated in the CHANGELOG and in the code comment.

## (b) Guard — the value is never lost

`delete btn.commandId` runs **only** once `target` actually holds a value (or the legacy value was empty, so there's nothing to preserve):

- **`target` already set and differs from `commandId`** → `target` is authoritative (it already won at runtime via `??`); the stale `commandId` is dropped without touching the live value.
- **`commandId` points at a command not in this vault** → migrated **verbatim anyway, no existence check**. At load time other plugins' commands may not be registered yet, so "missing" can mean "not yet loaded" — deleting would be data loss. Preserving the string keeps exactly today's fallback behaviour (a genuinely dead id shows the same "command not found" notice it does today).
- **`mobileActionButtons` undefined / empty** (old installs) → `Array.isArray` guard + the existing default-seeding block; the loop simply doesn't run.

## (c) Persistence — verified from code, not asserted

`onload()` → `loadSettings()` calls `migrateSettings()` but there was **no `saveSettings()` afterwards** (`main.ts`), and `saveSettings()` is the only writer (`saveData(this.settings)`). So a pure in-memory mutation would be discarded, the migration would re-run every launch, and `commandId` would never leave storage — making the whole thing pointless. Fixed by:

```ts
const migrated = migrateSettings(this.settings, raw);
if (migrated) await this.saveSettings();
```

`migrateSettings()` returns `true` only when it actually deleted a `commandId`, so the flush happens once on the first post-upgrade load; on the next load nothing matches, it returns `false`, no save, converged. (Calling `saveSettings()` this early is safe — its `refreshViews()` runs before the view type is registered and simply finds no leaves.)

## (d) `layout.ts` re-persist removed in the same PR

The old `sanitizeMobileActionButton()` re-read and re-wrote `commandId`. It now folds into `target` using the identical rule as `migrateSettings()`, so import and migration agree instead of overwriting each other.

## (e) Removal condition in code

Both the field (`types.ts`) and the transitional fallback (`mobileactions.ts`) carry:
> Remove in 1.11.0 or later — two minor releases after 1.9.0, once the migration has run for everyone.

## Lint note (not silenced)

`commandId` `no-deprecated` warnings drop from **6 → 3**. The 3 that remain are the migration's own read + delete and the runtime fallback — the irreducible back-compat surface. The repo's `eslint-comments/no-restricted-disable` rule **forbids** `eslint-disable` of `no-deprecated` (I hit it and reverted), so they stay as **visible warnings** by design and vanish when the field is removed in 1.11.0. `typecheck` + `build` pass; CI (`ci.yml`) runs typecheck + build, not eslint.

---

## Test plan

CI won't exercise runtime behaviour here — please verify in a dev vault.

### 1. Fabricate the old state (you don't have a `commandId` button lying around)

Close Obsidian (or the vault), then edit `<vault>/.obsidian/plugins/hearth/data.json`. Find `mobileActionButtons` and hand-craft the legacy shapes — the key is a button with **`commandId` and no `target`**:

```jsonc
"mobileActionButtons": [
  { "id": "legacy-1", "label": "Legacy note", "icon": "plus", "commandId": "hearth:new-note" },        // pure legacy, no target
  { "id": "legacy-2", "label": "Legacy dead", "icon": "bug",  "commandId": "some-plugin:gone" },        // commandId to a command not installed
  { "id": "legacy-3", "label": "Both",        "icon": "mic",  "target": "hearth:record-voice", "commandId": "hearth:new-note" } // target wins, commandId stale
]
```
(If there's no `hearth` folder yet: install the built plugin — `main.js` + `manifest.json` + `styles.css` — into `<vault>/.obsidian/plugins/hearth/`, enable it once so `data.json` is written, then close and inject the block above.)

Build this branch with `npm run build` and copy `main.js` into that plugin folder.

### 2. Trigger the migration

Reopen the vault (or toggle the plugin off/on). `onload` → `loadSettings` runs the migration and, because it changed something, saves.

### 3. Verify storage was rewritten (point c)

Reopen `data.json`:
- `legacy-1` → now has `"target": "hearth:new-note"` and **no** `commandId`.
- `legacy-2` → `"target": "some-plugin:gone"`, **no** `commandId` (dead id preserved, not dropped).
- `legacy-3` → `"target": "hearth:record-voice"` kept, `commandId` **gone**.
- Close and reopen once more → `data.json` is unchanged (migration converged, doesn't re-fire).

### 4. Verify the buttons work (runtime)

On a mobile device or with Obsidian's mobile emulation (right-click ribbon → *Toggle emulation*, or the developer "Emulate mobile" toggle), open the Hearth view and check the action bar:
- **Legacy note** runs the new-note command.
- **Both** runs Record voice.
- **Legacy dead** shows the "command not found" notice (same as before — nothing regressed).

### 5. Verify a freshly-created button still works

In settings → Behaviour → Mobile action buttons: add a button, pick a command via the picker, set another to a note/URL. Confirm `data.json` stores only `target` (never `commandId`) and the buttons fire correctly.

### 6. Verify backup import (point d)

Export settings (Backup tab), then import the fabricated old `data.json`-style backup containing `commandId`. Confirm the imported buttons come in with `target` set and **no** `commandId` written.

I stopped here and did **not** run the dev-vault steps for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrorffQE9s4gkqz1DYhgvQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrorffQE9s4gkqz1DYhgvQ)_


Correction:
### Description correction — verified by live testing

The description above claims that "dangling commands are not removed" (i.e. that
`commandId` is left in place when the command doesn't exist). **This does not match
the code.**

Tested in a dev vault with a hand-crafted `data.json`:

**Before migration:**
```json
{ "id": "action-new-note",    "type": "command", "commandId": "workspace:new-tab" },
{ "id": "action-new-drawing", "type": "command", "commandId": "neexistuje:vubec" }
```

**After migration (written to `data.json`, not just held in memory):**
```json
{ "id": "action-new-note",    "type": "command", "target": "workspace:new-tab" },
{ "id": "action-new-drawing", "type": "command", "target": "neexistuje:vubec" }
```

**Actual behaviour:** the migration is a straight field rename, `commandId` →
`target`, with no check whatsoever as to whether the command exists in Obsidian.
The bogus `neexistuje:vubec` migrated exactly like the valid `workspace:new-tab`.

**This is correct.** The value is always preserved, so buttons pointing at commands
from disabled or not-yet-loaded plugins keep working. Had the migration discarded
unknown commands, users would silently lose buttons whenever a plugin was turned off.

**Verified:**
- ✅ `commandId` is actually gone from storage (not just from memory) → `saveSettings()` works
- ✅ Converges — a second startup migrates nothing
- ✅ No values lost

**Out of scope, found while testing:** if a button in `data.json` is missing its
required keys (`id`, `type`), the plugin silently discards the entire
`mobileActionButtons` array and falls back to the defaults. A corrupted `data.json`
therefore means silently losing all mobile buttons, with no warning. Worth an issue.