### PR TITLE
ci: lint+typecheck tests and guard manifest/versions invariants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
           fi
           echo "Store manifest version OK: $store"
 
+      # Complements the guard above: versions.json must map the stable manifest
+      # version, and manifest-beta.json must stay a pre-release strictly ahead of
+      # stable and identical to it in every other field. See scripts for details.
+      - name: Guard manifest / versions invariants
+        run: npm run verify:manifests
+
       - name: Lint
         run: npm run lint
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"typecheck": "tsc -noEmit -skipLibCheck",
-		"lint": "eslint src",
-		"lint:fix": "eslint src --fix",
-		"test": "vitest run"
+		"lint": "eslint src test",
+		"lint:fix": "eslint src test --fix",
+		"test": "vitest run",
+		"verify:manifests": "node scripts/verify-manifests.mjs"
 	},
 	"keywords": [
 		"obsidian",

--- a/scripts/verify-manifests.mjs
+++ b/scripts/verify-manifests.mjs
@@ -1,0 +1,125 @@
+// Release-safety guards for the manifest/version files, run in CI.
+//
+// These protect two Obsidian-store invariants that are easy to break by hand
+// and only surface as a failed *release*:
+//
+//   1. versions.json must contain an entry for manifest.json's version.
+//      Obsidian resolves a plugin release by looking up the manifest version
+//      in versions.json; a missing entry yields "No release matches your
+//      manifest version" and the release is rejected.
+//
+//   2. manifest-beta.json (read by BRAT) must stay a pre-release that is
+//      strictly ahead of the stable manifest, and must not drift from it in
+//      any field other than `version`. This keeps the beta channel from ever
+//      falling behind — or diverging from — the store-facing manifest.
+//
+// The plain-x.y.z guard on manifest.json already lives in ci.yml/release.yml;
+// this file complements it. Run locally with: node scripts/verify-manifests.mjs
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const readJson = (name) => JSON.parse(readFileSync(join(root, name), "utf8"));
+
+const errors = [];
+const fail = (msg) => errors.push(msg);
+
+const manifest = readJson("manifest.json");
+const versions = readJson("versions.json");
+const beta = readJson("manifest-beta.json");
+
+// --- 1. versions.json has an entry for the stable manifest version ----------
+if (!Object.prototype.hasOwnProperty.call(versions, manifest.version)) {
+	fail(
+		`versions.json is missing an entry for manifest.json version ` +
+			`"${manifest.version}". Add "${manifest.version}": "${manifest.minAppVersion}" ` +
+			`or the Obsidian store rejects the release with ` +
+			`"No release matches your manifest version".`,
+	);
+}
+
+// --- semver precedence (enough of the spec for our x.y.z[-pre] tags) --------
+function parseSemver(v) {
+	const m = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(String(v));
+	if (!m) return null;
+	return { major: +m[1], minor: +m[2], patch: +m[3], pre: m[4] ? m[4].split(".") : [] };
+}
+
+function cmpSemver(a, b) {
+	if (a.major !== b.major) return a.major - b.major;
+	if (a.minor !== b.minor) return a.minor - b.minor;
+	if (a.patch !== b.patch) return a.patch - b.patch;
+	// A version WITHOUT a prerelease outranks one that has it (1.0.0 > 1.0.0-beta).
+	if (a.pre.length === 0 && b.pre.length === 0) return 0;
+	if (a.pre.length === 0) return 1;
+	if (b.pre.length === 0) return -1;
+	const n = Math.min(a.pre.length, b.pre.length);
+	for (let i = 0; i < n; i++) {
+		const x = a.pre[i];
+		const y = b.pre[i];
+		const xn = /^\d+$/.test(x);
+		const yn = /^\d+$/.test(y);
+		if (xn && yn) {
+			const d = +x - +y;
+			if (d) return d;
+		} else if (xn) {
+			return -1; // numeric identifiers rank below alphanumeric
+		} else if (yn) {
+			return 1;
+		} else if (x !== y) {
+			return x < y ? -1 : 1;
+		}
+	}
+	return a.pre.length - b.pre.length;
+}
+
+// --- 4. manifest-beta invariants --------------------------------------------
+const stableSv = parseSemver(manifest.version);
+const betaSv = parseSemver(beta.version);
+
+if (!stableSv) fail(`manifest.json version "${manifest.version}" is not valid semver.`);
+if (!betaSv) {
+	fail(`manifest-beta.json version "${beta.version}" is not valid semver.`);
+} else {
+	if (betaSv.pre.length === 0) {
+		fail(
+			`manifest-beta.json version "${beta.version}" is not a pre-release ` +
+				`(no "-suffix"). BRAT's beta channel must hold a pre-release; ` +
+				`stable versions belong in manifest.json.`,
+		);
+	}
+	if (stableSv && cmpSemver(betaSv, stableSv) <= 0) {
+		fail(
+			`manifest-beta.json version "${beta.version}" must be strictly ahead ` +
+				`of manifest.json version "${manifest.version}". Open the next beta ` +
+				`(e.g. bump manifest-beta.json) so BRAT users are not stuck behind stable.`,
+		);
+	}
+}
+
+// No field other than `version` may differ between the two manifests.
+const keys = new Set([...Object.keys(manifest), ...Object.keys(beta)]);
+keys.delete("version");
+for (const k of keys) {
+	const a = JSON.stringify(manifest[k]);
+	const b = JSON.stringify(beta[k]);
+	if (a !== b) {
+		fail(
+			`Field "${k}" differs between manifest.json (${a}) and ` +
+				`manifest-beta.json (${b}). The two manifests must match on every ` +
+				`field except "version".`,
+		);
+	}
+}
+
+if (errors.length) {
+	for (const e of errors) console.error(`::error::${e}`);
+	console.error(`\n${errors.length} manifest/version problem(s) — see RELEASING.md.`);
+	process.exit(1);
+}
+
+console.log(
+	`Manifest guards OK: stable ${manifest.version} in versions.json; ` +
+		`beta ${beta.version} is a pre-release ahead of stable and matches on all other fields.`,
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,12 +11,20 @@
 		"importHelpers": true,
 		"isolatedModules": true,
 		"strictNullChecks": true,
+		// The unit-test shim (test/support/obsidian-shim.ts) default-imports the
+		// real moment.js; esbuild/Vitest allow that interop at runtime, so let
+		// tsc resolve it too. This only relaxes default-import checking — it does
+		// not change how src compiles.
+		"allowSyntheticDefaultImports": true,
 		"lib": [
 			"DOM",
 			"ES2020"
 		]
 	},
+	// Tests are typechecked here too (Vitest itself does not typecheck), and this
+	// is also the project the type-aware ESLint service loads for test/**.
 	"include": [
-		"src/**/*.ts"
+		"src/**/*.ts",
+		"test/**/*.ts"
 	]
 }


