### PR TITLE
fix(settings): isolate section render failures so one bad section can't blank the pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   memory, degrade gracefully offline (the last good items stay), and honour the
   **"disable external calls"** setting — with it on, no feed request is made.
 
+### Fixed
+
+- **A failing settings section no longer blanks the whole settings pane.**
+  Previously, if any part of the settings tab threw while rendering, the entire
+  pane was left empty with nothing to explain why — and, because the tab
+  remembers the last category you opened, it could stay blank on every reopen.
+  Each section (and the tab as a whole) is now isolated: a section that fails to
+  render shows an inline error in its place, logs the underlying error to the
+  developer console, and leaves every other section — and the category ribbon,
+  so you can still switch tabs — working as normal.
+
 ## [1.9.0]
 
 ### Changed

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -190,6 +190,11 @@ export const en = {
 		resetField: "Reset to default",
 		collapseSection: "Collapse section",
 		expandSection: "Expand section",
+		/** Shown in place of a settings section (or tab) whose render threw, so a
+		 * single failing section can no longer blank the whole settings pane. */
+		sectionError: (name: string) => `The "${name}" section couldn't be shown.`,
+		sectionErrorHint:
+			"Open the developer console (Cmd/Ctrl+Option+I) to see the error, then please report it on GitHub. The other settings are unaffected.",
 		/** Category ribbon at the top of the settings tab. */
 		tabs: {
 			appearance: "Appearance",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -107,7 +107,33 @@ export class HomeSettingTab extends PluginSettingTab {
 		this.renderRibbon(containerEl, active);
 
 		const body = containerEl.createDiv("hearth-settings-tabbody");
-		this.renderTab(body, active);
+		// A tab-level backstop: individual sections already isolate their own
+		// failures (see `section`), but the About tab and a couple of bare rows
+		// render straight into the body. Guard here too so a throw anywhere in a
+		// tab shows an inline error rather than a blank pane — and, because the
+		// ribbon above is already drawn, the user can still switch to a working
+		// tab. (A silently-blank settings page is exactly issue #52.)
+		try {
+			this.renderTab(body, active);
+		} catch (err) {
+			body.empty();
+			this.renderError(body, t().settings.tabs[active], err);
+		}
+	}
+
+	/** Render an inline error block in place of content that failed to render,
+	 * and log the real stack to the console so it can be reported. Keeps one
+	 * broken section from blanking the entire settings pane. */
+	private renderError(containerEl: HTMLElement, name: string, err: unknown): void {
+		console.error(`Hearth: the "${name}" settings section failed to render`, err);
+		const box = containerEl.createDiv("hearth-settings-error");
+		setIcon(box.createSpan("hearth-settings-error-icon"), "alert-triangle");
+		const text = box.createDiv("hearth-settings-error-text");
+		text.createDiv({
+			cls: "hearth-settings-error-title",
+			text: t().settings.sectionError(name),
+		});
+		text.createDiv({ cls: "hearth-settings-error-hint", text: t().settings.sectionErrorHint });
 	}
 
 	/** The currently-selected ribbon tab, defaulting to the first. */
@@ -237,7 +263,15 @@ export class HomeSettingTab extends PluginSettingTab {
 		setIcon(chevron, "chevron-down");
 
 		const body = wrap.createDiv("hearth-section-body");
-		render(body);
+		// Isolate each section: a throw while rendering one section shows an inline
+		// error there instead of blanking the whole tab, so its siblings still
+		// render. The heading/fold behaviour below stays intact regardless.
+		try {
+			render(body);
+		} catch (err) {
+			body.empty();
+			this.renderError(body, title, err);
+		}
 
 		// Persist the collapsed state per-section and per-vault via Obsidian's
 		// vault-scoped local storage.

--- a/styles.css
+++ b/styles.css
@@ -928,6 +928,37 @@
 	animation: hearth-tab-fade 140ms ease;
 }
 
+/* Inline error shown when a section (or tab) fails to render, so one broken
+   section can't leave the whole settings pane blank. */
+.hearth-settings-error {
+	display: flex;
+	gap: 10px;
+	align-items: flex-start;
+	padding: 12px 14px;
+	margin: 8px 0;
+	border: 1px solid var(--background-modifier-error);
+	border-radius: 8px;
+	background: var(--background-modifier-error-hover);
+}
+
+.hearth-settings-error-icon {
+	display: inline-flex;
+	color: var(--text-error);
+	flex-shrink: 0;
+}
+
+.hearth-settings-error-title {
+	font-weight: 600;
+	color: var(--text-normal);
+}
+
+.hearth-settings-error-hint {
+	margin-top: 4px;
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+	line-height: 1.4;
+}
+
 @keyframes hearth-tab-fade {
 	from {
 		opacity: 0;


### PR DESCRIPTION
## What does this PR do?

Prevents a single failing settings section from blanking the entire settings pane.

A throw anywhere while rendering the settings tab previously left the whole pane empty with nothing to explain why — and because the active category is remembered in `localStorage`, it could stay blank on every reopen. This is the behaviour reported in #52 (blank on macOS and iPad, no way to reproduce with a different vault's data).

Now each section — and the tab body as a whole — renders inside a guard:

- a section that throws shows an inline error in its place instead of disappearing;
- the underlying error is logged to the developer console so it can be reported;
- sibling sections keep rendering, and the category ribbon (drawn before the guarded body) stays intact, so the user can still switch tabs.

This makes the failure self-diagnosing — a recurrence will name the exact section that's failing — even though the specific trigger on the reporter's vault isn't yet known.

Changed files: `src/settings.ts` (guards + inline error helper), `styles.css` (error block styling), `src/locales/en.ts` (error strings), `CHANGELOG.md`.

## Related issue

Closes #52

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjwoJmH6NAFdYLykjufZKT)_