### PR TITLE
chore: cut 1.11.0-beta.4 for BRAT testing

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "1.11.0-beta.3",
+	"version": "1.11.0-beta.4",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
## What does this PR do?

Version-only bump of `manifest-beta.json` to `1.11.0-beta.4`, so the beta carrying #60 (strict task-date parsing — no more moment `Date()` fallback warnings, wikilink due dates — plus the extended #52 diagnostics) can be tagged and released for BRAT testing.

## Related issue

#52

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [x] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault (version-only bump, no code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWvfDZJ1QKxESmsEW9GH52

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWvfDZJ1QKxESmsEW9GH52)_