### PR TITLE
fix(settings): guard entire display() so the pane can never be silently blank; cut 1.11.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,13 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   Previously, if any part of the settings tab threw while rendering, the entire
   pane was left empty with nothing to explain why — and, because the tab
   remembers the last category you opened, it could stay blank on every reopen.
-  Each section (and the tab as a whole) is now isolated: a section that fails to
-  render shows an inline error in its place, logs the underlying error to the
-  developer console, and leaves every other section — and the category ribbon,
-  so you can still switch tabs — working as normal.
+  The **entire** settings render is now guarded — each section, each tab, and
+  the surrounding ribbon/datalist build — so a failure anywhere shows an inline
+  error in its place and logs the underlying error to the developer console
+  (including when Obsidian 1.13 renders settings in a separate window, whose
+  console is easy to miss), instead of a silent blank pane. Whatever still
+  works — sibling sections and the category ribbon — keeps working so you can
+  navigate.
 - **Orphaned file/folder bookmarks no longer linger in the Bookmarks card.**
   Obsidian keeps a file/folder bookmark in its store after the target note is
   deleted, and its native bookmarks pane hides those orphans; the Bookmarks card

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "1.11.0-beta.1",
+	"version": "1.11.0-beta.2",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -98,26 +98,41 @@ export class HomeSettingTab extends PluginSettingTab {
 		containerEl.empty();
 		containerEl.addClass("hearth-settings");
 
-		this.fileDatalist(containerEl);
-
-		// A ribbon of category tabs sits pinned at the top; only the active tab's
-		// sections render below it, keeping a long settings panel navigable. The
-		// active tab persists per-vault in localStorage.
-		const active = this.activeTab();
-		this.renderRibbon(containerEl, active);
-
-		const body = containerEl.createDiv("hearth-settings-tabbody");
-		// A tab-level backstop: individual sections already isolate their own
-		// failures (see `section`), but the About tab and a couple of bare rows
-		// render straight into the body. Guard here too so a throw anywhere in a
-		// tab shows an inline error rather than a blank pane — and, because the
-		// ribbon above is already drawn, the user can still switch to a working
-		// tab. (A silently-blank settings page is exactly issue #52.)
+		// Whole-pane backstop. #52 reports a completely blank settings pane — no
+		// ribbon, no error in the (main-window) console — for some users on
+		// Obsidian 1.13, which renders settings in a *separate window*. A throw
+		// anywhere in the build (even before the ribbon, e.g. in `fileDatalist` or
+		// `activeTab`) would blank everything, and its error lands in that other
+		// window's console where it's easy to miss. Guard the entire build so the
+		// pane can never be silently blank: on failure, show an inline error and
+		// log the real stack (to whichever console this window uses).
 		try {
-			this.renderTab(body, active);
+			this.fileDatalist(containerEl);
+
+			// A ribbon of category tabs sits pinned at the top; only the active
+			// tab's sections render below it, keeping a long settings panel
+			// navigable. The active tab persists per-vault in localStorage.
+			const active = this.activeTab();
+			this.renderRibbon(containerEl, active);
+
+			const body = containerEl.createDiv("hearth-settings-tabbody");
+			// A tab-level backstop nested inside: individual sections already
+			// isolate their own failures (see `section`), but the About tab and a
+			// couple of bare rows render straight into the body. Guard here too so
+			// a throw in a tab shows an inline error rather than a blank pane —
+			// and, because the ribbon above is already drawn, the user can still
+			// switch to a working tab.
+			try {
+				this.renderTab(body, active);
+			} catch (err) {
+				body.empty();
+				this.renderError(body, t().settings.tabs[active], err);
+			}
 		} catch (err) {
-			body.empty();
-			this.renderError(body, t().settings.tabs[active], err);
+			// The ribbon/datalist itself failed to build. Append the error rather
+			// than empty()-ing, so any partially-drawn ribbon that survived still
+			// lets the user navigate.
+			this.renderError(containerEl, "Hearth", err);
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

Extends the settings render guard and cuts the next beta for testing on #52.

The previous hardening (shipped in 1.11.0-beta.1) only wrapped `renderTab`. But #52 reports a **completely blank** settings pane — no ribbon at all, and **no error in the main-window console** — for users on **Obsidian 1.13**, which renders the settings pane in a *separate window*. A throw *before* the ribbon is built (e.g. in `fileDatalist` or `activeTab`) blanks everything, and its stack lands in that other window's console where it's easy to miss — which is why beta.1 appeared to do nothing.

This wraps the **entire** `display()` build (datalist, ribbon, and each tab/section), so the pane can never be silently blank: any failure now shows an inline error and logs the real stack. Whatever still renders — sibling sections and the category ribbon — keeps working so the user can navigate.

Also bumps `manifest-beta.json` to `1.11.0-beta.2` so BRAT testers on #52 can verify (per `RELEASING.md`, `manifest.json` is untouched and stays at stable `1.10.0`).

Changed files: `src/settings.ts` (whole-`display()` guard), `manifest-beta.json` (→ `1.11.0-beta.2`), `CHANGELOG.md`.

## Related issue

Refs #52

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] `npm run verify:manifests` passes (beta 1.11.0-beta.2 ahead of stable 1.10.0)
- [ ] I've tested this in an actual vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjwoJmH6NAFdYLykjufZKT)_