### PR TITLE
feat(cards): add RSS feed reader card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ preceding beta series.
 History begins at 1.5.0. For releases before 1.5.0, see the
 [GitHub Releases](https://github.com/ondreu/Hearth/releases) page.
 
+## [1.10.0]
+
+### Added
+
+- **RSS feed card.** A lightweight, self-contained feed reader you can drop on
+  any dashboard. Add one or more RSS/Atom feeds — each becomes a tab in the card
+  header — with an optional combined **"All"** tab that merges every source
+  newest-first. Choose between three layouts (**List** title + date, **Cards**
+  with excerpt and thumbnail, or a **Compact** headlines view), cap how many
+  items each feed shows, and set an auto-refresh interval (or 0 to refresh only
+  when opened, plus a manual refresh button). Feeds are fetched through
+  Obsidian's own request bridge (so cross-origin feeds work) and cached in
+  memory, degrade gracefully offline (the last good items stay), and honour the
+  **"disable external calls"** setting — with it on, no feed request is made.
+
 ## [1.9.0]
 
 ### Changed

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -22,6 +22,8 @@ import type {
 	DashboardCard,
 	EmbedView,
 	LinkItem,
+	RssLayout,
+	RssSource,
 	TaskDueFilter,
 	TaskFilterConfig,
 	TaskMeta,
@@ -33,6 +35,7 @@ import type {
 import { evaluate as evaluateCalc } from "./calculator";
 import { cachedRates, loadRates } from "./currency";
 import { getDataviewApi } from "./dataview";
+import { cachedFeed, loadFeed, type RssItem } from "./rss";
 import { isViewTypeHostable, mountLeafView } from "./leafview";
 import { EXCALIDRAW_PLUGIN_ID, iconForFile, isExcalidraw } from "./filetypes";
 import { type QueryHit, runQuery, searchFileContents } from "./query";
@@ -148,6 +151,9 @@ export function renderCardBody(
 			break;
 		case "dataview":
 			renderDataview(view, card, body, component);
+			break;
+		case "rss":
+			renderRss(view, card, body, component);
 			break;
 		case "leaf":
 			renderLeaf(view, card, body, component);
@@ -5930,6 +5936,221 @@ function renderAnalogClock(wrap: HTMLElement, cfg: ClockConfig): (now: Date) => 
 		rotate(minHand, (m + s / 60) * 6);
 		if (secHand) rotate(secHand, s * 6);
 	};
+}
+
+// ---- RSS (lightweight feed reader) -------------------------------------
+
+/** Which source tab each rss card is showing. Transient (not persisted): keyed
+ * by the card object so the choice survives body redraws and full rebuilds —
+ * the card objects live in settings and are reused — but resets on reload. */
+const rssActiveTab = new WeakMap<DashboardCard, string>();
+
+/** moment's `.fromNow()` isn't on the shared Moment shim; assert it locally. */
+interface RelativeMoment {
+	fromNow(): string;
+}
+
+/** A source's short host label, e.g. "https://blog.foo.com/feed" → "blog.foo.com". */
+function feedHost(url: string): string {
+	try {
+		return new URL(url).hostname.replace(/^www\./, "");
+	} catch {
+		return url;
+	}
+}
+
+function renderRss(
+	view: HomeView,
+	card: DashboardCard,
+	body: HTMLElement,
+	component: Component,
+): void {
+	const cfg = card.rss ?? {};
+	const sources = (cfg.sources ?? []).filter((s) => s.url.trim());
+	if (sources.length === 0) {
+		emptyState(body, "rss", t().cards.empty.rssNoSources);
+		return;
+	}
+
+	const layout: RssLayout = cfg.layout ?? "list";
+	const limit = cfg.itemLimit && cfg.itemLimit > 0 ? cfg.itemLimit : 15;
+	const refreshMin = cfg.refreshMin ?? 30;
+	const disabled = view.plugin.settings.disableExternalCalls;
+	// Freshness window for the cache: at least a minute so re-renders don't spam.
+	const ttlMs = Math.max(refreshMin, 1) * 60_000;
+
+	/** A header tab: one source, or the merged "All" view over several. */
+	interface Tab {
+		id: string;
+		urls: string[];
+	}
+	const tabs: Tab[] = [];
+	if (cfg.mergeAll && sources.length > 1) {
+		tabs.push({ id: "all", urls: sources.map((s) => s.url) });
+	}
+	for (const s of sources) tabs.push({ id: s.id, urls: [s.url] });
+
+	let activeId = rssActiveTab.get(card) ?? tabs[0].id;
+	if (!tabs.some((tab) => tab.id === activeId)) activeId = tabs[0].id;
+
+	// Async loads may resolve after the card is torn down and rebuilt; ignore them.
+	let destroyed = false;
+	component.register(() => {
+		destroyed = true;
+	});
+	let loading = false;
+
+	const wrap = body.createDiv("hearth-rss");
+
+	const sourceById = (id: string): RssSource | undefined =>
+		sources.find((s) => s.id === id);
+
+	/** Friendly label for a source: its name, else the feed's own title, else host. */
+	const sourceLabel = (source: RssSource): string =>
+		source.name.trim() || cachedFeed(source.url)?.title || feedHost(source.url);
+
+	const tabLabel = (tab: Tab): string =>
+		tab.id === "all"
+			? t().cards.rss.allTab
+			: sourceLabel(sourceById(tab.id) ?? { id: tab.id, name: "", url: tab.urls[0] });
+
+	const activeTab = (): Tab =>
+		tabs.find((tab) => tab.id === activeId) ?? tabs[0];
+
+	const openItem = (item: RssItem): void => {
+		if (item.link && /^https?:\/\//i.test(item.link)) {
+			window.open(item.link, "_blank");
+		}
+	};
+
+	const renderItem = (
+		container: HTMLElement,
+		item: RssItem,
+		badge: string,
+	): void => {
+		const row = container.createDiv("hearth-rss-item");
+		makeClickable(row, () => openItem(item), item.title || t().cards.rss.untitled);
+		row.addEventListener("click", () => openItem(item));
+
+		if (layout === "cards" && cfg.showImages !== false && item.image) {
+			const thumb = row.createDiv("hearth-rss-thumb");
+			const img = thumb.createEl("img");
+			img.setAttribute("src", item.image);
+			img.setAttribute("loading", "lazy");
+			img.setAttribute("referrerpolicy", "no-referrer");
+			// Drop the thumbnail slot entirely if the image can't be fetched.
+			img.addEventListener("error", () => thumb.remove());
+		}
+
+		const main = row.createDiv("hearth-rss-main");
+		main.createDiv({
+			cls: "hearth-rss-title",
+			text: item.title || t().cards.rss.untitled,
+		});
+		if (layout === "cards" && cfg.showExcerpt !== false && item.excerpt) {
+			main.createDiv({ cls: "hearth-rss-excerpt", text: item.excerpt });
+		}
+
+		const metaBits: string[] = [];
+		if (badge) metaBits.push(badge);
+		if (cfg.showDate !== false && item.published) {
+			metaBits.push(
+				(createMoment(new Date(item.published)) as unknown as RelativeMoment).fromNow(),
+			);
+		}
+		if (metaBits.length) {
+			main.createDiv({ cls: "hearth-rss-meta", text: metaBits.join(" · ") });
+		}
+	};
+
+	/** Paint the item list (or a loading/empty/offline state) for the active tab. */
+	const paint = (content: HTMLElement): void => {
+		const tab = activeTab();
+		const merged = tab.urls.length > 1;
+		const rows: { item: RssItem; badge: string }[] = [];
+		let anyCached = false;
+		for (const url of tab.urls) {
+			const feed = cachedFeed(url);
+			if (!feed) continue;
+			anyCached = true;
+			const src = sources.find((s) => s.url === url);
+			const badge = merged && src ? sourceLabel(src) : "";
+			for (const item of feed.items) rows.push({ item, badge });
+		}
+		if (merged) {
+			rows.sort((a, b) => (b.item.published ?? 0) - (a.item.published ?? 0));
+		}
+		const items = rows.slice(0, limit);
+
+		if (items.length === 0) {
+			if (loading) {
+				emptyState(content, "rss", t().cards.rss.loading);
+			} else if (disabled && !anyCached) {
+				emptyState(content, "wifi-off", t().cards.rss.disabled);
+			} else if (anyCached) {
+				emptyState(content, "rss", t().cards.rss.empty);
+			} else {
+				emptyState(content, "rss", t().cards.rss.error);
+			}
+			return;
+		}
+		for (const row of items) renderItem(content, row.item, row.badge);
+	};
+
+	/** Rebuild tab bar + content from the current cache and loading flag. */
+	const rebuild = (): void => {
+		wrap.empty();
+
+		const bar = wrap.createDiv("hearth-rss-tabs");
+		const tabsEl = bar.createDiv("hearth-rss-tablist");
+		if (tabs.length > 1) {
+			for (const tab of tabs) {
+				const btn = tabsEl.createEl("button", {
+					cls: "hearth-rss-tab",
+					text: tabLabel(tab),
+				});
+				if (tab.id === activeId) btn.addClass("is-active");
+				btn.addEventListener("click", () => {
+					activeId = tab.id;
+					rssActiveTab.set(card, tab.id);
+					load(false);
+				});
+			}
+		}
+		const refresh = bar.createEl("button", {
+			cls: "hearth-rss-refresh",
+			attr: { "aria-label": t().cards.rss.refresh },
+		});
+		setIcon(refresh, "refresh-cw");
+		if (loading) refresh.addClass("is-loading");
+		refresh.addEventListener("click", () => load(true));
+
+		const content = wrap.createDiv(`hearth-rss-content hearth-rss-${layout}`);
+		paint(content);
+	};
+
+	/** Show cached content immediately, then fetch and repaint. `force` bypasses
+	 * the cache TTL (used by the manual refresh button and the auto-refresh timer). */
+	const load = (force: boolean): void => {
+		const tab = activeTab();
+		// Only show the loading placeholder when there's nothing cached to show.
+		loading = tab.urls.every((url) => !cachedFeed(url));
+		rebuild();
+		void Promise.all(
+			tab.urls.map((url) => loadFeed(url, { ttlMs, disabled, force })),
+		).then(() => {
+			if (destroyed) return;
+			loading = false;
+			rebuild();
+		});
+	};
+
+	load(false);
+	if (refreshMin > 0) {
+		component.registerInterval(
+			window.setInterval(() => load(true), refreshMin * 60_000),
+		);
+	}
 }
 
 function renderClock(

--- a/src/editors.ts
+++ b/src/editors.ts
@@ -7,6 +7,7 @@ import type {
 	DashboardCard,
 	EmbedView,
 	LinkItem,
+	RssLayout,
 	TasksConfig,
 } from "./types";
 import { confirmAction } from "./ui";
@@ -294,6 +295,9 @@ export class CardSettingsModal extends Modal {
 			case "dataview":
 				this.dataviewEditor(containerEl);
 				break;
+			case "rss":
+				this.rssEditor(containerEl);
+				break;
 			case "leaf":
 				this.leafEditor(containerEl);
 				break;
@@ -558,6 +562,189 @@ export class CardSettingsModal extends Modal {
 			txt.inputEl.addClass("hearth-dataview-input");
 		});
 		query.settingEl.addClass("hearth-setting-stacked");
+	}
+
+	private rssEditor(containerEl: HTMLElement): void {
+		const cfg = (this.card.rss ??= {});
+		const sources = (cfg.sources ??= []);
+
+		new Setting(containerEl).setName(t().editors.rss.feeds).setHeading();
+
+		sources.forEach((source, index) => {
+			const row = new Setting(containerEl).setClass("hearth-rss-setting");
+			row.addText((txt) =>
+				txt
+					.setPlaceholder(t().editors.rss.namePlaceholder)
+					.setValue(source.name)
+					.onChange((v) => {
+						source.name = v;
+						this.opts.save();
+					}),
+			);
+			row.addText((txt) => {
+				txt
+					.setPlaceholder(t().editors.rss.urlPlaceholder)
+					.setValue(source.url)
+					.onChange((v) => {
+						source.url = v.trim();
+						this.opts.save();
+						this.opts.rerender();
+					});
+				txt.inputEl.addClass("hearth-rss-url");
+			});
+			row.addExtraButton((b) =>
+				b
+					.setIcon("chevron-up")
+					.setTooltip(t().editors.links.moveUp)
+					.setDisabled(index === 0)
+					.onClick(() => this.moveItem(sources, index, index - 1)),
+			);
+			row.addExtraButton((b) =>
+				b
+					.setIcon("chevron-down")
+					.setTooltip(t().editors.links.moveDown)
+					.setDisabled(index === sources.length - 1)
+					.onClick(() => this.moveItem(sources, index, index + 1)),
+			);
+			row.addExtraButton((b) =>
+				b
+					.setIcon("trash-2")
+					.setTooltip(t().editors.rss.removeFeed)
+					.onClick(() => {
+						sources.splice(index, 1);
+						this.opts.save();
+						this.opts.rerender();
+						this.render();
+					}),
+			);
+		});
+
+		new Setting(containerEl).addButton((b) =>
+			b.setButtonText(t().editors.rss.addFeed).onClick(() => {
+				sources.push({
+					id: `rss-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e4)}`,
+					name: "",
+					url: "",
+				});
+				this.opts.save();
+				this.render();
+			}),
+		);
+
+		if (sources.length > 1) {
+			new Setting(containerEl)
+				.setName(t().editors.rss.mergeAll)
+				.setDesc(t().editors.rss.mergeAllDesc)
+				.addToggle((tg) =>
+					tg.setValue(cfg.mergeAll ?? false).onChange((v) => {
+						cfg.mergeAll = v || undefined;
+						this.opts.save();
+						this.opts.rerender();
+					}),
+				);
+		}
+
+		new Setting(containerEl).setName(t().editors.rss.display).setHeading();
+
+		new Setting(containerEl)
+			.setName(t().editors.rss.layout)
+			.setDesc(t().editors.rss.layoutDesc)
+			.addDropdown((d) => {
+				d.addOption("list", t().editors.rss.layoutList);
+				d.addOption("cards", t().editors.rss.layoutCards);
+				d.addOption("compact", t().editors.rss.layoutCompact);
+				d.setValue(cfg.layout ?? "list").onChange((v) => {
+					cfg.layout = v === "list" ? undefined : (v as RssLayout);
+					this.opts.save();
+					this.opts.rerender();
+					this.render();
+				});
+			});
+
+		const items = new Setting(containerEl)
+			.setName(t().editors.rss.itemLimit)
+			.setDesc(t().editors.rss.itemLimitDesc);
+		items.addSlider((s) => {
+			s.setLimits(3, 50, 1)
+				.setValue(cfg.itemLimit ?? 15)
+				.setDynamicTooltip()
+				.onChange((v) => {
+					cfg.itemLimit = v === 15 ? undefined : v;
+					this.opts.save();
+					this.opts.rerender();
+				});
+		});
+		items.addExtraButton((b) =>
+			b
+				.setIcon("rotate-ccw")
+				.setTooltip(t().settings.resetSlider)
+				.onClick(() => {
+					cfg.itemLimit = undefined;
+					this.opts.save();
+					this.opts.rerender();
+					this.render();
+				}),
+		);
+
+		const refresh = new Setting(containerEl)
+			.setName(t().editors.rss.refresh)
+			.setDesc(t().editors.rss.refreshDesc);
+		refresh.addSlider((s) => {
+			s.setLimits(0, 180, 5)
+				.setValue(cfg.refreshMin ?? 30)
+				.setDynamicTooltip()
+				.onChange((v) => {
+					cfg.refreshMin = v === 30 ? undefined : v;
+					this.opts.save();
+					this.opts.rerender();
+				});
+		});
+		refresh.addExtraButton((b) =>
+			b
+				.setIcon("rotate-ccw")
+				.setTooltip(t().settings.resetSlider)
+				.onClick(() => {
+					cfg.refreshMin = undefined;
+					this.opts.save();
+					this.opts.rerender();
+					this.render();
+				}),
+		);
+
+		const isCards = (cfg.layout ?? "list") === "cards";
+		if (isCards) {
+			new Setting(containerEl)
+				.setName(t().editors.rss.showImages)
+				.setDesc(t().editors.rss.showImagesDesc)
+				.addToggle((tg) =>
+					tg.setValue(cfg.showImages !== false).onChange((v) => {
+						cfg.showImages = v ? undefined : false;
+						this.opts.save();
+						this.opts.rerender();
+					}),
+				);
+			new Setting(containerEl)
+				.setName(t().editors.rss.showExcerpt)
+				.setDesc(t().editors.rss.showExcerptDesc)
+				.addToggle((tg) =>
+					tg.setValue(cfg.showExcerpt !== false).onChange((v) => {
+						cfg.showExcerpt = v ? undefined : false;
+						this.opts.save();
+						this.opts.rerender();
+					}),
+				);
+		}
+
+		new Setting(containerEl)
+			.setName(t().editors.rss.showDate)
+			.setDesc(t().editors.rss.showDateDesc)
+			.addToggle((tg) =>
+				tg.setValue(cfg.showDate !== false).onChange((v) => {
+					cfg.showDate = v ? undefined : false;
+					this.opts.save();
+					this.opts.rerender();
+				}),
+			);
 	}
 
 	private calculatorEditor(containerEl: HTMLElement): void {

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -15,6 +15,8 @@ import {
 	type LinkItem,
 	type MobileActionButton,
 	newDashboardId,
+	type RssConfig,
+	type RssSource,
 	type SavedSearchConfig,
 	type TaskFilterConfig,
 	type TaskSortRule,
@@ -76,6 +78,7 @@ const CARD_KINDS: CardKind[] = [
 	"heatmap",
 	"calculator",
 	"dataview",
+	"rss",
 	"leaf",
 ];
 
@@ -306,6 +309,9 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 		card.calculator = sanitizeCalculator(
 			r.calculator as Record<string, unknown>,
 		);
+	}
+	if (r.rss && typeof r.rss === "object") {
+		card.rss = sanitizeRss(r.rss as Record<string, unknown>);
 	}
 	if (r.dataview && typeof r.dataview === "object") {
 		card.dataview = sanitizeDataview(r.dataview as Record<string, unknown>);
@@ -558,6 +564,41 @@ function sanitizeCalculator(r: Record<string, unknown>): CalculatorConfig {
 		cfg.keypad = r.keypad;
 	const lastInput = str(r.lastInput);
 	if (lastInput !== undefined) cfg.lastInput = lastInput;
+	return cfg;
+}
+
+function sanitizeRssSource(raw: unknown): RssSource | null {
+	if (!raw || typeof raw !== "object") return null;
+	const r = raw as Record<string, unknown>;
+	const url = str(r.url);
+	if (url === undefined) return null;
+	return {
+		id: str(r.id) ?? `rss-${Math.random().toString(36).slice(2)}`,
+		name: str(r.name) ?? "",
+		url,
+	};
+}
+
+function sanitizeRss(r: Record<string, unknown>): RssConfig {
+	const cfg: RssConfig = {};
+	if (Array.isArray(r.sources)) {
+		cfg.sources = r.sources
+			.map(sanitizeRssSource)
+			.filter((s): s is RssSource => s !== null);
+	}
+	if (r.layout === "list" || r.layout === "cards" || r.layout === "compact") {
+		cfg.layout = r.layout;
+	}
+	if (typeof r.refreshMin === "number" && r.refreshMin >= 0) {
+		cfg.refreshMin = r.refreshMin;
+	}
+	if (typeof r.itemLimit === "number" && r.itemLimit > 0) {
+		cfg.itemLimit = r.itemLimit;
+	}
+	if (typeof r.showImages === "boolean") cfg.showImages = r.showImages;
+	if (typeof r.showExcerpt === "boolean") cfg.showExcerpt = r.showExcerpt;
+	if (typeof r.showDate === "boolean") cfg.showDate = r.showDate;
+	if (typeof r.mergeAll === "boolean") cfg.mergeAll = r.mergeAll;
 	return cfg;
 }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -456,6 +456,7 @@ export const en = {
 			heatmap: "Activity heatmap",
 			calculator: "Calculator",
 			dataview: "Dataview query",
+			rss: "RSS feed",
 			leaf: "Plugin view (beta)",
 		},
 		linkTypes: {
@@ -731,6 +732,32 @@ export const en = {
 				'TABLE file.mtime AS "Modified" FROM #project SORT file.mtime DESC',
 			queryJsPlaceholder: "dv.list(dv.pages('#project').file.link)",
 		},
+		rss: {
+			feeds: "Feeds",
+			namePlaceholder: "Name (optional)",
+			urlPlaceholder: "https://example.com/feed.xml",
+			addFeed: "Add feed",
+			removeFeed: "Remove feed",
+			mergeAll: "Combined “All” tab",
+			mergeAllDesc:
+				"Add a leading tab that merges every feed into one stream, newest first.",
+			display: "Display",
+			layout: "Layout",
+			layoutDesc: "How each item is shown.",
+			layoutList: "List (title + date)",
+			layoutCards: "Cards (excerpt + image)",
+			layoutCompact: "Compact (headlines)",
+			itemLimit: "Items per feed",
+			itemLimitDesc: "How many recent items to show.",
+			refresh: "Auto-refresh (minutes)",
+			refreshDesc: "How often to refetch feeds. 0 = only when opened.",
+			showImages: "Show images",
+			showImagesDesc: "Show item thumbnails when the feed provides them.",
+			showExcerpt: "Show excerpt",
+			showExcerptDesc: "Show a short text snippet under each item.",
+			showDate: "Show date",
+			showDateDesc: "Show each item's publish time.",
+		},
 		leaf: {
 			view: "View to host",
 			viewDesc:
@@ -803,6 +830,7 @@ export const en = {
 				"No Kanban board found — pick a board note in card settings, or create one with the Kanban plugin",
 			dataviewEnable: "Enable the Dataview plugin to run queries",
 			dataviewNoQuery: "Set a Dataview query in card settings",
+			rssNoSources: "Add a feed in card settings",
 			leafPickView: "Pick a plugin view in card settings",
 			leafViewMissing:
 				"This view isn't available — enable the plugin that provides it",
@@ -820,6 +848,15 @@ export const en = {
 		},
 		calculator: {
 			placeholder: "2 + 2, 10 km to miles, 10 € to USD…",
+		},
+		rss: {
+			allTab: "All",
+			untitled: "(untitled)",
+			loading: "Loading feed…",
+			empty: "No items in this feed",
+			error: "Couldn't load this feed",
+			disabled: "Feeds are off (external calls disabled)",
+			refresh: "Refresh",
 		},
 		daily: {
 			createToday: "Create today's note",
@@ -1054,6 +1091,7 @@ export const en = {
 		text: "Text / jot-down",
 		calculator: "Calculator",
 		dataview: "Dataview query",
+		rss: "RSS feed",
 		leaf: "Plugin view (beta)",
 	},
 

--- a/src/rss.ts
+++ b/src/rss.ts
@@ -1,0 +1,219 @@
+/**
+ * Feed fetching and parsing for the "rss" card.
+ *
+ * Feeds are fetched through Obsidian's `requestUrl` (which bypasses the browser
+ * CORS restrictions a plain `fetch` would hit) and parsed with the platform
+ * `DOMParser`. Both RSS 2.0 (`<item>`) and Atom (`<entry>`) are understood.
+ *
+ * Results are cached in memory per URL for a card-configurable window, so a
+ * board with several feed cards (and Hearth's frequent full re-renders) makes at
+ * most one request per feed per refresh window. Everything degrades gracefully
+ * offline: a failed fetch keeps the last good items, and the one outbound
+ * request is skipped entirely when the user has disabled external calls.
+ */
+import { requestUrl } from "obsidian";
+
+/** A single parsed feed entry, normalised across RSS and Atom. */
+export interface RssItem {
+	title: string;
+	/** Absolute link to the article, or "" when the feed gives none. */
+	link: string;
+	/** Plain-text excerpt (HTML stripped, collapsed whitespace). */
+	excerpt: string;
+	/** Publish time in epoch ms, or null when absent/unparseable. */
+	published: number | null;
+	/** Thumbnail image URL when the item advertises one, else "". */
+	image: string;
+}
+
+/** A parsed feed: its own title plus its items, newest first. */
+export interface RssFeed {
+	/** The feed's `<title>`, or "" when it has none. */
+	title: string;
+	items: RssItem[];
+	/** Epoch ms when these items were fetched. */
+	fetched: number;
+}
+
+interface CacheEntry {
+	feed: RssFeed | null;
+	inflight: Promise<RssFeed | null> | null;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/** The last-fetched feed for a URL (possibly stale), or null if never loaded. */
+export function cachedFeed(url: string): RssFeed | null {
+	return cache.get(url)?.feed ?? null;
+}
+
+/**
+ * Return a feed, fetching only when the cache is missing or older than
+ * `ttlMs`. Concurrent callers for the same URL share one in-flight request.
+ * Never throws: on failure it returns whatever was cached (possibly null).
+ *
+ * When `disabled` is true (the "disable external calls" setting) no request is
+ * made — only an already-cached feed, if any, is returned. Set `force` to
+ * bypass the freshness check for an explicit manual refresh.
+ */
+export async function loadFeed(
+	url: string,
+	opts: { ttlMs: number; disabled?: boolean; force?: boolean } = { ttlMs: 0 },
+): Promise<RssFeed | null> {
+	let entry = cache.get(url);
+	if (!entry) {
+		entry = { feed: null, inflight: null };
+		cache.set(url, entry);
+	}
+	if (opts.disabled) return entry.feed;
+	const fresh =
+		entry.feed && Date.now() - entry.feed.fetched < opts.ttlMs;
+	if (fresh && !opts.force) return entry.feed;
+	if (entry.inflight) return entry.inflight;
+
+	const current = entry;
+	current.inflight = (async () => {
+		try {
+			const res = await requestUrl({ url });
+			const parsed = parseFeed(res.text);
+			// Keep prior items when a fetch returns something unparseable.
+			if (parsed) current.feed = parsed;
+			return current.feed;
+		} catch {
+			// Offline or blocked — keep any prior items.
+			return current.feed;
+		} finally {
+			current.inflight = null;
+		}
+	})();
+	return current.inflight;
+}
+
+/** Drop cached data so the next load refetches. Used when a source URL changes. */
+export function forgetFeed(url: string): void {
+	cache.delete(url);
+}
+
+/** Parse a raw RSS/Atom document into a normalised feed, or null when the text
+ * isn't a recognisable feed. Exported for direct use and testing. */
+export function parseFeed(xml: string): RssFeed | null {
+	const doc = new DOMParser().parseFromString(xml, "text/xml");
+	// A parse error yields a <parsererror> element rather than throwing.
+	if (doc.querySelector("parsererror")) return null;
+
+	const channel = doc.querySelector("channel");
+	const atomFeed = doc.querySelector("feed");
+	const root = channel ?? atomFeed;
+	if (!root) return null;
+
+	const title = text(root.querySelector(":scope > title"));
+	const entries = channel
+		? Array.from(doc.querySelectorAll("item"))
+		: Array.from(doc.querySelectorAll("entry"));
+
+	const items: RssItem[] = entries.map((el) =>
+		channel ? parseRssItem(el) : parseAtomEntry(el),
+	);
+	// Newest first; items with no date sink to the bottom in original order.
+	items.sort((a, b) => (b.published ?? 0) - (a.published ?? 0));
+	return { title, items, fetched: Date.now() };
+}
+
+/** An RSS 2.0 `<item>`. */
+function parseRssItem(el: Element): RssItem {
+	const description = text(el.querySelector("description"));
+	const encoded = text(tagNS(el, "content:encoded"));
+	const body = encoded || description;
+	return {
+		title: text(el.querySelector("title")),
+		link: text(el.querySelector("link")),
+		excerpt: stripHtml(description || encoded),
+		published: parseDate(
+			text(el.querySelector("pubDate")) ||
+				text(tagNS(el, "dc:date")),
+		),
+		image: rssImage(el, body),
+	};
+}
+
+/** An Atom `<entry>`. */
+function parseAtomEntry(el: Element): RssItem {
+	const summary =
+		text(el.querySelector("summary")) || text(el.querySelector("content"));
+	return {
+		title: text(el.querySelector("title")),
+		link: atomLink(el),
+		excerpt: stripHtml(summary),
+		published: parseDate(
+			text(el.querySelector("published")) ||
+				text(el.querySelector("updated")),
+		),
+		image: htmlImage(summary),
+	};
+}
+
+/** Atom links live in <link href> attributes; prefer rel="alternate"/no rel. */
+function atomLink(el: Element): string {
+	const links = Array.from(el.querySelectorAll("link"));
+	const alt =
+		links.find((l) => l.getAttribute("rel") === "alternate") ??
+		links.find((l) => !l.getAttribute("rel")) ??
+		links[0];
+	return alt?.getAttribute("href")?.trim() ?? "";
+}
+
+/** Best-effort thumbnail for an RSS item: media/enclosure elements first, then
+ * the first <img> in the item's HTML body. */
+function rssImage(el: Element, htmlBody: string): string {
+	const mediaContent = el.querySelector("*|content[url]");
+	const mediaThumb = el.querySelector("*|thumbnail[url]");
+	const media = mediaContent ?? mediaThumb;
+	if (media) {
+		const type = media.getAttribute("type") ?? "";
+		const medium = media.getAttribute("medium") ?? "";
+		// media:content may point at video/audio too — only take images.
+		if (!type || type.startsWith("image") || medium === "image") {
+			const url = media.getAttribute("url")?.trim();
+			if (url) return url;
+		}
+	}
+	const enclosure = el.querySelector("enclosure[type^='image']");
+	const enc = enclosure?.getAttribute("url")?.trim();
+	if (enc) return enc;
+	return htmlImage(htmlBody);
+}
+
+/** First <img src> found in a snippet of HTML markup, or "". */
+function htmlImage(html: string): string {
+	const m = /<img[^>]+src\s*=\s*["']([^"']+)["']/i.exec(html);
+	return m ? m[1].trim() : "";
+}
+
+/** Read a namespaced child (e.g. "content:encoded", "dc:date") independent of
+ * how the parser exposes the prefix. */
+function tagNS(el: Element, name: string): Element | null {
+	const direct = el.getElementsByTagName(name);
+	if (direct.length) return direct[0];
+	const local = name.split(":").pop() ?? name;
+	const byLocal = el.getElementsByTagName(local);
+	return byLocal.length ? byLocal[0] : null;
+}
+
+/** Trimmed text content of an element, or "" when null. */
+function text(el: Element | null): string {
+	return el?.textContent?.trim() ?? "";
+}
+
+/** Strip HTML tags and entities down to a single-line plain-text excerpt. */
+function stripHtml(html: string): string {
+	if (!html) return "";
+	const doc = new DOMParser().parseFromString(html, "text/html");
+	return (doc.body.textContent ?? "").replace(/\s+/g, " ").trim();
+}
+
+/** Parse a feed date (RFC 822 or ISO 8601) to epoch ms, or null. */
+function parseDate(raw: string): number | null {
+	if (!raw) return null;
+	const t = Date.parse(raw);
+	return Number.isNaN(t) ? null : t;
+}

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -147,6 +147,12 @@ export const CARD_TEMPLATES: CardTemplate[] = [
 		available: (app) => isDataviewAvailable(app),
 	},
 	{
+		id: "rss",
+		name: "RSS feed",
+		icon: "rss",
+		build: () => ({ kind: "rss", title: "RSS", rss: { sources: [] }, w: 4, h: 5 }),
+	},
+	{
 		id: "leaf",
 		name: "Plugin view (beta)",
 		icon: "layout-panel-left",

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export type CardKind =
 	| "heatmap"
 	| "calculator"
 	| "dataview"
+	| "rss"
 	| "leaf";
 
 /** A single command tile inside a "commands" card. */
@@ -259,6 +260,44 @@ export interface LeafViewConfig {
 	viewType?: string;
 }
 
+/** A single feed a "rss" card can subscribe to. Each source becomes a tab in
+ * the card header; `name` labels the tab (falling back to the feed's own title
+ * when blank) and `url` is the RSS/Atom feed address. */
+export interface RssSource {
+	id: string;
+	/** Tab label; when empty the feed's own <title> is shown instead. */
+	name: string;
+	/** RSS 2.0 or Atom feed URL (http/https). */
+	url: string;
+}
+
+/** How a "rss" card lays out its items. "list" is a title + meta line per item;
+ * "cards" adds an excerpt and (when present) a thumbnail; "compact" is just the
+ * headlines. */
+export type RssLayout = "list" | "cards" | "compact";
+
+/** Per-card configuration for a "rss" card — a lightweight feed reader. All
+ * fields are optional; omitted fields use the defaults noted below. */
+export interface RssConfig {
+	/** The subscribed feeds, one tab each. */
+	sources?: RssSource[];
+	/** Item layout. Default "list". */
+	layout?: RssLayout;
+	/** Auto-refresh interval in minutes. 0 (or omitted → default 30) with 0
+	 * meaning "refresh only when opened / manually". */
+	refreshMin?: number;
+	/** Max items shown per feed. Default 15. */
+	itemLimit?: number;
+	/** Show item thumbnails when the feed provides them (cards layout). Default true. */
+	showImages?: boolean;
+	/** Show a short text excerpt under each item. Default true. */
+	showExcerpt?: boolean;
+	/** Show each item's publish date. Default true. */
+	showDate?: boolean;
+	/** Add a leading "All" tab that merges every source, newest first. Default false. */
+	mergeAll?: boolean;
+}
+
 /** Per-card configuration for a "clock" card. All fields are optional; omitted
  * fields fall back to the defaults that match the original clock behaviour. */
 export interface ClockConfig {
@@ -383,6 +422,8 @@ export interface DashboardCard {
 	calculator?: CalculatorConfig;
 	/** kind === "dataview": the query text and language. */
 	dataview?: DataviewConfig;
+	/** kind === "rss": feed sources, layout and refresh options. */
+	rss?: RssConfig;
 	/** kind === "leaf": the registered view type to host. */
 	leafView?: LeafViewConfig;
 

--- a/styles.css
+++ b/styles.css
@@ -1592,6 +1592,174 @@
 	fill: var(--interactive-accent);
 }
 
+/* RSS feed card */
+.hearth-rss {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+}
+
+/* Tab bar: source tabs (scroll horizontally if they overflow) + a refresh
+ * button pinned to the right. */
+.hearth-rss-tabs {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex: 0 0 auto;
+	margin-bottom: 6px;
+}
+
+.hearth-rss-tablist {
+	display: flex;
+	gap: 4px;
+	overflow-x: auto;
+	scrollbar-width: none;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.hearth-rss-tablist::-webkit-scrollbar {
+	display: none;
+}
+
+.hearth-rss-tab {
+	flex: 0 0 auto;
+	max-width: 140px;
+	padding: 2px 10px;
+	border: none;
+	border-radius: 999px;
+	background: var(--background-modifier-hover);
+	color: var(--text-muted);
+	font-size: 0.78rem;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	cursor: pointer;
+}
+
+.hearth-rss-tab.is-active {
+	background: var(--interactive-accent);
+	color: var(--text-on-accent);
+}
+
+.hearth-rss-refresh {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	padding: 0;
+	border: none;
+	border-radius: 8px;
+	background: transparent;
+	color: var(--text-muted);
+	cursor: pointer;
+}
+
+.hearth-rss-refresh:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.hearth-rss-refresh.is-loading {
+	animation: hearth-rss-spin 0.9s linear infinite;
+}
+
+@keyframes hearth-rss-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.hearth-rss-content {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	overflow-x: hidden;
+	display: flex;
+	flex-direction: column;
+}
+
+/* An item is a clickable row; layout tweaks per view live below. */
+.hearth-rss-item {
+	display: flex;
+	gap: 10px;
+	padding: 6px 4px;
+	border-radius: 8px;
+	cursor: pointer;
+	border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.hearth-rss-item:last-child {
+	border-bottom: none;
+}
+
+.hearth-rss-item:hover {
+	background: var(--background-modifier-hover);
+}
+
+.hearth-rss-main {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
+.hearth-rss-title {
+	color: var(--text-normal);
+	font-size: 0.88rem;
+	font-weight: 600;
+	line-height: 1.25;
+	overflow-wrap: anywhere;
+}
+
+.hearth-rss-excerpt {
+	color: var(--text-muted);
+	font-size: 0.78rem;
+	line-height: 1.3;
+	/* Clamp to two lines so cards stay tidy. */
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.hearth-rss-meta {
+	color: var(--text-faint);
+	font-size: 0.72rem;
+}
+
+.hearth-rss-thumb {
+	flex: 0 0 auto;
+	width: 64px;
+	height: 64px;
+	border-radius: 8px;
+	overflow: hidden;
+	background: var(--background-modifier-hover);
+}
+
+.hearth-rss-thumb img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+/* Compact view: single-line headlines, tighter rows, no images. */
+.hearth-rss-compact .hearth-rss-item {
+	padding: 4px 4px;
+}
+
+.hearth-rss-compact .hearth-rss-title {
+	font-weight: 500;
+	font-size: 0.84rem;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 /* Mini calendar card */
 .hearth-calendar {
 	display: flex;


### PR DESCRIPTION
## What

Adds a new **RSS feed** card type — a lightweight, self-contained feed reader that drops onto any dashboard.

- **Multiple sources, tab switch.** Add one or more RSS/Atom feeds; each becomes a tab in the card header. An optional **"All"** tab merges every source newest-first.
- **Multiple layouts / views.** *List* (title + relative date), *Cards* (excerpt + thumbnail), and *Compact* (single-line headlines).
- **Refresh time settings.** Configurable auto-refresh interval in minutes (0 = only when opened), plus an always-available manual refresh button.
- **Customizable.** Per-feed item cap, and toggles for images, excerpt and date.

## How it works

- New `src/rss.ts` module: fetch + parse (RSS 2.0 and Atom) + an in-memory per-URL cache with a TTL derived from the card's refresh interval.
- Feeds are fetched through Obsidian's `requestUrl` so cross-origin feeds work without CORS issues (same bridge the currency conversion already uses).
- Degrades gracefully offline — the last good items stay on a failed fetch — and honours the existing **"disable external calls"** setting: with it on, no feed request is made and only cached items (if any) show.
- Card refresh is self-contained (its own `registerInterval` + async loads), so it needs no changes to `mountCardBody`.

## Touched files

Follows the standard add-a-card-type flow: `types.ts` (data model + `CardKind`), `rss.ts` (new), `cards.ts` (render), `templates.ts` (Add-card catalogue), `editors.ts` (settings UI), `layout.ts` (import/export sanitizer + round-trip), `locales/en.ts` (strings), `styles.css`, and a `CHANGELOG.md` entry under the open 1.10.0 series.

## Testing

`npm run typecheck`, `npm run lint` (0 errors), `npm test` (70 passing), and `npm run build` all pass. Note: the parser isn't unit-tested because it relies on `DOMParser`, which isn't available in the node/vitest environment (consistent with the other network/DOM cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)