### PR TITLE
fix(release): use valid glob for pre-release tag filter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
       # Stable version tags, e.g. 1.8.1 — must match manifest.json.
       - "[0-9]+.[0-9]+.[0-9]+"
       # Pre-release tags, e.g. 1.9.0-beta.1 / -alpha.2 / -rc.1 — must match
-      # manifest-beta.json. Four-segment tags (1.8.1.4-beta) are NOT valid
-      # semver and deliberately do not match either pattern.
-      - "[0-9]+.[0-9]+.[0-9]+-[0-9A-Za-z.]+"
+      # manifest-beta.json. The trailing "-*" requires a hyphen immediately
+      # after x.y.z, so four-segment tags (1.8.1.4-beta) still do not match.
+      - "[0-9]+.[0-9]+.[0-9]+-*"
   # Allow cutting a release manually from the Actions tab / API.
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Problem
Every push to the repo — including plain branch pushes and PRs — produces a **failed `release.yml` run** (0s, zero jobs, *"This run likely failed because of a workflow file issue"*). It's a **startup failure**: GitHub can't parse the workflow, so it stops honoring the tags-only trigger and fails a run on every push.

## Root cause
PR #42 changed the pre-release tag filter to:

```yaml
- "[0-9]+.[0-9]+.[0-9]+-[0-9A-Za-z.]+"
```

GitHub's branch/tag **filter patterns are a restricted glob, not regex**. A `[...]` class matches a single *alphanumeric* character or range, so the literal `.` inside `[0-9A-Za-z.]` is invalid — GitHub rejects the entire workflow file.

`yaml.safe_load` and `actionlint` both pass because they treat the glob as an opaque string; only GitHub validates the pattern grammar, which is why nothing caught it locally.

## Fix
Revert the pre-release filter to the previously-working `-*` form:

```yaml
- "[0-9]+.[0-9]+.[0-9]+-*"
```

Known-good — it shipped `1.9.0-beta.1` before #42 — and it still requires a hyphen immediately after `x.y.z`, so four-segment tags like `1.8.1.4-beta` remain excluded, preserving #42's intent. The rest of #42's beta/stable manifest split is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)