### PR DESCRIPTION
Closes three gaps in the CI gate. No product code changes — CI/config only.

## What & why

### Tests are now linted and typechecked
Previously `test/` was invisible to both checks — `npm run lint` was `eslint src`, and the tsconfig `include` was `src/**` only (Vitest does not typecheck). A broken-but-uncompiled test could ship silently.
- `tsconfig.json`: add `test/**/*.ts` to `include`; this also becomes the project the type-aware ESLint service loads for `test/**`.
- `allowSyntheticDefaultImports: true`: the test shim (`test/support/obsidian-shim.ts`) default-imports the real moment.js — esbuild/Vitest already allow that interop at runtime; this only lets `tsc` resolve it. It does **not** change how `src` compiles (verified: `tsc` output identical).
- `package.json`: `lint`/`lint:fix` now target `src test`. `typecheck` and `build` cover tests automatically via the include.

### New guard: `scripts/verify-manifests.mjs` (run in CI, before lint)
Guards two Obsidian-store invariants that otherwise only surface as a **failed release**:
1. `versions.json` must contain an entry for `manifest.json`'s version — a missing entry makes the store reject the release with *"No release matches your manifest version"*.
2. `manifest-beta.json` (read by BRAT) must stay a pre-release, be **strictly ahead** of stable by semver precedence, and not drift from `manifest.json` in any field except `version`.

Complements the existing plain-`x.y.z` guard in `ci.yml`. Runnable locally: `npm run verify:manifests`.

## Verification
Full CI gate run locally — all green:
- `verify:manifests` ✅ (`stable 1.9.0 in versions.json; beta 1.10.0-beta.1 ahead of stable`)
- `lint` (src + test) ✅ 0 errors
- `test` ✅ 67 passed / 1 skipped
- `typecheck` (now including tests) ✅
- `build` ✅, output check ✅

Each guard failure path was exercised (missing versions entry, beta behind stable, beta not a pre-release, field drift) — all exit 1; the current tree exits 0.

## Not included (deliberate)
- `--max-warnings=0` on lint — would fail today on 30 intentional `no-deprecated` warnings (slated for removal in 1.11.0).
- `release.yml` left untouched to keep the release path low-risk; the guard runs on every push/PR to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)