### PR TITLE
ci(release): enforce that stable is a promotion of its beta-tested build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
       version:
         description: "Version to release (e.g. 1.8.1). Defaults to the manifest matching the tag."
         required: false
+      allow_no_beta:
+        description: "Emergency hotfix ONLY: allow a stable release with no matching x.y.z-beta.* build. Leave false normally."
+        type: boolean
+        default: false
+        required: false
 
 permissions:
   contents: write
@@ -28,6 +33,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history + all tags so the beta-parity guard below can diff the
+          # stable commit against its x.y.z-beta.* tag.
+          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -91,6 +100,43 @@ jobs:
             exit 1
           fi
           echo "Tag matches $file version: $manifest"
+
+      # A stable x.y.z must be the PROMOTION of a beta-tested build, not a fresh
+      # build of whatever is on main now. This is the guard that catches a beta's
+      # un-tested code — a new feature, a refactor — from shipping straight to
+      # every stable user. It enforces that the tagged commit's build inputs
+      # (src/, styles.css, esbuild.config.mjs) are byte-for-byte identical to the
+      # newest x.y.z-beta.* release that preceded it. A version-only promotion
+      # bump (manifest / versions.json / package.json / CHANGELOG) leaves those
+      # untouched, so a correct promotion passes; tagging a diverged main fails.
+      - name: Verify stable is the promotion of its beta-tested build
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          case "$tag" in
+            *-*) echo "Pre-release $tag — beta-parity check does not apply."; exit 0 ;;
+          esac
+          betaTag="$(git tag -l "${tag}-*" | sort -V | tail -n1)"
+          if [ -z "$betaTag" ]; then
+            echo "::error::No ${tag}-beta.* tag exists. A stable release must promote a beta-tested build."
+            echo "Cut ${tag}-beta.N and let it soak first (see RELEASING.md), or — for a genuine"
+            echo "emergency hotfix ONLY — re-run from the Actions tab with allow_no_beta = true."
+            if [ "${{ github.event.inputs.allow_no_beta }}" = "true" ]; then
+              echo "::warning::allow_no_beta set — shipping stable $tag with no beta. Emergency path."
+              exit 0
+            fi
+            exit 1
+          fi
+          if git diff --quiet "$betaTag" HEAD -- src styles.css esbuild.config.mjs; then
+            echo "Stable $tag matches beta-tested $betaTag: src/, styles.css and esbuild.config.mjs are identical."
+          else
+            echo "::error::Stable $tag diverges from its beta $betaTag in build inputs (src/, styles.css or esbuild.config.mjs)."
+            echo "Stable must be the exact code that was beta-tested. Either tag the beta-tested"
+            echo "commit as $tag (a version-only bump is fine), or cut a fresh ${tag}-beta.N, let it"
+            echo "soak, and promote that. See RELEASING.md -> 'Promoting a beta to stable'."
+            echo "--- differing build inputs ($betaTag..HEAD) ---"
+            git --no-pager diff --stat "$betaTag" HEAD -- src styles.css esbuild.config.mjs || true
+            exit 1
+          fi
 
       # Belt-and-braces: even if a bad manifest slipped past CI, never let a
       # pre-release version sit in the store-facing manifest.json.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,19 +66,56 @@ becomes "latest" for all users. Use `1.9.0-beta.4`, not `1.8.1.4-beta`.
 
 ## Cutting a stable release
 
-1. **Bump both store-facing files** — they must match the tag exactly:
+> **Golden rule: a stable `x.y.z` is a _promotion_ of the beta-tested build, not
+> a fresh build of whatever is on `main` now.** The code that ships to every
+> stable user must be the exact code that soaked as `x.y.z-beta.N`. The only
+> things that change on promotion are the version-carrying files
+> (`manifest.json`, `versions.json`, `package.json`) and `CHANGELOG.md` — never
+> `src/`, `styles.css` or `esbuild.config.mjs`.
+>
+> The release workflow **enforces this**: step _"Verify stable is the promotion
+> of its beta-tested build"_ diffs the tagged commit's build inputs against the
+> newest `x.y.z-beta.*` tag and **fails the release** if they differ (or if no
+> such beta exists). This is what stops a beta's un-tested code — a new feature,
+> a refactor — from riding a stable tag straight into the store.
+
+**First, make sure `main` hasn't drifted past the beta.** If commits touching
+`src/` / `styles.css` have landed since the last `x.y.z-beta.N` you shipped,
+those changes were **never beta-tested**. Do **not** promote — cut a fresh beta
+from current `main` (bump `manifest-beta.json`, tag `x.(y+1).0-beta.1` or the
+next `-beta.N`), let it soak, and promote _that_.
+
+To promote:
+
+1. **Check out the beta-tested commit** (the one the final `x.y.z-beta.N` was
+   built from) and bump the store-facing files on top of it — they must match
+   the tag exactly:
    - `manifest.json` → `"version": "1.9.0"`
    - `versions.json` → add `"1.9.0": "<minAppVersion>"`
    - (also bump `package.json` `version` to match, for tooling)
