### PR TITLE
Add global card corner radius setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
+- **Card corner radius setting.** A global **Card corner radius** slider
+  (Settings → Dashboard) controls how rounded card corners are, from the
+  default 14 px down to sharp 0 px corners. Merged-together cards still flatten
+  their touching corners, and the shared frosted-glass layer follows the same
+  radius so nothing seams.
 - **RSS feed card.** A lightweight, self-contained feed reader you can drop on
   any dashboard. Add one or more RSS/Atom feeds — each becomes a tab in the card
   header — with an optional combined **"All"** tab that merges every source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
-- **Card corner radius setting.** A global **Card corner radius** slider
-  (Settings → Dashboard) controls how rounded card corners are, from the
-  default 14 px down to sharp 0 px corners. Merged-together cards still flatten
-  their touching corners, and the shared frosted-glass layer follows the same
-  radius so nothing seams.
+- **Card corner radius setting.** A **Card corner radius** slider controls how
+  rounded card corners are, from the default 14 px down to sharp 0 px corners,
+  at both global (Settings → Dashboard) and per-dashboard (dashboard settings)
+  levels. Merged-together cards still flatten their touching corners, and the
+  shared frosted-glass layer follows the same radius so nothing seams.
 - **RSS feed card.** A lightweight, self-contained feed reader you can drop on
   any dashboard. Add one or more RSS/Atom feeds — each becomes a tab in the card
   header — with an optional combined **"All"** tab that merges every source

--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ toolbar; configure each one from the card itself (title, content, colors, size).
 - **Card blur (frosted glass)** — blur the dashboard behind translucent cards
   for a frosted-glass look, at global, per-dashboard and per-card levels. On by
   default for fresh installs; merged cards blur as one seamless surface.
+- **Card corner radius** — a global **Card corner radius** slider (Settings →
+  Dashboard) controls how rounded card corners are, from the default 14 px down
+  to sharp 0 px corners. Merged-together cards still flatten their touching
+  corners as usual, and the frosted-glass layer follows the same radius.
 
 ## Mobile
 

--- a/README.md
+++ b/README.md
@@ -359,10 +359,11 @@ toolbar; configure each one from the card itself (title, content, colors, size).
 - **Card blur (frosted glass)** — blur the dashboard behind translucent cards
   for a frosted-glass look, at global, per-dashboard and per-card levels. On by
   default for fresh installs; merged cards blur as one seamless surface.
