### PR TITLE
test: add Vitest suite for pure date/query/calculator logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Test
+        run: npm test
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
 				"obsidian": "latest",
 				"tslib": "^2.6.2",
 				"typescript": "^5.4.0",
-				"typescript-eslint": "^8.63.0"
+				"typescript-eslint": "^8.63.0",
+				"vitest": "^4.1.10"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -42,6 +43,40 @@
 				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -752,6 +787,13 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@marijn/find-cluster-break": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
@@ -798,6 +840,35 @@
 				"ret": "~0.1.10"
 			}
 		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+			"integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.3"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.139.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+			"integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
 		"node_modules/@pkgr/core": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
@@ -811,12 +882,305 @@
 				"url": "https://opencollective.com/unts"
 			}
 		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+			"integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+			"integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+			"integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+			"integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+			"integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+			"integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+			"integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+			"integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+			"integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+			"integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+			"integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+			"integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+			"integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.1",
+				"@emnapi/runtime": "1.11.1",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+			"integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+			"integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
 			"integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
 		},
 		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
@@ -827,6 +1191,13 @@
 			"dependencies": {
 				"@types/tern": "*"
 			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/eslint": {
 			"version": "9.6.1",
@@ -1162,6 +1533,119 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.10",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.10",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.17.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1385,6 +1869,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/async-function": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -1489,6 +1983,16 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1530,6 +2034,13 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1669,6 +2180,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/doctrine": {
@@ -1858,6 +2379,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+			"integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.2",
@@ -2570,6 +3098,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2578,6 +3116,16 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -2701,6 +3249,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/function-bind": {
@@ -3654,6 +4217,267 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3688,6 +4512,16 @@
 			},
 			"bin": {
 				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -3746,6 +4580,25 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.15",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+			"integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -3921,6 +4774,20 @@
 				"@codemirror/view": "6.38.6"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4029,6 +4896,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/picomatch": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
@@ -4050,6 +4931,35 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.17",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+			"integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.12",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -4207,6 +5117,40 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12"
+			}
+		},
+		"node_modules/rolldown": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+			"integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.139.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.1.5",
+				"@rolldown/binding-darwin-arm64": "1.1.5",
+				"@rolldown/binding-darwin-x64": "1.1.5",
+				"@rolldown/binding-freebsd-x64": "1.1.5",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.5",
+				"@rolldown/binding-linux-arm64-musl": "1.1.5",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-musl": "1.1.5",
+				"@rolldown/binding-openharmony-arm64": "1.1.5",
+				"@rolldown/binding-wasm32-wasi": "1.1.5",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.5",
+				"@rolldown/binding-win32-x64-msvc": "1.1.5"
 			}
 		},
 		"node_modules/safe-array-concat": {
@@ -4456,6 +5400,37 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/stop-iteration-iterator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -4657,6 +5632,23 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.17",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4672,6 +5664,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/toml-eslint-parser": {
@@ -4914,6 +5916,174 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/vite": {
+			"version": "8.1.4",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+			"integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.16",
+				"rolldown": "~1.1.4",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.3.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -5025,6 +6195,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"typecheck": "tsc -noEmit -skipLibCheck",
 		"lint": "eslint src",
-		"lint:fix": "eslint src --fix"
+		"lint:fix": "eslint src --fix",
+		"test": "vitest run"
 	},
 	"keywords": [
 		"obsidian",
@@ -27,6 +28,7 @@
 		"obsidian": "latest",
 		"tslib": "^2.6.2",
 		"typescript": "^5.4.0",
-		"typescript-eslint": "^8.63.0"
+		"typescript-eslint": "^8.63.0",
+		"vitest": "^4.1.10"
 	}
 }

