### PR TITLE
fix(settings): render the pane via the 1.13 settings API so it can't be skipped; cut 1.11.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **Settings pane no longer opens blank on Obsidian 1.13.** Obsidian 1.13
+  rebuilt the settings window around a new declarative settings API, and when
+  it takes that path for a tab it never calls the plugin's legacy `display()`
+  renderer — on affected installs (reported on macOS and iPad, #52) Hearth's
+  settings therefore came up completely empty, with no error anywhere, ever
+  since the category-ribbon redesign. The tab now registers its pane through
+  the new API's render hook, so Obsidian 1.13+ renders it on the declarative
+  path while older Obsidian versions keep using `display()` — the same UI
+  either way. A temporary console line names which path rendered, to confirm
+  the diagnosis on affected machines.
 - **A failing settings section no longer blanks the whole settings pane.**
   Previously, if any part of the settings tab threw while rendering, the entire
   pane was left empty with nothing to explain why — and, because the tab

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "1.11.0-beta.2",
+	"version": "1.11.0-beta.3",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { type App, type ButtonComponent, Notice, Platform, PluginSettingTab, setIcon, Setting, type SliderComponent, type TextComponent, TFile } from "obsidian";
+import { type App, type ButtonComponent, Notice, Platform, PluginSettingTab, setIcon, Setting, type SettingDefinitionItem, type SliderComponent, type TextComponent, TFile } from "obsidian";
 import type HearthPlugin from "./main";
 import { FILE_TYPE_GROUPS, fileTypeLabel } from "./filetypes";
 import { CommandPickerModal } from "./pickers";
@@ -93,8 +93,69 @@ export class HomeSettingTab extends PluginSettingTab {
 		new Notice(frag, 10000);
 	}
 
+	/** Where the pane last rendered: the declarative host row on Obsidian
+	 * 1.13+, `containerEl` on the legacy path. Internal re-renders (ribbon
+	 * clicks, list mutations) must target this element — on 1.13 `containerEl`
+	 * is never attached, so rendering into it would silently go nowhere. */
+	private renderTarget: HTMLElement | null = null;
+
+	/**
+	 * Obsidian 1.13 reworked the settings modal around declarative setting
+	 * definitions; when a tab's definitions are non-empty, the legacy
+	 * `display()` is never called. On affected installs (#52) the modal took
+	 * that path for this tab, so the pane stayed completely blank — no error,
+	 * and no guard inside display() could ever run. Registering the whole pane
+	 * as a single self-rendered definition makes the tab render on the new
+	 * pipeline; older Obsidian versions never call this and keep using
+	 * `display()`. Same builder either way.
+	 */
+	getSettingDefinitions(): SettingDefinitionItem[] {
+		return [
+			{
+				name: this.plugin.manifest.name,
+				// The pane manages its own layout and content; keep the host
+				// row out of the 1.13 settings search.
+				searchable: false,
+				render: (setting: Setting) => {
+					const host = setting.settingEl;
+					// Drop the empty name/desc/control skeleton and the
+					// setting-row flex layout; the pane is a plain block.
+					host.empty();
+					host.addClass("hearth-settings-host");
+					this.renderTarget = host;
+					// Temporary #52 diagnostic: names the render path in the
+					// console of whichever window hosts settings. Remove once
+					// the blank-pane report is confirmed fixed.
+					console.warn(
+						`Hearth ${this.plugin.manifest.version}: rendering settings via setting definitions (Obsidian 1.13+)`,
+					);
+					this.renderInto(host);
+					return () => {
+						if (this.renderTarget === host) this.renderTarget = null;
+					};
+				},
+			},
+		];
+	}
+
 	display(): void {
-		const { containerEl } = this;
+		this.renderTarget = this.containerEl;
+		// Temporary #52 diagnostic — see getSettingDefinitions above.
+		console.warn(
+			`Hearth ${this.plugin.manifest.version}: rendering settings via legacy display()`,
+		);
+		this.renderInto(this.containerEl);
+	}
+
+	/** Re-render the pane in place after a state change (tab switch, list
+	 * mutation, import) — into whichever element the pane currently lives in. */
+	private rerender(): void {
+		this.renderInto(this.renderTarget ?? this.containerEl);
+	}
+
+	/** Build the full settings pane into `containerEl`, shared by both render
+	 * paths (legacy `display()` and the 1.13 setting-definition host). */
+	private renderInto(containerEl: HTMLElement): void {
 		containerEl.empty();
 		containerEl.addClass("hearth-settings");
 
@@ -175,7 +236,7 @@ export class HomeSettingTab extends PluginSettingTab {
 			btn.createSpan({ cls: "hearth-ribbon-tab-label", text: label });
 			btn.addEventListener("click", () => {
 				this.app.saveLocalStorage(ACTIVE_TAB_KEY, tab.id);
-				this.display();
+				this.rerender();
 			});
 		}
 	}
@@ -498,7 +559,7 @@ export class HomeSettingTab extends PluginSettingTab {
 				d.setValue(s.backgroundKind).onChange((v) => {
 					s.backgroundKind = v as BackgroundKind;
 					void this.save();
-					this.display();
+					this.rerender();
 				});
 			});
 