-- **Card corner radius** — a global **Card corner radius** slider (Settings →
-  Dashboard) controls how rounded card corners are, from the default 14 px down
-  to sharp 0 px corners. Merged-together cards still flatten their touching
-  corners as usual, and the frosted-glass layer follows the same radius.
+- **Card corner radius** — a **Card corner radius** slider controls how rounded
+  card corners are, from the default 14 px down to sharp 0 px corners, at global
+  (Settings → Dashboard) and per-dashboard levels. Merged-together cards still
+  flatten their touching corners as usual, and the frosted-glass layer follows
+  the same radius.
 
 ## Mobile
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -27,6 +27,7 @@ import {
 	cloneCard,
 	type DashboardCard,
 	effectiveCardOpacity,
+	effectiveCardRadius,
 	effectiveColumns,
 	effectiveFitToPage,
 	effectiveMaxWidth,
@@ -82,6 +83,10 @@ export function renderDashboard(
 	grid.toggleClass("is-arranging", view.arrangeMode);
 	// Board-level defaults; per-card overrides are set in the render loop below.
 	grid.style.setProperty("--card-opacity", String(effectiveCardOpacity(s)));
+	// Board-wide corner radius (px). Every card reads this via CSS; the frost
+	// mask in grid.ts reads the resolved value back off the grid so its rounding
+	// matches. Merged-edge corners still flatten to 0 regardless (see styles.css).
+	grid.style.setProperty("--hearth-card-radius", `${effectiveCardRadius(s)}px`);
 	const fit = effectiveFitToPage(s);
 	// In fit-to-page mode the board is locked to one screen, so leave the
 	// min-height to CSS (which clips the overflow). Otherwise grow the board

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -4,6 +4,7 @@ import {
 	type BackgroundConfig,
 	type BackgroundKind,
 	type Dashboard,
+	CARD_RADIUS_MAX,
 	DEFAULT_SETTINGS,
 	newDashboardId,
 	cloneCard,
@@ -128,6 +129,7 @@ function showDashboardMenu(view: HomeView, dash: Dashboard, evt: MouseEvent): vo
 				if (dash.showSearch != null) copy.showSearch = dash.showSearch;
 				if (dash.cardOpacity != null) copy.cardOpacity = dash.cardOpacity;
 				if (dash.cardBlur != null) copy.cardBlur = dash.cardBlur;
+				if (dash.cardRadius != null) copy.cardRadius = dash.cardRadius;
 				if (dash.background) copy.background = { ...dash.background };
 				const i = s.dashboards.findIndex((d) => d.id === dash.id);
 				s.dashboards.splice(i + 1, 0, copy);
@@ -291,6 +293,22 @@ class DashboardSettingsModal extends Modal {
 			1,
 			(v) => {
 				dash.cardBlur = v;
+				this.commit();
+			},
+		);
+
+		// Corner radius is capped at the design baseline (CARD_RADIUS_MAX): only
+		// sharper corners are offered, since rounding beyond it was never tuned for.
+		this.overrideSlider(
+			contentEl,
+			t().dashboards.modal.cardRadius,
+			dash.cardRadius,
+			s.cardRadius,
+			0,
+			CARD_RADIUS_MAX,
+			1,
+			(v) => {
+				dash.cardRadius = v;
 				this.commit();
 			},
 		);

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -686,26 +686,34 @@ export function applyEdgeMerging(gridEl: HTMLElement): void {
 	updateFrostLayers(gridEl);
 }
 
-/** Card corner radius (px), matching `border-radius` in styles.css. Merged
- *  corners flatten to 0 (the .merge-tl/tr/bl/br rules), so the frost mask must
- *  round the same corners the cards do. */
-const CARD_RADIUS = 14;
+/** Fallback card corner radius (px), matching the `border-radius` fallback in
+ *  styles.css, used when the board hasn't set --hearth-card-radius. */
+const CARD_RADIUS_FALLBACK = 14;
+
+/** Resolve the board's live corner radius (px) from the --hearth-card-radius
+ *  CSS variable set by renderDashboard, so the frost mask rounds by exactly the
+ *  same amount the cards do. Falls back to the design baseline if unset. */
+function resolveGridRadius(gridEl: HTMLElement): number {
+	const raw = getComputedStyle(gridEl).getPropertyValue("--hearth-card-radius");
+	const n = parseFloat(raw);
+	return Number.isFinite(n) && n >= 0 ? n : CARD_RADIUS_FALLBACK;
+}
 
 /** SVG path for one card's border-box silhouette, rounding each corner to
- *  CARD_RADIUS unless that corner is merged flat. A zero-radius elliptical arc
+ *  `radius` unless that corner is merged flat. A zero-radius elliptical arc
  *  renders as a straight line to its endpoint, so all four arcs are always
  *  emitted regardless of merge state. Coordinates are in the grid's own pixel
  *  space (offset* is relative to the positioned grid). */
-function cardSilhouettePath(el: HTMLElement): string {
+function cardSilhouettePath(el: HTMLElement, radius: number): string {
 	const x = el.offsetLeft;
 	const y = el.offsetTop;
 	const w = el.offsetWidth;
 	const h = el.offsetHeight;
 	const cl = el.classList;
-	const tl = cl.contains("merge-tl") ? 0 : CARD_RADIUS;
-	const tr = cl.contains("merge-tr") ? 0 : CARD_RADIUS;
-	const br = cl.contains("merge-br") ? 0 : CARD_RADIUS;
-	const bl = cl.contains("merge-bl") ? 0 : CARD_RADIUS;
+	const tl = cl.contains("merge-tl") ? 0 : radius;
+	const tr = cl.contains("merge-tr") ? 0 : radius;
+	const br = cl.contains("merge-br") ? 0 : radius;
+	const bl = cl.contains("merge-bl") ? 0 : radius;
 	return (
 		`M${x + tl},${y}` +
 		`L${x + w - tr},${y}A${tr},${tr} 0 0 1 ${x + w},${y + tr}` +
@@ -750,6 +758,7 @@ export function updateFrostLayers(gridEl: HTMLElement): void {
 
 	const w = gridEl.clientWidth;
 	const h = gridEl.clientHeight;
+	const radius = resolveGridRadius(gridEl);
 	const seen = new Set<string>();
 	for (const [blur, group] of byBlur) {
 		seen.add(blur);
@@ -764,7 +773,7 @@ export function updateFrostLayers(gridEl: HTMLElement): void {
 		layer.style.setProperty("backdrop-filter", filter);
 		layer.style.setProperty("-webkit-backdrop-filter", filter);
 		const paths = group
-			.map((c) => `<path d="${cardSilhouettePath(c)}" fill="#fff"/>`)
+			.map((c) => `<path d="${cardSilhouettePath(c, radius)}" fill="#fff"/>`)
 			.join("");
 		const svg =
 			`<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" ` +

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -58,6 +58,7 @@ const RANGE = {
 	cardW: { min: 1, max: 16 },
 	cardH: { min: 1, max: 60 },
 	cardBlur: { min: 0, max: 24 },
+	cardRadius: { min: 0, max: 14 },
 };
 
 const CARD_KINDS: CardKind[] = [
@@ -139,6 +140,7 @@ export function exportSettings(s: HomeSettings): string {
 		compact: s.compact,
 		cardOpacity: s.cardOpacity,
 		cardBlur: s.cardBlur,
+		cardRadius: s.cardRadius,
 
 		// Search filters
 		hiddenFilters: s.hiddenFilters,
@@ -924,6 +926,14 @@ function applySettings(s: HomeSettings, data: Record<string, unknown>): void {
 			RANGE.cardBlur.min,
 			RANGE.cardBlur.max,
 			s.cardBlur,
+		);
+	}
+	if (typeof data.cardRadius === "number") {
+		s.cardRadius = clampNum(
+			data.cardRadius,
+			RANGE.cardRadius.min,
+			RANGE.cardRadius.max,
+			s.cardRadius,
 		);
 	}
 

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -696,6 +696,14 @@ function sanitizeDashboard(
 			s.cardBlur,
 		);
 	}
+	if (typeof r.cardRadius === "number") {
+		dash.cardRadius = clampNum(
+			r.cardRadius,
+			RANGE.cardRadius.min,
+			RANGE.cardRadius.max,
+			s.cardRadius,
+		);
+	}
 	const bg = sanitizeBackground(r.background);
 	if (bg) dash.background = bg;
 	return dash;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -392,6 +392,9 @@ export const en = {
 			cardBlur: "Card blur",
 			cardBlurDesc:
 				"Frosted-glass blur behind translucent cards. Needs card opacity below 100% to show. 0 = off.",
+			cardRadius: "Card corner radius",
+			cardRadiusDesc:
+				"How rounded card corners are, in pixels. 14 is the default; lower makes corners sharper.",
 			cards: "Cards",
 			cardsDesc:
 				"Add and configure cards on the dashboard itself: open the home view, " +

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -157,6 +157,7 @@ export const en = {
 			fitOptionScroll: "Allow scrolling",
 			cardOpacity: "Card opacity",
 			cardBlur: "Card blur",
+			cardRadius: "Card corner radius",
 			done: "Done",
 			overriding: "Overriding the global default.",
 			usingGlobal: (value: number | string) =>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,7 +16,8 @@ type NumericSettingKey =
 	| "backgroundOpacity"
 	| "backgroundBlur"
 	| "cardOpacity"
-	| "cardBlur";
+	| "cardBlur"
+	| "cardRadius";
 
 /** Keys of HomeSettings whose default lives in DEFAULT_SETTINGS as a string and
  * would be awkward to reconstruct by hand (frontmatter field names, the search
@@ -906,6 +907,22 @@ export class HomeSettingTab extends PluginSettingTab {
 					await this.save();
 				});
 			this.addSliderReset(cardBlur, sl, "cardBlur");
+		});
+
+		const cardRadius = new Setting(containerEl)
+			.setName(t().settings.dashboard.cardRadius)
+			.setDesc(t().settings.dashboard.cardRadiusDesc);
+		cardRadius.addSlider((sl) => {
+			// Capped at the design baseline (14): only sharper corners are offered,
+			// since rounding beyond it was never tuned for.
+			sl.setLimits(0, DEFAULT_SETTINGS.cardRadius, 1)
+				.setValue(s.cardRadius)
+				.setDynamicTooltip()
+				.onChange(async (v) => {
+					s.cardRadius = v;
+					await this.save();
+				});
+			this.addSliderReset(cardRadius, sl, "cardRadius");
 		});
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -600,6 +600,10 @@ export interface HomeSettings {
 	/** Card surface backdrop blur in pixels — the frosted-glass strength behind
 	 * translucent cards. 0 = no blur. */
 	cardBlur: number;
+	/** Card corner radius in pixels. Ranges from 0 (sharp corners) up to the
+	 * design default of 14; larger is disallowed so nothing that assumes the
+	 * baseline rounding (merged-edge sharpening, the frost mask) breaks. */
+	cardRadius: number;
 
 	// ---- Search filters ----
 	/** Group ids the user has hidden from the auto-detected filter row. */
@@ -677,6 +681,9 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	// Frosted glass on by default: a translucent card surface with a gentle blur
 	// of the background behind it. Pairs with the 0.5 opacity above.
 	cardBlur: 7,
+	// The design baseline corner radius; also the maximum (only sharper is
+	// allowed) so it matches the hardcoded 14 the layout was tuned around.
+	cardRadius: 14,
 
 	hiddenFilters: [],
 
@@ -864,6 +871,21 @@ export function resolveCardBlur(s: HomeSettings, card: DashboardCard): number {
 	return typeof v === "number" && !Number.isNaN(v) ? Math.max(0, Math.min(40, v)) : 0;
 }
 
+/** The design baseline card corner radius (px). Also the maximum the setting
+ * allows: rounding beyond this was never tuned for (merged-edge sharpening, the
+ * frosted-glass mask, arrange outlines) so only sharper is offered. */
+export const CARD_RADIUS_MAX = 14;
+
+/** Effective card corner radius (px) for the dashboard, clamped to
+ * [0, CARD_RADIUS_MAX]. Applied board-wide via the --hearth-card-radius CSS
+ * variable so every card (and the frost mask) rounds by the same amount. */
+export function effectiveCardRadius(s: HomeSettings): number {
+	const v = s.cardRadius;
+	return typeof v === "number" && !Number.isNaN(v)
+		? Math.max(0, Math.min(CARD_RADIUS_MAX, v))
+		: CARD_RADIUS_MAX;
+}
+
 /** Remove a card from whichever list holds it (a board or the pinned set). */
 export function removeCard(s: HomeSettings, card: DashboardCard): void {
 	for (const d of s.dashboards) {
@@ -966,6 +988,7 @@ export function migrateSettings(s: HomeSettings, raw: Record<string, unknown>): 
 	if (typeof s.rowHeight !== "number" || s.rowHeight <= 0) s.rowHeight = 92;
 	if (typeof s.cardOpacity !== "number") s.cardOpacity = 0.5;
 	if (typeof s.cardBlur !== "number") s.cardBlur = 7;
+	if (typeof s.cardRadius !== "number") s.cardRadius = CARD_RADIUS_MAX;
 	if (typeof s.backgroundOpacity !== "number") s.backgroundOpacity = 0.35;
 	if (typeof s.backgroundBlur !== "number") s.backgroundBlur = 2;
 	// Fit-to-page is the default for fresh installs; existing users keep their

--- a/src/types.ts
+++ b/src/types.ts
@@ -540,6 +540,8 @@ export interface Dashboard {
 	/** Override the card surface backdrop blur (px) for this board (undefined =
 	 * global). */
 	cardBlur?: number;
+	/** Override the card corner radius (px) for this board (undefined = global). */
+	cardRadius?: number;
 	/** Show the dashboard search/command section (undefined = visible). */
 	showSearch?: boolean;
 }
@@ -876,11 +878,12 @@ export function resolveCardBlur(s: HomeSettings, card: DashboardCard): number {
  * frosted-glass mask, arrange outlines) so only sharper is offered. */
 export const CARD_RADIUS_MAX = 14;
 
-/** Effective card corner radius (px) for the dashboard, clamped to
- * [0, CARD_RADIUS_MAX]. Applied board-wide via the --hearth-card-radius CSS
- * variable so every card (and the frost mask) rounds by the same amount. */
+/** Effective card corner radius (px) for the active board (per-dashboard
+ * override or global), clamped to [0, CARD_RADIUS_MAX]. Applied board-wide via
+ * the --hearth-card-radius CSS variable so every card (and the frost mask)
+ * rounds by the same amount. */
 export function effectiveCardRadius(s: HomeSettings): number {
-	const v = s.cardRadius;
+	const v = activeDashboard(s).cardRadius ?? s.cardRadius;
 	return typeof v === "number" && !Number.isNaN(v)
 		? Math.max(0, Math.min(CARD_RADIUS_MAX, v))
 		: CARD_RADIUS_MAX;

--- a/styles.css
+++ b/styles.css
@@ -407,7 +407,9 @@
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
-	border-radius: 14px;
+	/* --hearth-card-radius (px) is set per-board by renderDashboard; the 14px
+	 * fallback keeps the design baseline when it isn't set. */
+	border-radius: var(--hearth-card-radius, 14px);
 	border: 1px solid var(--background-modifier-border);
 	/* --card-opacity (0..1) tints the card surface without dimming content. */
 	background: color-mix(
@@ -2379,7 +2381,7 @@
 	position: absolute;
 	inset: 0;
 	border: 1px dashed var(--interactive-accent);
-	border-radius: 14px;
+	border-radius: var(--hearth-card-radius, 14px);
 	opacity: 0.5;
 	pointer-events: none;
 }
@@ -2411,7 +2413,7 @@
 	background: color-mix(in srgb, var(--background-primary) 88%, transparent);
 	backdrop-filter: blur(6px);
 	border-bottom: 1px solid var(--background-modifier-border);
-	border-radius: 14px 14px 0 0;
+	border-radius: var(--hearth-card-radius, 14px) var(--hearth-card-radius, 14px) 0 0;
 }
 
 .hearth-card-title-input {


### PR DESCRIPTION
## What does this PR do?

Adds a global **Card corner radius** slider (Settings → Dashboard) that controls how rounded dashboard cards are, from the design default of **14 px** down to sharp **0 px** corners.

Rounding *beyond* 14 is intentionally not offered — the layout (merged-edge sharpening, the frosted-glass mask, arrange outlines) was only ever tuned around that baseline, so allowing rounder corners risked visual breakage. Sharper is safe.

How it works:
- Applied board-wide via a new `--hearth-card-radius` CSS variable set on the grid by `renderDashboard` (same mechanism as the existing card-opacity setting).
- `styles.css` reads it (with a `14px` fallback) in the three places that hardcoded 14: the card, the arrange-mode outline, and the editing header.
- The shared frosted-glass mask in `grid.ts` reads the resolved value back off the grid so its silhouette rounding always matches the cards — otherwise a custom radius would leave a seam between a card edge and its frost.
- Merged-edge corners still flatten to 0 as before, layered on top of whatever radius is chosen.
- Persisted as a global setting with a migration back-fill, clamped to `[0, 14]`, and round-tripped through settings export/import.

## Related issue

<!-- N/A -->

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015yXCY6cUCYt2Fcu324VQg5)_