+   A version-only bump like this leaves the build inputs untouched, so the guard
+   passes. **Never** carry along extra `src/`/`styles.css` commits here.
 2. Commit (e.g. `chore: release 1.9.0`).
-3. **Tag and push:**
+3. **Tag and push** — the tag must point at that promotion commit:
    ```sh
    git tag 1.9.0
    git push origin 1.9.0
    ```
-4. The workflow verifies the tag matches `manifest.json` (**fails** on mismatch,
-   so the store never sees *"No release matches your manifest version"*), builds,
-   attaches the assets, and pins the tag as **latest**.
+4. The workflow verifies the tag matches `manifest.json`, confirms beta parity
+   (above), builds, attaches the assets, and pins the tag as **latest**.
+
+> Genuine emergency hotfix with no beta? Run the workflow from the **Actions
+> tab** (`workflow_dispatch`) with `allow_no_beta = true`. This is the only
+> supported way to skip the beta-parity gate, and it's logged as a warning.
+
+## Keep the changelog honest
+
+`CHANGELOG.md`'s newest `## [x.y.z]` entry must describe the version that is
+**actually in flight** — the current beta line (or the stable just cut), not a
+version whose contents aren't locked yet. CI (`verify:manifests`) fails if the
+top entry matches neither `manifest.json` nor the current beta base version.
+File a change under a version only once that version's build is what carries it;
+if you're unsure which release will ship it, it belongs in the current beta line.
 
 ## If something goes out wrong
 

--- a/scripts/verify-manifests.mjs
+++ b/scripts/verify-manifests.mjs
@@ -113,6 +113,29 @@ for (const k of keys) {
 	}
 }
 
+// --- 5. CHANGELOG top entry tracks the in-flight version --------------------
+// The newest documented release must be either the current stable
+// (manifest.json) or the current beta line (manifest-beta.json minus its -pre
+// suffix). This stops changelog entries being filed under a version that isn't
+// the one actually in flight — the label half of shipping the wrong thing. It
+// can't police prose against code; the release workflow's beta-parity guard
+// ("Verify stable is the promotion of its beta-tested build") does that.
+const changelog = readFileSync(join(root, "CHANGELOG.md"), "utf8");
+const topHeading = changelog.match(/^##\s+\[["']?(\d+\.\d+\.\d+)["']?\]/m);
+if (!topHeading) {
+	fail(`CHANGELOG.md has no top-most "## [x.y.z]" release heading.`);
+} else {
+	const top = topHeading[1];
+	const betaBase = String(beta.version).split("-")[0];
+	if (top !== manifest.version && top !== betaBase) {
+		fail(
+			`CHANGELOG.md's newest entry [${top}] is neither the stable manifest ` +
+				`version (${manifest.version}) nor the current beta line (${betaBase}). ` +
+				`Document changes under the version actually in flight — see RELEASING.md.`,
+		);
+	}
+}
+
 if (errors.length) {
 	for (const e of errors) console.error(`::error::${e}`);
 	console.error(`\n${errors.length} manifest/version problem(s) — see RELEASING.md.`);


### PR DESCRIPTION
Prevents the failure mode we just hit: a stable `x.y.z` built from a `main` that had drifted past the last published `x.y.z-beta.N`, so un-beta-tested code (a whole new card, a core refactor) shipped straight to every stable user.

## What it does

**`release.yml` — new step "Verify stable is the promotion of its beta-tested build"**
For a stable tag, it diffs the tagged commit's build inputs (`src/`, `styles.css`, `esbuild.config.mjs`) against the newest `x.y.z-beta.*` tag and **fails the release** if they differ — or if no such beta exists.
- A version-only promotion bump (`manifest.json` / `versions.json` / `package.json` / `CHANGELOG.md`) leaves the build inputs untouched, so a correct promotion passes.
- Checkout switched to `fetch-depth: 0` so the beta tag is available to diff.
- New `workflow_dispatch` input `allow_no_beta` — an audited escape hatch for genuine emergency hotfixes (logged as a warning).

**`scripts/verify-manifests.mjs` — CHANGELOG label guard**
CI fails if the changelog's newest `## [x.y.z]` entry matches neither the stable manifest nor the current beta line, so entries can't be filed under a version that isn't in flight.

**`RELEASING.md`**
New "promote, don't rebuild" golden rule + checklist, a "check `main` hasn't drifted past the beta" step, the emergency-hotfix path, and a "Keep the changelog honest" section.

## Verified locally
- Guard **fails** on the bad case (tagging `main`/`716bf86` as stable → `src/` + `styles.css` diverge from beta `3c9a159`).
- Guard **passes** on a clean version-only promotion (build inputs byte-identical to the beta).
- `verify:manifests` passes on the current tree; both workflow YAMLs parse.

No product-code or manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QToA9AHHqFT49HUpAnCsph)_