### PR TITLE
ci: add lint step before typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,5 +15,10 @@ export default tseslint.config(
 				tsconfigRootDir: import.meta.dirname,
 			},
 		},
+		rules: {
+			// Vyžaduje Obsidian API 1.13.0+; minAppVersion je 1.8.7.
+			// Zapnout zpět, až se minAppVersion zvedne.
+			"obsidianmd/settings-tab/prefer-setting-definitions": "off",
+		},
 	},
 );


### PR DESCRIPTION
## What does this PR do?

Adds a `Lint` step (`npm run lint`) to the CI workflow, running before Typecheck.

There is **no `--max-warnings` cap**, so the ~28 `@typescript-eslint/no-deprecated` warnings (pending a `minAppVersion` bump) don't block merge — eslint exits 0 on warnings. Errors still exit 1 and block the merge.

Also disables `obsidianmd/settings-tab/prefer-setting-definitions` in `eslint.config.mjs`, since that rule requires Obsidian API 1.13.0+ while `minAppVersion` is 1.8.7. It's commented to be re-enabled once `minAppVersion` is raised.

No changes to `src/`.

## Related issue

<!-- n/a -->

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (CI tooling)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KB4tiS1x4S14wnJ4xESnFz)_