### PR TITLE
refactor(settings): reorganise card & dashboard settings into tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ## [1.11.0]
 
+### Changed
+
+- **Card & dashboard settings, reorganised into tabs.** The card-settings and
+  per-dashboard-settings dialogs — previously one long, flat scroll of every
+  control — are now split across tabs, mirroring the plugin settings pane so the
+  whole plugin configures the same way. Card settings groups into **Content**
+  (type, title and the card's own options), **Style** (colours, opacity, blur)
+  and **Layout** (size, pin to all dashboards, copy to another), with Remove and
+  Done always in reach at the bottom. Dashboard settings groups into **General**,
+  **Layout**, **Style** and **Background**. The last-used tab is remembered, and
+  a single failing group can no longer blank the whole dialog.
+
 ### Added
 
 - **Recent files card — file-type filter.** The **Recent files** card can now be

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -1,4 +1,4 @@
-import { Menu, Modal, Setting, setIcon } from "obsidian";
+import { Menu, Setting, setIcon } from "obsidian";
 import type { HomeView } from "./view";
 import {
 	type BackgroundConfig,
@@ -10,6 +10,7 @@ import {
 	cloneCard,
 } from "./types";
 import { confirmAction } from "./ui";
+import { HearthTabbedModal, type HearthModalTab } from "./tabbedmodal";
 import { t } from "./i18n";
 
 /** A per-dashboard background's opacity and blur default to — and reset to —
@@ -168,8 +169,12 @@ function showDashboardMenu(view: HomeView, dash: Dashboard, evt: MouseEvent): vo
 
 /** Per-dashboard settings: name, switcher icon, dashboard chrome, and optional
  * overrides for grid columns, row height and background. Overrides fall back to
- * the global settings when left off. */
-class DashboardSettingsModal extends Modal {
+ * the global settings when left off.
+ *
+ * Laid out as a tabbed modal (General / Layout / Style / Background) with a
+ * persistent Done footer, mirroring the plugin settings pane so both configure
+ * the same way. */
+class DashboardSettingsModal extends HearthTabbedModal {
 	private view: HomeView;
 	private dash: Dashboard;
 
@@ -181,7 +186,13 @@ class DashboardSettingsModal extends Modal {
 
 	onOpen(): void {
 		this.titleEl.setText(t().dashboards.modal.title);
-		this.render();
+		this.hearthRenderShell();
+	}
+
+	/** Rebuild the modal in place, keeping the active tab. Used by the override
+	 * toggles and background dropdown, which swap which controls are shown. */
+	private render(): void {
+		this.hearthRenderShell();
 	}
 
 	/** Persist and refresh the live view without closing the modal. */
@@ -190,20 +201,56 @@ class DashboardSettingsModal extends Modal {
 		this.view.render();
 	}
 
-	private render(): void {
-		const { contentEl } = this;
-		contentEl.empty();
-		const dash = this.dash;
-		const s = this.view.plugin.settings;
+	protected hearthTabStorageKey(): string {
+		return "hearth-dash-settings-tab";
+	}
 
-		new Setting(contentEl).setName(t().dashboards.modal.name).addText((tx) =>
+	protected hearthTabs(): HearthModalTab[] {
+		const tabs = t().dashboards.modal.tabs;
+		return [
+			{ id: "general", label: tabs.general, icon: "settings-2" },
+			{ id: "layout", label: tabs.layout, icon: "layout-dashboard" },
+			{ id: "style", label: tabs.style, icon: "palette" },
+			{ id: "background", label: tabs.background, icon: "image" },
+		];
+	}
+
+	protected hearthRenderBody(body: HTMLElement, tabId: string): void {
+		switch (tabId) {
+			case "general":
+				this.generalSection(body);
+				break;
+			case "layout":
+				this.layoutSection(body);
+				break;
+			case "style":
+				this.styleSection(body);
+				break;
+			case "background":
+				this.backgroundSection(body);
+				break;
+		}
+	}
+
+	/** Persistent footer shared by every tab: close the modal. */
+	protected hearthRenderFooter(footer: HTMLElement): void {
+		new Setting(footer).addButton((b) =>
+			b.setButtonText(t().dashboards.modal.done).setCta().onClick(() => this.close()),
+		);
+	}
+
+	/** Name, switcher icons and whether the search section shows. */
+	private generalSection(containerEl: HTMLElement): void {
+		const dash = this.dash;
+
+		new Setting(containerEl).setName(t().dashboards.modal.name).addText((tx) =>
 			tx.setValue(dash.name).onChange((v) => {
 				dash.name = v || t().dashboards.fallbackName;
 				this.commit();
 			}),
 		);
 
-		new Setting(contentEl)
+		new Setting(containerEl)
 			.setName(t().dashboards.modal.switcherIcon)
 			.setDesc(t().dashboards.modal.switcherIconDesc)
 			.addText((tx) =>
@@ -213,7 +260,7 @@ class DashboardSettingsModal extends Modal {
 				}),
 			);
 
-		new Setting(contentEl)
+		new Setting(containerEl)
 			.setName(t().dashboards.modal.switcherLucide)
 			.setDesc(t().dashboards.modal.switcherLucideDesc)
 			.addText((tx) =>
@@ -226,7 +273,7 @@ class DashboardSettingsModal extends Modal {
 					}),
 			);
 
-		new Setting(contentEl)
+		new Setting(containerEl)
 			.setName(t().dashboards.modal.showSearch)
 			.setDesc(t().dashboards.modal.showSearchDesc)
 			.addToggle((tg) =>
@@ -235,9 +282,15 @@ class DashboardSettingsModal extends Modal {
 					this.commit();
 				}),
 			);
+	}
+
+	/** Content width and fit-to-page, each an override of the global default. */
+	private layoutSection(containerEl: HTMLElement): void {
+		const dash = this.dash;
+		const s = this.view.plugin.settings;
 
 		this.overrideSlider(
-			contentEl,
+			containerEl,
 			t().dashboards.modal.contentWidth,
 			dash.maxWidth,
 			s.maxWidth,
@@ -250,7 +303,7 @@ class DashboardSettingsModal extends Modal {
 			},
 		);
 
-		new Setting(contentEl)
+		new Setting(containerEl)
 			.setName(t().dashboards.modal.fitToPage)
 			.setDesc(t().dashboards.modal.fitToPageDesc)
 			.addDropdown((d) => {
@@ -268,9 +321,15 @@ class DashboardSettingsModal extends Modal {
 					this.commit();
 				});
 			});
+	}
+
+	/** Card surface overrides: opacity, blur and corner radius. */
+	private styleSection(containerEl: HTMLElement): void {
+		const dash = this.dash;
+		const s = this.view.plugin.settings;
 
 		this.overrideSlider(
-			contentEl,
+			containerEl,
 			t().dashboards.modal.cardOpacity,
 			dash.cardOpacity,
 			s.cardOpacity,
@@ -284,7 +343,7 @@ class DashboardSettingsModal extends Modal {
 		);
 
 		this.overrideSlider(
-			contentEl,
+			containerEl,
 			t().dashboards.modal.cardBlur,
 			dash.cardBlur,
 			s.cardBlur,
@@ -300,7 +359,7 @@ class DashboardSettingsModal extends Modal {
 		// Corner radius is capped at the design baseline (CARD_RADIUS_MAX): only
 		// sharper corners are offered, since rounding beyond it was never tuned for.
 		this.overrideSlider(
-			contentEl,
+			containerEl,
 			t().dashboards.modal.cardRadius,
 			dash.cardRadius,
 			s.cardRadius,
@@ -311,12 +370,6 @@ class DashboardSettingsModal extends Modal {
 				dash.cardRadius = v;
 				this.commit();
 			},
-		);
-
-		this.backgroundSection(contentEl);
-
-		new Setting(contentEl).addButton((b) =>
-			b.setButtonText(t().dashboards.modal.done).setCta().onClick(() => this.close()),
 		);
 	}
 

--- a/src/editors.ts
+++ b/src/editors.ts
@@ -1,4 +1,4 @@
-import { type App, Modal, Notice, setIcon, Setting } from "obsidian";
+import { type App, Notice, setIcon, Setting } from "obsidian";
 import { FILE_TYPE_GROUPS, fileTypeLabel, FOLDERS_GROUP_ID } from "./filetypes";
 import { listBaseViews, isBaseTarget } from "./bases";
 import { CommandPickerModal, FilePickerModal } from "./pickers";
@@ -13,6 +13,7 @@ import type {
 } from "./types";
 import { confirmAction } from "./ui";
 import { listLeafViewTypes } from "./leafview";
+import { HearthTabbedModal, type HearthModalTab } from "./tabbedmodal";
 import { t } from "./i18n";
 
 export interface CardSettingsOptions {
@@ -38,8 +39,12 @@ export interface CardSettingsOptions {
  * The single place to configure a card — opened from the card itself in arrange
  * mode. Covers kind, title, kind-specific content, colors and size so nothing
  * has to be hunted for in the plugin settings tab.
+ *
+ * Laid out as a tabbed modal (Content / Style / Layout) with a persistent
+ * Remove/Done footer, so a card with a dense editor (tasks, RSS) stays as
+ * navigable as a plain one.
  */
-export class CardSettingsModal extends Modal {
+export class CardSettingsModal extends HearthTabbedModal {
 	private card: DashboardCard;
 	private opts: CardSettingsOptions;
 
@@ -51,15 +56,50 @@ export class CardSettingsModal extends Modal {
 
 	onOpen(): void {
 		this.titleEl.setText(t().editors.title);
-		this.render();
+		this.hearthRenderShell();
 	}
 
+	/** Rebuild the modal in place, keeping the active tab. Kind-specific editors
+	 * call this after a change that swaps which controls are shown. */
 	private render(): void {
-		const { contentEl } = this;
-		contentEl.empty();
+		this.hearthRenderShell();
+	}
+
+	protected hearthTabStorageKey(): string {
+		return "hearth-card-settings-tab";
+	}
+
+	protected hearthTabs(): HearthModalTab[] {
+		const tabs = t().editors.tabs;
+		return [
+			{ id: "content", label: tabs.content, icon: "square-pen" },
+			{ id: "style", label: tabs.style, icon: "palette" },
+			{ id: "layout", label: tabs.layout, icon: "layout-dashboard" },
+		];
+	}
+
+	protected hearthRenderBody(body: HTMLElement, tabId: string): void {
+		switch (tabId) {
+			case "content":
+				this.identitySection(body);
+				this.contentSection(body);
+				break;
+			case "style":
+				this.colorsSection(body);
+				break;
+			case "layout":
+				this.sizeSection(body);
+				this.pinSection(body);
+				this.copySection(body);
+				break;
+		}
+	}
+
+	/** Type and title — what the card is, shown at the top of the Content tab. */
+	private identitySection(containerEl: HTMLElement): void {
 		const card = this.card;
 
-		new Setting(contentEl)
+		new Setting(containerEl)
 			.setName(t().editors.type)
 			.setDesc(t().editors.typeDesc)
 			.addDropdown((d) => {
@@ -73,7 +113,7 @@ export class CardSettingsModal extends Modal {
 				});
 			});
 
-		new Setting(contentEl)
+		new Setting(containerEl)
 			.setName(t().editors.cardTitle)
 			.setDesc(t().editors.cardTitleDesc)
 			.addText((txt) =>
@@ -85,14 +125,11 @@ export class CardSettingsModal extends Modal {
 						this.opts.save();
 					}),
 			);
+	}
 
-		this.contentSection(contentEl);
-		this.colorsSection(contentEl);
-		this.sizeSection(contentEl);
-		this.pinSection(contentEl);
-		this.copySection(contentEl);
-
-		new Setting(contentEl)
+	/** Persistent footer shared by every tab: remove the card, or close. */
+	protected hearthRenderFooter(footer: HTMLElement): void {
+		new Setting(footer)
 			.addButton((b) => {
 				b.setButtonText(t().editors.removeCard).onClick(() => {
 					confirmAction(this.app, {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -137,6 +137,13 @@ export const en = {
 		deleteConfirm: "Delete",
 		modal: {
 			title: "Dashboard settings",
+			/** Tabs across the top of the dashboard settings modal. */
+			tabs: {
+				general: "General",
+				layout: "Layout",
+				style: "Style",
+				background: "Background",
+			},
 			name: "Name",
 			switcherIcon: "Switcher icon",
 			switcherIconDesc:
@@ -434,6 +441,12 @@ export const en = {
 	// ---- Card settings editor ------------------------------------------
 	editors: {
 		title: "Card settings",
+		/** Tabs across the top of the card settings modal. */
+		tabs: {
+			content: "Content",
+			style: "Style",
+			layout: "Layout",
+		},
 		type: "Type",
 		typeDesc: "What this card shows.",
 		cardTitle: "Title",

--- a/src/tabbedmodal.ts
+++ b/src/tabbedmodal.ts
@@ -1,0 +1,130 @@
+import { Modal, setIcon } from "obsidian";
+import { t } from "./i18n";
+
+/** One tab in a {@link HearthTabbedModal}'s ribbon. */
+export interface HearthModalTab {
+	/** Stable id — persisted as the active tab and passed to the body renderer. */
+	id: string;
+	/** Ribbon label. */
+	label: string;
+	/** Lucide icon id shown beside the label. */
+	icon: string;
+}
+
+/**
+ * A modal whose content is split across a top ribbon of tabs — one group shown
+ * at a time — with an optional persistent footer below. It mirrors the plugin
+ * settings pane's ribbon so every configuration surface in Hearth navigates the
+ * same way: click a tab, see just that group.
+ *
+ * ⚠️ #52 naming hazard: members here live on the same prototype chain as
+ * Obsidian's `Modal` (and `Component`), whose *undocumented internals* aren't in
+ * the typings — so a colliding method name compiles cleanly and silently
+ * replaces engine behaviour at runtime (exactly how the blank-settings bug #52
+ * happened one layer up, in `SettingTab`). Every member here is prefixed
+ * `hearth*` to stay unmistakably clear of them; subclasses must do the same and
+ * must never name a method `open`/`close`/`onOpen`/`onClose`/`setTitle`/
+ * `load`/`unload`/`render`-that-shadows-anything without checking.
+ */
+export abstract class HearthTabbedModal extends Modal {
+	/** The tabs to show, in ribbon order. Read once per shell render, so tabs
+	 * may appear or disappear with state. */
+	protected abstract hearthTabs(): HearthModalTab[];
+
+	/** Render the body of the given tab into `body`. */
+	protected abstract hearthRenderBody(body: HTMLElement, tabId: string): void;
+
+	/** localStorage key under which the active tab persists across opens, so the
+	 * modal reopens on the tab you last used. */
+	protected abstract hearthTabStorageKey(): string;
+
+	/** Optional persistent footer, rendered below the body on every tab (e.g. the
+	 * Remove/Done actions). Left unset for modals that need no footer. */
+	protected hearthRenderFooter?(footer: HTMLElement): void;
+
+	/** Resolve the active tab: the persisted one if it still exists, else the
+	 * first tab. */
+	private hearthActiveTab(tabs: HearthModalTab[]): string {
+		const saved = this.app.loadLocalStorage(this.hearthTabStorageKey()) as
+			| string
+			| null;
+		return tabs.some((tab) => tab.id === saved) ? (saved as string) : tabs[0].id;
+	}
+
+	/**
+	 * Build (or rebuild) the whole modal: ribbon, the active tab's body, and the
+	 * footer. Call from `onOpen`, and again after any state change that should
+	 * redraw — the active tab is preserved across rebuilds.
+	 */
+	protected hearthRenderShell(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass("hearth-tabbed-modal");
+
+		const tabs = this.hearthTabs();
+		const active = this.hearthActiveTab(tabs);
+
+		this.hearthRenderRibbon(contentEl, tabs, active);
+
+		const body = contentEl.createDiv("hearth-modal-tabbody");
+		// Per-tab backstop (the #52 lesson): a throw while building one tab shows
+		// an inline error in the body instead of blanking the whole modal, and the
+		// ribbon above still lets the user switch to a tab that works.
+		try {
+			this.hearthRenderBody(body, active);
+		} catch (err) {
+			const label = tabs.find((tab) => tab.id === active)?.label ?? active;
+			body.empty();
+			this.hearthRenderTabError(body, label, err);
+		}
+
+		if (this.hearthRenderFooter) {
+			this.hearthRenderFooter(contentEl.createDiv("hearth-modal-footer"));
+		}
+	}
+
+	/** Draw the tab ribbon. Clicking a tab persists the choice and rebuilds. */
+	private hearthRenderRibbon(
+		containerEl: HTMLElement,
+		tabs: HearthModalTab[],
+		active: string,
+	): void {
+		const ribbon = containerEl.createDiv("hearth-modal-ribbon");
+		ribbon.setAttribute("role", "tablist");
+		for (const tab of tabs) {
+			const btn = ribbon.createEl("button", { cls: "hearth-ribbon-tab" });
+			btn.setAttribute("role", "tab");
+			btn.toggleClass("is-active", tab.id === active);
+			btn.setAttribute("aria-selected", String(tab.id === active));
+			btn.setAttribute("aria-label", tab.label);
+			setIcon(btn.createSpan("hearth-ribbon-tab-icon"), tab.icon);
+			btn.createSpan({ cls: "hearth-ribbon-tab-label", text: tab.label });
+			btn.addEventListener("click", () => {
+				if (tab.id === active) return;
+				this.app.saveLocalStorage(this.hearthTabStorageKey(), tab.id);
+				this.hearthRenderShell();
+			});
+		}
+	}
+
+	/** Inline error shown in place of a tab body whose render threw, reusing the
+	 * settings pane's error styling and copy. */
+	private hearthRenderTabError(
+		body: HTMLElement,
+		label: string,
+		err: unknown,
+	): void {
+		console.error(`Hearth: the "${label}" settings tab failed to render`, err);
+		const box = body.createDiv("hearth-settings-error");
+		setIcon(box.createSpan("hearth-settings-error-icon"), "alert-triangle");
+		const text = box.createDiv("hearth-settings-error-text");
+		text.createDiv({
+			cls: "hearth-settings-error-title",
+			text: t().settings.sectionError(label),
+		});
+		text.createDiv({
+			cls: "hearth-settings-error-hint",
+			text: t().settings.sectionErrorHint,
+		});
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -1026,6 +1026,51 @@
 	}
 }
 
+/* ---- Tabbed modals: card & dashboard settings -----------------------
+   The card- and dashboard-settings modals reuse the settings pane's ribbon
+   look (.hearth-ribbon-tab): a row of tabs pinned to the top, one group's
+   controls shown at a time, and a persistent action footer below. */
+
+.hearth-modal-ribbon {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	position: sticky;
+	top: 0;
+	z-index: 5;
+	padding-bottom: 10px;
+	margin-bottom: 6px;
+	background: var(--background-primary);
+	border-bottom: 1px solid var(--background-modifier-border);
+}
+
+/* Give the body a floor so switching from a dense tab (tasks) to a sparse one
+   (style) doesn't make the modal jump in height on every click. */
+.hearth-modal-tabbody {
+	min-height: 220px;
+	animation: hearth-tab-fade 140ms ease;
+}
+
+/* The footer sits below the scrolling tab body, its actions right-aligned. */
+.hearth-modal-footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	padding-top: 12px;
+	margin-top: 8px;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.hearth-modal-footer .setting-item {
+	border: none;
+	padding: 0;
+	width: 100%;
+}
+
+.hearth-modal-footer .setting-item-control {
+	gap: 8px;
+}
+
 /* ---- Settings tab: About panel --------------------------------------
    The Ko-fi tip button keeps the brand's white/dark look (from the official
    widget) so it reads as a support button, not a stock accent button. */


### PR DESCRIPTION
## What does this PR do?

The global plugin settings pane was refactored into a clean, tabbed, sectioned layout — but the two remaining configuration surfaces were still one long, flat scroll of every control:

- **Card settings** (`CardSettingsModal`) — type, title, kind-specific content, colours, size, pin and copy all stacked with no grouping. The tasks editor alone is a few hundred rows deep.
- **Per-dashboard settings** (`DashboardSettingsModal`) — name, icons, width, fit, opacity, blur, radius and background all stacked flat.

This PR reorganises both into a **top tab ribbon**, mirroring the plugin settings pane so the whole plugin configures the same way — sorted into relevant groups, easy to navigate, and approachable even without knowing where a given control lives.

**Card settings** → three tabs:
- **Content** — type, title, and the card's own options (embed, tasks, RSS, clock, …)
- **Style** — accent/background colours, card opacity, card blur
- **Layout** — size, pin to all dashboards, copy to another dashboard

Remove and Done stay pinned in a footer on every tab.

**Dashboard settings** → four tabs:
- **General** — name, switcher icon/Lucide icon, show search section
- **Layout** — content width, fit to page
- **Style** — card opacity, blur, corner radius
- **Background** — background type, value, opacity, blur

Done stays pinned in a footer.

### Implementation

- New **`HearthTabbedModal`** base class (`src/tabbedmodal.ts`): a `Modal` with a top tab ribbon, per-tab body render, an optional persistent footer, and active-tab persistence (the last-used tab is remembered per modal, via vault-scoped local storage).
- The ribbon reuses the settings pane's `.hearth-ribbon-tab` styling; new `.hearth-modal-ribbon` / `-tabbody` / `-footer` styles handle the modal layout (sticky ribbon, a min-height floor so switching a dense tab for a sparse one doesn't make the modal jump, and a bottom action bar).
- **On the `#52` lesson:** these are `Modal` subclasses rather than `PluginSettingTab`, so that exact `renderTab` collision can't recur — but the same two safeguards are applied. Every base-class member is prefixed `hearth*` to stay clear of Obsidian's undocumented `Modal`/`Component` internals, and each tab body renders inside a try/catch backstop, so a single failing group shows an inline error there (and the ribbon still lets you switch away) instead of blanking the whole dialog.

## Related issue

No separate issue — follow-up to the global-settings refactor, applying the same treatment to the last two flat settings surfaces.

## Type of change

- [x] ✨ Feature / behaviour change

## Checklist

- [x] `npm run build` passes locally (esbuild bundles clean; `tsc` reports only the two pre-existing `tsconfig.json` deprecation notices present on `main`)
- [x] `npm test` — 99 passing, 1 skipped
- [x] `npm run lint` — 0 errors (only pre-existing `setDynamicTooltip` deprecation warnings)

> Note: I can't launch a live Obsidian vault from this environment, so the tabbed modals haven't been exercised in-app — worth a quick manual check when opening a card's settings and a dashboard's settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ig1c1ppuzuDg58dnM4fg1)_