### PR TITLE
fix(dashboard): stop hover-visibility controls from shifting the board

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1831,10 +1831,11 @@
 	align-items: center;
 }
 
-.hearth-arrange-zone.is-auto-hide {
-	padding: 16px;
-}
-
+/* Hover mode must keep the SAME footprint as always-visible mode: the button
+ * stays laid out (opacity:0, not display:none), so its own box is the hover
+ * target and revealing it shifts nothing. Do NOT add in-flow padding/margin to
+ * the auto-hide zone — that grew the zone only in hover mode and pushed the
+ * whole board down (see the switcher zone below for the same rule). */
 .hearth-arrange-zone.is-auto-hide .hearth-tool-btn {
 	opacity: 0;
 	pointer-events: none;
@@ -1855,10 +1856,9 @@
 	align-items: center;
 }
 
-.hearth-dash-switcher-zone.is-auto-hide {
-	padding: 16px 0;
-}
-
+/* No in-flow padding on the auto-hide zone (see .hearth-arrange-zone above): the
+ * hidden switcher keeps its normal box, so hover mode has the same footprint as
+ * always-visible mode and enabling hover doesn't push the header/grid down. */
 .hearth-dash-switcher {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
## Problem

PR #19 (Add hover visibility options for dashboard controls, #19) introduced a regression: turning on **Show on hover** for either the arrange/edit button or the dashboard switcher shifts the whole dashboard area down, and in fit-to-page mode clips ("breaks") the board.

## Root cause

The follow-up commit *"Increase hover area for auto-hide dashboard controls"* gave the **auto-hide** zones in-flow padding to enlarge the hover hit-area:

```css
.hearth-arrange-zone.is-auto-hide      { padding: 16px;   }
.hearth-dash-switcher-zone.is-auto-hide { padding: 16px 0; }
```

That padding exists **only** in hover mode, not in always-visible mode. So flipping a control to "Show on hover" grows that control's zone by ~32px and pushes everything below it (header, grid) down. The switcher's `margin-bottom: -16px`, calibrated for the zero-padding layout, no longer compensates.

The invariant being violated: **hover mode must not change layout versus always-visible mode** — the control should just fade in place.

## Fix

Drop the in-flow padding from both auto-hide zones. The control is `opacity: 0` (not `display: none`), so it still reserves its normal box — the button's own area remains the hover target, and revealing it on hover/`:focus-within` no longer moves anything. Comments added on both zones so future edits don't reintroduce state-only spacing.

Only the two `.is-auto-hide` padding rules change; always-visible mode (the default) is untouched.

## Trade-off

The hover hit-area is now the control's own footprint rather than a padded 16px ring — a slightly smaller but perfectly usable target at a known location. This is the low-risk fix; an alternative that preserves the larger target via padding + equal negative margin was considered but avoided here to keep the change minimal and side-effect-free.

## Testing

- `npm run build` (tsc + esbuild) passes.
- Static CSS change; recommend a visual check in Obsidian: (a) default always-visible layout unchanged, (b) switching either control to "Show on hover" no longer shifts the board, (c) hover / keyboard focus still reveals the control, (d) switcher drag-to-reorder still reveals via `.is-dragging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)