### PR TITLE
fix(cards): hide orphaned file/folder bookmarks

### DIFF
--- a/src/cards.ts
+++ b/src/cards.ts
@@ -1392,13 +1392,25 @@ function renderBookmarks(view: HomeView, body: HTMLElement): void {
 	const items: BookmarkItem[] = [];
 	flattenBookmarks(instance.getBookmarks() ?? [], items);
 
-	if (items.length === 0) {
+	// Obsidian keeps a file/folder bookmark in its store even after the target is
+	// deleted (the entry only goes away if the bookmark itself is removed), but its
+	// native pane hides those orphans. `getBookmarks()` returns the raw store, so we
+	// drop file/folder bookmarks whose target no longer exists to match Obsidian and
+	// avoid rendering dead, unclickable rows (see issue #41).
+	const live = items.filter((item) => {
+		if ((item.type === "file" || item.type === "folder") && item.path) {
+			return view.app.vault.getAbstractFileByPath(item.path) !== null;
+		}
+		return true;
+	});
+
+	if (live.length === 0) {
 		emptyState(body, "bookmark", t().cards.empty.bookmarksEmpty);
 		return;
 	}
 
 	const list = body.createDiv("hearth-list");
-	for (const item of items) {
+	for (const item of live) {
 		const label =
 			item.title ||
 			item.path ||


### PR DESCRIPTION
## What does this PR do?

The bookmarks card was showing dead, unclickable entries for notes that had been deleted.

Root cause: when you delete a bookmarked note inside Obsidian *without* removing the bookmark, Obsidian keeps the entry in its bookmark store (the entry only goes away if the bookmark itself is removed), but its native bookmarks pane hides those orphans. Hearth's card rendered the raw `getBookmarks()` store with no existence check, so the deleted-note bookmarks lingered as rows that couldn't be opened.

The fix filters out `file`/`folder` bookmarks whose `path` no longer resolves via `getAbstractFileByPath`, matching Obsidian's native behavior. `url`, `search`, and `group` items are not file-backed and are left untouched.

## Related issue

Closes #41

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (also: `npm test` → 70 passed, `npm run lint` → 0 errors)
- [ ] I've tested this in an actual vault — not run in a live vault; verified via build + unit tests only. Worth a manual check against the issue's repro before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)