### PR TITLE
fix(settings): stop shadowing Obsidian 1.13's internal SettingTab.renderTab; cut 1.11.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,16 +39,22 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   [[2026-08-01]]` or `[[Daily/2026-08-01|due]]` resolve to the linked day) and
   trailing `#tags` after a date are ignored (`📅 2026-08-01 #home`).
 
-- **Settings pane no longer opens blank on Obsidian 1.13.** Obsidian 1.13
-  rebuilt the settings window around a new declarative settings API, and when
-  it takes that path for a tab it never calls the plugin's legacy `display()`
-  renderer — on affected installs (reported on macOS and iPad, #52) Hearth's
-  settings therefore came up completely empty, with no error anywhere, ever
-  since the category-ribbon redesign. The tab now registers its pane through
-  the new API's render hook, so Obsidian 1.13+ renders it on the declarative
-  path while older Obsidian versions keep using `display()` — the same UI
-  either way. A temporary console line names which path rendered, to confirm
-  the diagnosis on affected machines.
+- **Settings pane no longer opens blank on Obsidian 1.13.** Root cause found
+  (with an enormous assist from the affected users' console digging in #52):
+  since the category-ribbon redesign, the settings tab had a private helper
+  named `renderTab(body, tab)` — and Obsidian 1.13's reworked settings window
+  calls an *internal, undocumented* `SettingTab.renderTab()` method (no
+  arguments) as the entry point for opening a tab. Hearth's same-named helper
+  silently shadowed it: Obsidian invoked it with no arguments, the
+  `switch (undefined)` inside matched no category, and the pane rendered
+  nothing — no error, on every reopen, on macOS and iPad alike (#52). And
+  because Obsidian never got past that entry point, none of the earlier
+  guards or the declarative registration could ever run. The helper is renamed
+  so Obsidian's own machinery runs again, the tab additionally registers its
+  pane through the 1.13 declarative settings API (older Obsidian versions keep
+  using `display()` — same UI either way), and a constructor tripwire now
+  reports any future member-name collision with Obsidian's `SettingTab`
+  internals as a loud console error instead of a silent blank pane.
 - **A failing settings section no longer blanks the whole settings pane.**
   Previously, if any part of the settings tab threw while rendering, the entire
   pane was left empty with nothing to explain why — and, because the tab

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "1.11.0-beta.4",
+	"version": "1.11.0-beta.5",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hearth",
-	"version": "1.8.1.4-beta",
+	"version": "1.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hearth",
-			"version": "1.8.1.4-beta",
+			"version": "1.10.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^20.11.0",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -65,12 +65,52 @@ const SETTINGS_TABS: { id: SettingsTabId; icon: string }[] = [
 /** localStorage key for the last-opened settings tab. */
 const ACTIVE_TAB_KEY = "hearth-settings-tab";
 
+/**
+ * ⚠️ Naming hazard: members of this class live on the same prototype chain as
+ * Obsidian's `SettingTab`, whose *undocumented internals* are not in the
+ * typings — so a colliding name compiles cleanly and silently replaces engine
+ * behaviour at runtime. That is exactly how #52 happened: a private
+ * `renderTab(body, tab)` helper shadowed the internal `SettingTab.renderTab()`
+ * that Obsidian 1.13's settings window calls to open a tab. Obsidian invoked
+ * it with no arguments, the `switch (undefined)` matched nothing, and the pane
+ * came up completely blank — no error, on every reopen. Keep member names
+ * unmistakably Hearth-specific; the constructor tripwire below turns any
+ * future collision into a loud console error instead of a silent blank pane.
+ */
 export class HomeSettingTab extends PluginSettingTab {
 	plugin: HearthPlugin;
+
+	/** Members we deliberately override — the documented extension points of
+	 * `SettingTab`. Anything else that exists on the base prototype chain is an
+	 * Obsidian internal we must not shadow. */
+	private static readonly INTENDED_OVERRIDES = new Set([
+		"constructor",
+		"display",
+		"hide",
+		"getSettingDefinitions",
+		"getControlValue",
+		"setControlValue",
+	]);
 
 	constructor(app: App, plugin: HearthPlugin) {
 		super(app, plugin);
 		this.plugin = plugin;
+		this.warnOnBaseMemberShadowing();
+	}
+
+	/** #52 tripwire: at runtime (inside real Obsidian, where the internals
+	 * actually exist on the base prototypes) report any member of this class
+	 * that shadows a `SettingTab` member we didn't mean to override. */
+	private warnOnBaseMemberShadowing(): void {
+		const base = Object.getPrototypeOf(HomeSettingTab.prototype) as object | null;
+		if (!base) return;
+		for (const name of Object.getOwnPropertyNames(HomeSettingTab.prototype)) {
+			if (!HomeSettingTab.INTENDED_OVERRIDES.has(name) && name in base) {
+				console.error(
+					`Hearth: HomeSettingTab.${name} shadows an internal Obsidian SettingTab member and will break settings rendering — rename it (see issue #52)`,
+				);
+			}
+		}
 	}
 
 	private async save(): Promise<void> {
@@ -200,7 +240,7 @@ export class HomeSettingTab extends PluginSettingTab {
 			// and, because the ribbon above is already drawn, the user can still
 			// switch to a working tab.
 			try {
-				this.renderTab(body, active);
+				this.renderTabSections(body, active);
 			} catch (err) {
 				body.empty();
 				this.renderError(body, t().settings.tabs[active], err);
@@ -257,8 +297,10 @@ export class HomeSettingTab extends PluginSettingTab {
 		}
 	}
 
-	/** Render the sections that belong to a given tab. */
-	private renderTab(body: HTMLElement, tab: SettingsTabId): void {
+	/** Render the sections that belong to a given ribbon tab. (Named
+	 * `renderTabSections`, not `renderTab` — the latter is an Obsidian 1.13
+	 * internal and shadowing it blanked the whole pane, #52.) */
+	private renderTabSections(body: HTMLElement, tab: SettingsTabId): void {
 		const s = t().settings;
 		switch (tab) {
 			case "appearance":


### PR DESCRIPTION
## What does this PR do?

Fixes the blank settings pane on Obsidian 1.13 at its actual root cause. Obsidian 1.13's reworked settings window opens a plugin tab by calling an internal, undocumented `SettingTab.renderTab()` with no arguments — and Hearth's settings tab has had its own `private renderTab(body, tab)` helper since the category-ribbon redesign, which shadowed the engine method at runtime. Obsidian called it argument-less, the `switch (undefined)` matched no category, and the pane rendered nothing: no error, no ribbon, every reopen. Because Obsidian never got past that entry point, none of the earlier guards (beta.1/beta.2) or the declarative registration (beta.3) could ever execute.

- Renames the helper to `renderTabSections` so Obsidian's own machinery runs again on both the 1.13 and legacy paths.
- Adds a constructor tripwire that reports any future member-name collision with the `SettingTab` prototype chain as a loud console error instead of a silent blank pane (documented override points excepted).
- Rewrites the 1.11.0 changelog entry to describe the real cause.
- Bumps `manifest-beta.json` to `1.11.0-beta.5` for BRAT verification.

## Related issue

Fixes the remaining blank-pane case in #52 (diagnosis confirmed via the affected users' console sessions in that thread).

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault (cannot reproduce locally — verification via BRAT testers on beta.5, per the issue thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dkx6RSJUsAQMUeHwXhjmBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dkx6RSJUsAQMUeHwXhjmBr)_