### PR TITLE
feat(recent): add file-type filter to the Recent files card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
+- **Recent files card — file-type filter.** The **Recent files** card can now be
+  limited to specific file types. Its editor offers the same type chips as the
+  search filter (Notes, Images, PDFs, Canvas, …); pick any combination to list
+  only those, or leave them all off to keep showing every recently-opened file.
 - **Card corner radius setting.** A **Card corner radius** slider controls how
   rounded card corners are, from the default 14 px down to sharp 0 px corners,
   at both global (Settings → Dashboard) and per-dashboard (dashboard settings)

--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ toolbar; configure each one from the card itself (title, content, colors, size).
 - **Bookmarks** — pulls from Obsidian's core Bookmarks plugin, with site
   favicons next to URL bookmarks.
 - **Favorites** — a grid of curated note cards.
-- **Recent files** — your recently opened files (configurable count).
+- **Recent files** — your recently opened files (configurable count, with an
+  optional file-type filter — pick any combination of types to list).
 - **Links / launchpad** — a grid of tiles opening notes, URLs or commands.
   Tiles live on a **CSS grid** with independent **column and row spans**, so a
   tile can be 2×2, 4×1, or any proportion. In arrange mode, drag a tile to

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -37,7 +37,7 @@ import { cachedRates, loadRates } from "./currency";
 import { getDataviewApi } from "./dataview";
 import { cachedFeed, loadFeed, type RssItem } from "./rss";
 import { isViewTypeHostable, mountLeafView } from "./leafview";
-import { EXCALIDRAW_PLUGIN_ID, iconForFile, isExcalidraw } from "./filetypes";
+import { EXCALIDRAW_PLUGIN_ID, groupForFile, iconForFile, isExcalidraw } from "./filetypes";
 import { type QueryHit, runQuery, searchFileContents } from "./query";
 import { confirmAction, makeClickable } from "./ui";
 import { parseNaturalDate, formatRelativeDate, localDayKey } from "./dates";