--- a/test/calculator.test.ts
+++ b/test/calculator.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import { evaluate, formatNumber } from "../src/calculator";
+
+/**
+ * The calculator engine is fully pure: `evaluate` takes free text plus options
+ * (exchange rates are passed in, never fetched) and returns a result object.
+ * No time, no network, no DOM — ideal for regression tests of the parsing and
+ * conversion logic that a typecheck can't verify.
+ */
+
+/** Narrow a CalcResult to its success value, failing loudly otherwise. */
+function ok(input: string, opts?: Parameters<typeof evaluate>[1]) {
+	const r = evaluate(input, opts);
+	if (!r.ok) throw new Error(`expected success for "${input}", got error: ${r.error}`);
+	return r;
+}
+
+describe("evaluate — arithmetic", () => {
+	it("basic operators and precedence", () => {
+		expect(ok("2 + 2").value).toBe(4);
+		expect(ok("3 * (4 + 5)").value).toBe(27);
+		expect(ok("10 - 4 / 2").value).toBe(8);
+		// "%" is percent (not modulo) — modulo is the word "mod".
+		expect(ok("10 mod 3").value).toBe(1);
+		expect(ok("50%").value).toBe(0.5);
+	});
+
+	it("powers via ^ and **", () => {
+		expect(ok("2^10").value).toBe(1024);
+		expect(ok("2**10").value).toBe(1024);
+	});
+
+	it("right-associative exponentiation", () => {
+		expect(ok("2^2^3").value).toBe(256); // 2^(2^3), not (2^2)^3=64
+	});
+
+	it("unary minus and factorial", () => {
+		expect(ok("-5 + 3").value).toBe(-2);
+		expect(ok("5!").value).toBe(120);
+	});
+
+	it("functions and constants", () => {
+		expect(ok("sqrt(16)").value).toBe(4);
+		expect(ok("max(3, 7, 5)").value).toBe(7);
+		expect(ok("abs(-9)").value).toBe(9);
+		expect(ok("pi").value).toBeCloseTo(Math.PI, 10);
+	});
+
+	it("trig defaults to degrees", () => {
+		expect(ok("sin(30)").value).toBeCloseTo(0.5, 10);
+		expect(ok("cos(60)").value).toBeCloseTo(0.5, 10);
+	});
+
+	it("angleUnit option switches trig to radians", () => {
+		expect(ok("sin(pi/2)", { angleUnit: "rad" }).value).toBeCloseTo(1, 10);
+	});
+});
+
+describe("evaluate — plain language", () => {
+	it("word operators", () => {
+		expect(ok("3 plus 4").value).toBe(7);
+		expect(ok("10 minus 6").value).toBe(4);
+		expect(ok("6 times 7").value).toBe(42);
+		expect(ok("20 divided by 5").value).toBe(4);
+	});
+
+	it('"x" between numbers is multiplication', () => {
+		expect(ok("2 x 3").value).toBe(6);
+		expect(ok("2 x 3 x 4").value).toBe(24);
+	});
+
+	it("squared / cubed", () => {
+		expect(ok("10 squared").value).toBe(100);
+		expect(ok("3 cubed").value).toBe(27);
+	});
+
+	it("percentages", () => {
+		expect(ok("20% of 150").value).toBe(30);
+		expect(ok("50 percent of 80").value).toBe(40);
+	});
+
+	it("strips conversational filler", () => {
+		expect(ok("what is 2 + 2").value).toBe(4);
+		expect(ok("2 + 2 =").value).toBe(4);
+	});
+});
+
+describe("evaluate — unit conversions", () => {
+	it("length", () => {
+		const r = ok("10 km to miles");
+		expect(r.value).toBeCloseTo(6.2137, 3);
+		expect(r.formatted).toContain("mi");
+		expect(r.note).toBe("10 km → mi");
+	});
+
+	it("temperature (affine)", () => {
+		expect(ok("100 f in c").value).toBeCloseTo(37.7778, 3);
+		expect(ok("0 c in f").value).toBeCloseTo(32, 10);
+		expect(ok("300 k in c").value).toBeCloseTo(26.85, 2);
+	});
+
+	it("time", () => {
+		expect(ok("1 hour in minutes").value).toBe(60);
+		expect(ok("2 days in hours").value).toBe(48);
+	});
+
+	it("rejects cross-category conversions", () => {
+		const r = evaluate("10 km to kg");
+		expect(r.ok).toBe(false);
+	});
+});
+
+describe("evaluate — currency (rates supplied by caller)", () => {
+	const rates = { eur: 1, usd: 1.1, czk: 25 };
+
+	it("converts through the shared base", () => {
+		const r = ok("10 eur to usd", { rates });
+		expect(r.value).toBeCloseTo(11, 10);
+		expect(r.formatted).toBe("11 USD");
+	});
+
+	it("understands currency symbols", () => {
+		const r = ok("10 € to USD", { rates });
+		expect(r.value).toBeCloseTo(11, 10);
+	});
+
+	it("reports when rates are unavailable", () => {
+		const r = evaluate("10 eur to usd");
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toMatch(/unavailable/i);
+	});
+
+	it("reports a missing rate for a known code", () => {
+		const r = evaluate("10 eur to gbp", { rates });
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toMatch(/GBP/);
+	});
+});
+
+describe("evaluate — errors", () => {
+	it("empty input", () => {
+		expect(evaluate("").ok).toBe(false);
+	});
+
+	it("dangling operator", () => {
+		expect(evaluate("2 +").ok).toBe(false);
+	});
+
+	it("unknown name", () => {
+		expect(evaluate("hello world").ok).toBe(false);
+	});
+
+	it("unbalanced parentheses", () => {
+		expect(evaluate("(1 + 2").ok).toBe(false);
+	});
+});
+
+describe("formatNumber", () => {
+	it("groups thousands", () => {
+		expect(formatNumber(1000)).toBe("1,000");
+		expect(formatNumber(1234567)).toBe("1,234,567");
+	});
+
+	it("tames floating-point noise", () => {
+		expect(formatNumber(0.1 + 0.2)).toBe("0.3");
+	});
+
+	it("zero and negatives", () => {
+		expect(formatNumber(0)).toBe("0");
+		expect(formatNumber(-42)).toBe("-42");
+	});
+
+	it("non-finite values", () => {
+		expect(formatNumber(NaN)).toBe("undefined");
+		expect(formatNumber(Infinity)).toBe("∞");
+		expect(formatNumber(-Infinity)).toBe("-∞");
+	});
+
+	it("falls back to exponential for extreme magnitudes", () => {
+		expect(formatNumber(1e20)).toContain("e");
+		expect(formatNumber(1e-9)).toContain("e");
+	});
+});