@@ -660,7 +721,7 @@ export class HomeSettingTab extends PluginSettingTab {
 					// switching kinds.
 					btn.target = "";
 					void this.save();
-					this.display();
+					this.rerender();
 				});
 			});
 			const currentTarget = btn.target ?? "";
@@ -680,7 +741,7 @@ export class HomeSettingTab extends PluginSettingTab {
 							btn.target = command.id;
 							if (!btn.label.trim()) btn.label = command.name;
 							void this.save();
-							this.display();
+							this.rerender();
 						}).open();
 					});
 				});
@@ -718,7 +779,7 @@ export class HomeSettingTab extends PluginSettingTab {
 					.onClick(async () => {
 						buttons.splice(index, 1);
 						await this.save();
-						this.display();
+						this.rerender();
 					}),
 			);
 		});
@@ -737,7 +798,7 @@ export class HomeSettingTab extends PluginSettingTab {
 						target: "",
 					});
 					await this.save();
-					this.display();
+					this.rerender();
 				}),
 			)
 			.addExtraButton((b) =>
@@ -747,7 +808,7 @@ export class HomeSettingTab extends PluginSettingTab {
 					.onClick(async () => {
 						s.mobileActionButtons = defaultMobileActionButtons();
 						await this.save();
-						this.display();
+						this.rerender();
 					}),
 			);
 	}
@@ -758,7 +819,7 @@ export class HomeSettingTab extends PluginSettingTab {
 		const [item] = arr.splice(from, 1);
 		arr.splice(to, 0, item);
 		void this.save();
-		this.display();
+		this.rerender();
 	}
 
 	// ---- Tasks / TaskNotes ------------------------------------------------
@@ -1040,7 +1101,7 @@ export class HomeSettingTab extends PluginSettingTab {
 					return;
 				}
 				void this.save();
-				this.display();
+				this.rerender();
 				new Notice(opts.imported);
 			},
 		});

--- a/styles.css
+++ b/styles.css
@@ -861,6 +861,16 @@
 	border-bottom-color: transparent;
 }
 
+/* On Obsidian 1.13+ the whole pane is hosted inside a single declarative
+   setting row (see HomeSettingTab.getSettingDefinitions); strip the row's
+   flex layout and separators so the pane lays out as a plain block, exactly
+   as it does under the legacy display() path. */
+.setting-item.hearth-settings-host {
+	display: block;
+	border: none;
+	padding: 0;
+}
+
 /* ---- Settings tab: category ribbon ----------------------------------
    A row of tabs pinned to the top of the settings pane; clicking one shows
    only that category's sections in the body below. */


### PR DESCRIPTION
## What does this PR do?

Fixes the blank settings pane from #52 at its actual root cause and bumps `manifest-beta.json` to **1.11.0-beta.3** for BRAT testing.

**Root cause:** Obsidian 1.13 rebuilt the settings window around a declarative settings API. Per the official 1.13.1 typings, a tab's legacy `display()` is *"not called when `getSettingDefinitions` returns a non-empty array; the tab is rendered declaratively from those definitions instead"*. On affected 1.13 installs the modal takes that path for Hearth's tab and renders zero items — a completely blank pane with no ribbon, no inline error, and no console output. That's why the beta.1/beta.2 guards changed nothing: the guarded `display()` was never invoked. It also matches the reported bisect — the settings category-ribbon redesign landed in 1.7.1.13, inside the reporter's untested 1.7.1.10–14 gap.

**Fix:**
- `HomeSettingTab.getSettingDefinitions()` now returns a single self-rendered setting definition hosting the whole pane (`searchable: false`). Obsidian 1.13+ renders it through the declarative pipeline; older versions never call it and keep using `display()`. Both paths share one builder (`renderInto`), so the UI is identical and `minAppVersion` stays 1.8.7.
- Internal re-renders (ribbon clicks, mobile-action list edits, background-type switch, imports) go through `rerender()`, which targets the element the pane actually lives in — on 1.13 `containerEl` may never be attached.
- New CSS strips the host row's `.setting-item` flex layout so the pane lays out as a plain block.
- Temporary `console.warn` names the render path on each open, so #52 testers can finally confirm the diagnosis; remove once verified.

## Related issue

Closes #52 (pending tester confirmation on 1.11.0-beta.3).

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (typecheck, lint 0 errors, 91 tests pass, `verify:manifests` OK)
- [ ] I've tested this in an actual vault (not reproducible in this environment — verified against the official 1.13.1 API contract; the console diagnostic confirms the render path on testers' machines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6yPdJ5Ats7rLkcPTEpqdE

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6yPdJ5Ats7rLkcPTEpqdE)_