@@ -1760,10 +1760,20 @@ function renderCalculator(view: HomeView, card: DashboardCard, body: HTMLElement
 
 function renderRecent(view: HomeView, card: DashboardCard, body: HTMLElement): void {
 	const count = card.count && card.count > 0 ? card.count : 8;
+	// Optional file-type filter: keep only files whose group is selected. An
+	// empty/undefined list means no filtering (show every type). The filter is
+	// applied before the count is capped, so the card shows the N most recent
+	// files of the chosen types rather than the N most recent overall.
+	const types = card.recentTypes && card.recentTypes.length > 0 ? new Set(card.recentTypes) : null;
 	const files = view.app.workspace
 		.getLastOpenFiles()
 		.map((p) => view.app.vault.getAbstractFileByPath(p))
 		.filter((f): f is TFile => f instanceof TFile)
+		.filter((f) => {
+			if (!types) return true;
+			const group = groupForFile(f);
+			return group != null && types.has(group.id);
+		})
 		.slice(0, count);
 
 	if (files.length === 0) {

--- a/src/editors.ts
+++ b/src/editors.ts
@@ -1,4 +1,5 @@
-import { type App, Modal, Notice, Setting } from "obsidian";
+import { type App, Modal, Notice, setIcon, Setting } from "obsidian";
+import { FILE_TYPE_GROUPS, fileTypeLabel, FOLDERS_GROUP_ID } from "./filetypes";
 import { listBaseViews, isBaseTarget } from "./bases";
 import { CommandPickerModal, FilePickerModal } from "./pickers";
 import type {
@@ -263,6 +264,7 @@ export class CardSettingsModal extends Modal {
 				this.addResetButton(recent, t().settings.resetField, () => {
 					card.count = undefined;
 				});
+				this.recentTypesEditor(containerEl, card);
 				break;
 			}
 			case "links":
@@ -907,6 +909,50 @@ export class CardSettingsModal extends Modal {
 					this.render();
 				}),
 		);
+	}
+
+	/** File-type filter for the recent-files card: a row of toggleable chips
+	 * mirroring the search filter's types. Any combination may be selected; an
+	 * empty selection means every type is shown. */
+	private recentTypesEditor(containerEl: HTMLElement, card: DashboardCard): void {
+		const setting = new Setting(containerEl)
+			.setName(t().editors.recent.types)
+			.setDesc(t().editors.recent.typesDesc);
+		this.addResetButton(setting, t().settings.resetField, () => {
+			card.recentTypes = undefined;
+		});
+
+		const selected = new Set(card.recentTypes ?? []);
+		const row = containerEl.createDiv("hearth-type-filter");
+		// Folders can never appear among recently-opened files, so offer every
+		// search-filter type except that one.
+		const groups = FILE_TYPE_GROUPS.filter((g) => g.id !== FOLDERS_GROUP_ID);
+		for (const group of groups) {
+			const chip = row.createDiv("hearth-type-filter-chip");
+			chip.toggleClass("is-active", selected.has(group.id));
+			setIcon(chip.createDiv("hearth-type-filter-icon"), group.icon);
+			chip.createDiv({ cls: "hearth-type-filter-label", text: fileTypeLabel(group) });
+			chip.setAttribute("role", "button");
+			chip.setAttribute("tabindex", "0");
+			chip.setAttribute("aria-pressed", String(selected.has(group.id)));
+			const toggle = () => {
+				if (selected.has(group.id)) selected.delete(group.id);
+				else selected.add(group.id);
+				const on = selected.has(group.id);
+				chip.toggleClass("is-active", on);
+				chip.setAttribute("aria-pressed", String(on));
+				card.recentTypes = selected.size > 0 ? Array.from(selected) : undefined;
+				this.opts.save();
+				this.opts.rerender();
+			};
+			chip.addEventListener("click", toggle);
+			chip.addEventListener("keydown", (e) => {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					toggle();
+				}
+			});
+		}
 	}
 
 	/** Move an item within a list, then persist and re-render the editor. */

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -526,6 +526,8 @@ export const en = {
 		recent: {
 			count: "Number of files",
 			countDesc: "How many recently-opened files to list.",
+			types: "File types",
+			typesDesc: "Only list files of the selected types. Pick any combination; none selected shows every type.",
 		},
 		calendar: {
 			weekNumbers: "Week numbers",

--- a/src/types.ts
+++ b/src/types.ts
@@ -408,6 +408,10 @@ export interface DashboardCard {
 	commands?: CommandItem[];
 	/** kind === "recent": how many recent files to show. */
 	count?: number;
+	/** kind === "recent": file-type group ids (see FILE_TYPE_GROUPS) to include.
+	 * Any combination of the search filter's types; undefined or empty means all
+	 * types are shown. */
+	recentTypes?: string[];
 	/** kind === "clock": time/greeting/date display options. */
 	clock?: ClockConfig;
 	/** kind === "tasks": source, folder scope and display options. */

--- a/styles.css
+++ b/styles.css
@@ -347,6 +347,52 @@
 	display: flex;
 }
 
+/* ---- Recent-card type filter (card editor) -------------------------- */
+
+/* A wrap of labelled chips for choosing which file types a recent-files card
+ * lists. Multiple may be active at once, unlike the search filter's single
+ * selection. */
+.hearth-type-filter {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin: 0 0 18px;
+}
+
+.hearth-type-filter-chip {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px 10px;
+	border-radius: 10px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-primary);
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+	cursor: pointer;
+	transition: all 120ms ease;
+}
+
+.hearth-type-filter-chip:hover {
+	color: var(--text-normal);
+	border-color: var(--interactive-accent);
+}
+
+.hearth-type-filter-chip.is-active {
+	color: var(--text-on-accent);
+	background: var(--interactive-accent);
+	border-color: var(--interactive-accent);
+}
+
+.hearth-type-filter-icon {
+	display: flex;
+}
+
+.hearth-type-filter-icon svg {
+	width: 15px;
+	height: 15px;
+}
+
 /* ---- Dashboard grid ------------------------------------------------- */
 
 .hearth-dashboard {


### PR DESCRIPTION
## What does this PR do?

Adds an optional **file-type filter** to the **Recent files** card, so it can be limited to specific kinds of files instead of always listing every type.

The card editor gains a **File types** section with the same type chips as the search filter (Notes, Images, PDFs, Canvas, Bases, Audio, Video, …). Any combination can be selected:

- **One or more types selected** → the card lists only the N most recent files of those types (the filter is applied *before* the count is capped, so you get N matching files, not N-of-any-type minus the misses).
- **None selected** → unchanged behaviour: every recently-opened file is shown.

Folders are excluded from the chip options since recently-opened files are never folders.

### Implementation
- `types.ts` — new `recentTypes?: string[]` field on `DashboardCard` (group ids from `FILE_TYPE_GROUPS`; undefined/empty = all types).
- `cards.ts` — `renderRecent` filters files by `groupForFile(f).id` against the selected set before slicing to `count`.
- `editors.ts` — new `recentTypesEditor` renders the toggleable chip row (keyboard-accessible, `aria-pressed`), reusing the shared file-type groups and localized labels; a reset button clears the filter.
- `en.ts` — `editors.recent.types` / `typesDesc` strings.
- `styles.css` — chip styling that mirrors the search filter chips.
- `README.md` / `CHANGELOG.md` — documented.

## Related issue

Closes #64

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (typecheck, lint 0 errors, `vitest` 99 passing, esbuild production bundle)
- [ ] I've tested this in an actual vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENuz6M5ALnFFnb3nW3NpCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENuz6M5ALnFFnb3nW3NpCQ)_