--- a/test/currency.test.ts
+++ b/test/currency.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "vitest";
+
+/**
+ * src/currency.ts is intentionally NOT unit-tested.
+ *
+ * It exposes no pure functions worth locking down:
+ *   - `loadRates()` performs a network fetch via Obsidian's `requestUrl`, and
+ *     its result depends on wall-clock time (a 6-hour TTL against Date.now())
+ *     and hidden module-level cache/in-flight state.
+ *   - `cachedRates()` just reads that module-level cache.
+ *   - CURRENCY_CODES / CURRENCY_SYMBOLS are static data, not logic.
+ *
+ * Testing any of it would require mocking the network and manipulating the
+ * clock and module state — outside the "pure logic only" scope. The one piece
+ * of currency behaviour that IS pure — turning rates into a converted amount —
+ * lives in the calculator and is covered in calculator.test.ts.
+ */
+describe.skip("currency.ts (no pure logic to test — see file comment)", () => {
+	it("is covered indirectly via the calculator's currency conversions", () => {
+		/* intentionally empty */
+	});
+});

--- a/test/dates.test.ts
+++ b/test/dates.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatRelativeDate, parseNaturalDate } from "../src/dates";
+
+/**
+ * Date logic is the classic trap: without a frozen clock the same test passes
+ * or fails depending on the day it runs. Every test here pins "now" with
+ * vi.setSystemTime (noon UTC, so no timezone offset can flip the calendar day)
+ * before touching the parser. TZ is forced to UTC in vitest.config.ts.
+ */
+
+/** Freeze the clock at noon UTC on the given YYYY-MM-DD. */
+function freezeAt(isoDay: string): void {
+	vi.setSystemTime(new Date(`${isoDay}T12:00:00Z`));
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("parseNaturalDate — relative words", () => {
+	beforeEach(() => freezeAt("2026-07-15")); // a Wednesday
+
+	it("today / tonight / now → the frozen day", () => {
+		expect(parseNaturalDate("today")).toBe("2026-07-15");
+		expect(parseNaturalDate("tonight")).toBe("2026-07-15");
+		expect(parseNaturalDate("now")).toBe("2026-07-15");
+	});
+
+	it("tomorrow / tmrw", () => {
+		expect(parseNaturalDate("tomorrow")).toBe("2026-07-16");
+		expect(parseNaturalDate("tmrw")).toBe("2026-07-16");
+	});
+
+	it("yesterday", () => {
+		expect(parseNaturalDate("yesterday")).toBe("2026-07-14");
+	});
+
+	it("is case- and whitespace-insensitive", () => {
+		expect(parseNaturalDate("  ToMoRRoW  ")).toBe("2026-07-16");
+	});
+});
+
+describe("parseNaturalDate — offsets", () => {
+	beforeEach(() => freezeAt("2026-07-15"));
+
+	it('"in N days/weeks/months"', () => {
+		expect(parseNaturalDate("in 3 days")).toBe("2026-07-18");
+		expect(parseNaturalDate("in 2 weeks")).toBe("2026-07-29");
+		expect(parseNaturalDate("in 1 month")).toBe("2026-08-15");
+	});
+
+	it('bare "N days" (implicit in)', () => {
+		expect(parseNaturalDate("3 days")).toBe("2026-07-18");
+		expect(parseNaturalDate("1 week")).toBe("2026-07-22");
+	});
+
+	it('"next week/month/year"', () => {
+		expect(parseNaturalDate("next week")).toBe("2026-07-22");
+		expect(parseNaturalDate("next month")).toBe("2026-08-15");
+		expect(parseNaturalDate("next year")).toBe("2027-07-15");
+	});
+
+	it('"end of week/month/year" and short forms', () => {
+		expect(parseNaturalDate("end of week")).toBe("2026-07-18"); // en locale: week ends Saturday
+		expect(parseNaturalDate("end of month")).toBe("2026-07-31");
+		expect(parseNaturalDate("end of year")).toBe("2026-12-31");
+		expect(parseNaturalDate("eom")).toBe("2026-07-31");
+		expect(parseNaturalDate("eoy")).toBe("2026-12-31");
+	});
+
+	it('"start of month/year"', () => {
+		expect(parseNaturalDate("start of month")).toBe("2026-07-01");
+		expect(parseNaturalDate("start of year")).toBe("2026-01-01");
+	});
+});
+
+describe("parseNaturalDate — weekdays (next occurrence)", () => {
+	it("bare weekday rolls forward to the next such day", () => {
+		freezeAt("2026-07-15"); // Wednesday
+		expect(parseNaturalDate("friday")).toBe("2026-07-17");
+		expect(parseNaturalDate("monday")).toBe("2026-07-20");
+	});
+
+	it("accepts Czech weekday names", () => {
+		freezeAt("2026-07-15"); // Wednesday
+		expect(parseNaturalDate("pátek")).toBe("2026-07-17"); // Friday
+		expect(parseNaturalDate("pondělí")).toBe("2026-07-20"); // Monday
+	});
+
+	// The reason today-is-Friday is called out as an edge case: the three
+	// weekday phrasings must diverge only when the target equals today.
+	describe("when today IS the named weekday (Friday)", () => {
+		beforeEach(() => freezeAt("2026-07-10")); // a Friday
+
+		it('bare "friday" resolves to today', () => {
+			expect(parseNaturalDate("friday")).toBe("2026-07-10");
+		});
+
+		it('"this friday" resolves to today', () => {
+			expect(parseNaturalDate("this friday")).toBe("2026-07-10");
+		});
+
+		it('"next friday" rolls to the following week', () => {
+			expect(parseNaturalDate("next friday")).toBe("2026-07-17");
+		});
+	});
+});
+
+describe("parseNaturalDate — ISO passthrough", () => {
+	beforeEach(() => freezeAt("2026-07-15"));
+
+	it("returns a valid ISO date unchanged", () => {
+		expect(parseNaturalDate("2026-03-09")).toBe("2026-03-09");
+	});
+});
+
+describe("parseNaturalDate — month & year boundaries", () => {
+	it("tomorrow crosses into the new year", () => {
+		freezeAt("2026-12-31"); // New Year's Eve
+		expect(parseNaturalDate("tomorrow")).toBe("2027-01-01");
+	});
+
+	it('"next year" and "end of year" at year end', () => {
+		freezeAt("2026-12-31");
+		expect(parseNaturalDate("next year")).toBe("2027-12-31");
+		expect(parseNaturalDate("end of year")).toBe("2026-12-31");
+	});
+
+	it("tomorrow crosses into the new month", () => {
+		freezeAt("2026-01-31");
+		expect(parseNaturalDate("tomorrow")).toBe("2026-02-01");
+	});
+
+	it('"in 1 month" from Jan 31 clamps to end of February (non-leap 2026)', () => {
+		freezeAt("2026-01-31");
+		expect(parseNaturalDate("in 1 month")).toBe("2026-02-28");
+	});
+
+	it("tomorrow from Feb 28 lands on Mar 1 (2026 is not a leap year)", () => {
+		freezeAt("2026-02-28");
+		expect(parseNaturalDate("tomorrow")).toBe("2026-03-01");
+	});
+});
+
+describe("parseNaturalDate — unrecognised input", () => {
+	beforeEach(() => freezeAt("2026-07-15"));
+
+	it("returns null for empty / whitespace input", () => {
+		expect(parseNaturalDate("")).toBeNull();
+		expect(parseNaturalDate("   ")).toBeNull();
+	});
+
+	it('returns null for gibberish ("blabla")', () => {
+		expect(parseNaturalDate("blabla")).toBeNull();
+	});
+
+	it('returns null for an unparseable localized string ("31. února")', () => {
+		expect(parseNaturalDate("31. února")).toBeNull();
+	});
+
+	// BUG (documented, not fixed): an ISO-shaped but calendar-invalid date is
+	// NOT rejected. dates.ts guards with `if (!m.isValid) return null`, but
+	// moment's `isValid` is a *method*, so `m.isValid` is always a (truthy)
+	// function reference and the guard never fires. The invalid moment then
+	// formats to the literal string "Invalid date". This test asserts the
+	// CORRECT behaviour (null) and is skipped until the guard calls isValid().
+	it.skip('BUG: "2026-02-31" (Feb 31) should be null, but returns "Invalid date"', () => {
+		expect(parseNaturalDate("2026-02-31")).toBeNull();
+	});
+
+	it.skip('BUG: "2026-13-01" (month 13) should be null, but returns "Invalid date"', () => {
+		expect(parseNaturalDate("2026-13-01")).toBeNull();
+	});
+});
+
+describe("formatRelativeDate", () => {
+	beforeEach(() => freezeAt("2026-07-15")); // Wednesday
+
+	it("Today / Tomorrow / Yesterday", () => {
+		expect(formatRelativeDate("2026-07-15")).toBe("Today");
+		expect(formatRelativeDate("2026-07-16")).toBe("Tomorrow");
+		expect(formatRelativeDate("2026-07-14")).toBe("Yesterday");
+	});
+
+	it("names the weekday for the next few days", () => {
+		expect(formatRelativeDate("2026-07-17")).toBe("Friday"); // +2
+		expect(formatRelativeDate("2026-07-18")).toBe("Saturday"); // +3
+	});
+
+	it('"N days ago" for the past few days', () => {
+		expect(formatRelativeDate("2026-07-13")).toBe("2 days ago");
+	});
+
+	it('"Next <weekday>" / "Last <weekday>" for the surrounding week', () => {
+		expect(formatRelativeDate("2026-07-22")).toBe("Next Wednesday"); // +7
+		expect(formatRelativeDate("2026-07-08")).toBe("Last Wednesday"); // -7
+	});
+
+	it('falls back to compact "D MMM" beyond two weeks', () => {
+		expect(formatRelativeDate("2026-08-15")).toBe("15 Aug");
+	});
+
+	it("strips a time component before comparing", () => {
+		expect(formatRelativeDate("2026-07-16T09:30:00")).toBe("Tomorrow");
+	});
+
+	// BUG (documented, not fixed): same `isValid`-as-property mistake as above.
+	// The doc-comment promises the raw string is returned verbatim when it
+	// can't be parsed, but the guard `if (!target.isValid) return dateStr`
+	// never fires, so an unparseable input formats to "Invalid date" instead.
+	it.skip('BUG: unparseable input should echo the raw string, but returns "Invalid date"', () => {
+		expect(formatRelativeDate("blabla")).toBe("blabla");
+	});
+});

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { queryMode } from "../src/query";
+
+/**
+ * Only `queryMode` is pure — it classifies a raw search string into a mode
+ * from its syntax alone. The actual result-gathering (runQuery, searchByName,
+ * searchByTag, searchByProperty, searchFileContents) all need a live Obsidian
+ * `App`/vault and the fuzzy matcher, so they are intentionally NOT tested here
+ * (no Obsidian API mocks). This covers the syntax-dispatch logic that a
+ * typecheck can't catch.
+ */
+
+describe("queryMode", () => {
+	it('a leading "#" means a tag query', () => {
+		expect(queryMode("#project")).toBe("tag");
+		expect(queryMode("#")).toBe("tag");
+		expect(queryMode("#multi word")).toBe("tag");
+	});
+
+	it('"key:value" means a property query', () => {
+		expect(queryMode("status:active")).toBe("property");
+		expect(queryMode("priority:1")).toBe("property");
+		expect(queryMode("kebab-case_key:x")).toBe("property");
+	});
+
+	it("tolerates whitespace around the colon", () => {
+		expect(queryMode("status : active")).toBe("property");
+		expect(queryMode("status: ")).toBe("property"); // empty value still a property probe
+	});
+
+	it("plain text is a name query", () => {
+		expect(queryMode("meeting notes")).toBe("name");
+		expect(queryMode("report")).toBe("name");
+		expect(queryMode("")).toBe("name");
+	});
+
+	it("a key with spaces is NOT a property (not an identifier)", () => {
+		// "two words" before the colon isn't a legal property key → name query.
+		expect(queryMode("two words:x")).toBe("name");
+	});
+
+	// query.ts does not special-case ">command" — command-palette parsing lives
+	// elsewhere (the search bar), so from queryMode's perspective ">foo" is just
+	// a name query. Documented here so the behaviour is explicit, not a surprise.
+	it('">command" is treated as a name query by queryMode', () => {
+		expect(queryMode(">open settings")).toBe("name");
+	});
+});

--- a/test/support/obsidian-shim.ts
+++ b/test/support/obsidian-shim.ts
@@ -1,0 +1,42 @@
+/**
+ * Test-time stand-in for the `obsidian` module.
+ *
+ * The real `obsidian` npm package ships *types only* — it has no runtime
+ * entry point — so importing it under Vitest would fail. This shim makes the
+ * module graph resolve so we can exercise the plugin's *pure* logic.
+ *
+ * Deliberate boundary:
+ *   - `moment` is the GENUINE moment.js library (the very same implementation
+ *     Obsidian re-exports). It is not a mock — the date logic is tested against
+ *     real moment behaviour, with time frozen via vi.useFakeTimers().
+ *   - Everything else below is an INERT placeholder. Those exports exist only
+ *     to satisfy `import { … } from "obsidian"` in modules that transitively
+ *     sit above the pure functions under test (query.ts, filetypes.ts,
+ *     currency.ts). None of them is ever invoked by a pure-logic test — the
+ *     functions that would call them (vault queries, network fetches, DOM work)
+ *     are intentionally left untested, per the "no Obsidian API mocks" rule.
+ */
+import moment from "moment";
+
+export { moment };
+
+// i18n.ts reads this once; t() defaults to English without ever calling it.
+export function getLanguage(): string {
+	return "en";
+}
+
+// Inert placeholders — present for module resolution, never exercised.
+export function getAllTags(): string[] {
+	throw new Error("getAllTags is not implemented in tests (Obsidian API)");
+}
+export function prepareFuzzySearch(): unknown {
+	throw new Error("prepareFuzzySearch is not implemented in tests (Obsidian API)");
+}
+export function requestUrl(): unknown {
+	throw new Error("requestUrl is not implemented in tests (Obsidian API)");
+}
+
+export class TAbstractFile {}
+export class TFile extends TAbstractFile {}
+export class TFolder extends TAbstractFile {}
+export class App {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+export default defineConfig({
+	test: {
+		// Pure logic only — no DOM, no jsdom.
+		environment: "node",
+		include: ["test/**/*.test.ts"],
+		// Freeze the timezone so date logic is deterministic on any machine/CI.
+		env: { TZ: "UTC" },
+	},
+	resolve: {
+		alias: {
+			// The `obsidian` package is types-only; point it at a tiny shim that
+			// re-exports the real moment.js and inert placeholders (see the file).
+			obsidian: fileURLToPath(new URL("./test/support/obsidian-shim.ts", import.meta.url)),
+		},
+	},
+});


### PR DESCRIPTION
## What does this PR do?

Adds a Vitest test suite that covers **framework-independent logic only** — no DOM, no Obsidian API mocks. Where a module needs Obsidian, the untestable parts are deliberately left untested rather than faked. The goal is catching logic regressions a typecheck can't, not a coverage number.

**Setup**
- `vitest.config.ts` — Node environment, `TZ=UTC` for deterministic dates, and an alias mapping `obsidian` → a tiny shim.
- `test/support/obsidian-shim.ts` — the `obsidian` npm package is types-only (no runtime), so this shim re-exports the **real moment.js** (the same implementation Obsidian re-exports — not a mock) plus inert placeholders that exist only so the module graph resolves. None of the placeholders is ever invoked by a pure-logic test.

**Coverage**
- `dates.ts` — natural-language parsing and relative labels, with the clock **frozen** via `vi.useFakeTimers()` / `setSystemTime` (noon UTC) so results don't depend on when the suite runs. Covers year/month boundaries, "in 1 month" clamping (Jan 31 → Feb 28), today-is-Friday weekday disambiguation (`friday` / `this friday` / `next friday`), Czech weekday names, and invalid/empty input.
- `query.ts` — `queryMode` syntax dispatch (`#tag` / `key:value` / name). The result-gathering functions need a live `App`/vault and are intentionally untested.
- `calculator.ts` — arithmetic, plain-language, unit/temperature/currency conversions (rates injected by the caller), and number formatting.
- `currency.ts` — documented as having no pure logic to test (network + clock TTL + module cache); its one pure path (rates → converted amount) is covered via the calculator.

**Wiring**
- Adds `"test": "vitest run"` to package.json.
- Adds a `Test` step to CI, after `Lint`.

## Related issue

None — this is additive test-only scaffolding (no `src/` changes).

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

<sub>(No production behaviour changes — test infrastructure only.)</sub>

## Checklist

- [x] `npm run build` passes locally
- [x] Lint, typecheck and `npm test` pass locally (64 passed, 4 skipped)

## ⚠️ Bug surfaced (documented, not fixed here)

Three tests are marked `.skip` documenting a **pre-existing bug** in `dates.ts`: moment's `isValid` is used as a *property* (`m.isValid`) rather than a *method* (`m.isValid()`), so the guard is a truthy function reference that never fires. As a result, an ISO-shaped but calendar-invalid date like `2026-02-31` returns the string `"Invalid date"` instead of `null`, and `formatRelativeDate` returns `"Invalid date"` instead of echoing the raw string. Left unfixed here to keep this PR test-only — a separate `fix/dates-isvalid` PR will address it and un-skip those three tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBEdj7vUN4wSu2xFVhEtE5)_