### PR TITLE
feat(rss): quick-add GitHub repo releases/commits feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   Obsidian's own request bridge (so cross-origin feeds work) and cached in
   memory, degrade gracefully offline (the last good items stay), and honour the
   **"disable external calls"** setting — with it on, no feed request is made.
+  The editor also has an **Add from GitHub** shortcut: type a repository as
+  `owner/repo` (or paste its URL), pick **Releases**, **Commits**, or both, and
+  Hearth adds the matching `releases.atom` / `commits.atom` feeds for you — no
+  need to hand-write the feed URLs.
 
 ### Fixed
 

--- a/src/editors.ts
+++ b/src/editors.ts
@@ -9,12 +9,67 @@ import type {
 	EmbedView,
 	LinkItem,
 	RssLayout,
+	RssSource,
 	TasksConfig,
 } from "./types";
 import { confirmAction } from "./ui";
 import { listLeafViewTypes } from "./leafview";
 import { HearthTabbedModal, type HearthModalTab } from "./tabbedmodal";
 import { t } from "./i18n";
+
+/** A GitHub repo split into its owner and repo halves, as pulled from user
+ * input by {@link parseGithubRepo}. */
+interface GithubRepo {
+	owner: string;
+	repo: string;
+}
+
+/** Parse an `owner/repo` string — or a full GitHub URL, or an `git@…` SSH
+ * remote — into its two halves. Returns null when either half is missing so
+ * callers can warn the user. */
+function parseGithubRepo(input: string): GithubRepo | null {
+	let s = input.trim();
+	if (!s) return null;
+	// Strip a leading scheme + host, an SSH `git@github.com:` remote, or a bare
+	// `github.com/` prefix, so a pasted URL collapses to `owner/repo/…`.
+	s = s
+		.replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]+\//i, "")
+		.replace(/^git@[^:]+:/i, "")
+		.replace(/^github\.com\//i, "");
+	// Drop any query/hash and a trailing `.git`, then keep the first two path
+	// segments — the rest (tree/blob/…) is irrelevant to the feed.
+	s = s.split(/[?#]/)[0].replace(/\.git$/i, "");
+	const parts = s.split("/").filter(Boolean);
+	if (parts.length < 2) return null;
+	return { owner: parts[0], repo: parts[1] };
+}
+
+/** Build the RSS sources for a repo's GitHub Atom feeds. `type` selects the
+ * releases feed, the commits feed, or both. */
+function githubFeedSources(
+	repo: GithubRepo,
+	type: "releases" | "commits" | "both",
+): RssSource[] {
+	const base = `https://github.com/${repo.owner}/${repo.repo}`;
+	const slug = `${repo.owner}/${repo.repo}`;
+	const mk = (kind: "releases" | "commits", name: string): RssSource => ({
+		id: `rss-gh-${kind}-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e4)}`,
+		name,
+		url: `${base}/${kind}.atom`,
+	});
+	const out: RssSource[] = [];
+	if (type === "releases" || type === "both") {
+		out.push(
+			mk("releases", t().editors.rss.githubReleasesName.replace("{repo}", slug)),
+		);
+	}
+	if (type === "commits" || type === "both") {
+		out.push(
+			mk("commits", t().editors.rss.githubCommitsName.replace("{repo}", slug)),
+		);
+	}
+	return out;
+}
 
 export interface CardSettingsOptions {
 	/** The global favorites list (shared by all favorites cards). */
@@ -47,6 +102,11 @@ export interface CardSettingsOptions {
 export class CardSettingsModal extends HearthTabbedModal {
 	private card: DashboardCard;
 	private opts: CardSettingsOptions;
+
+	/** Transient state for the RSS "add from GitHub" helper, kept on the modal so
+	 * it survives the in-place rerenders that adding a feed triggers. */
+	private ghRepo = "";
+	private ghFeedType: "releases" | "commits" | "both" = "releases";
 
 	constructor(app: App, card: DashboardCard, opts: CardSettingsOptions) {
 		super(app);
@@ -670,6 +730,8 @@ export class CardSettingsModal extends HearthTabbedModal {
 			}),
 		);
 
+		this.githubFeedAdder(containerEl, sources);
+
 		if (sources.length > 1) {
 			new Setting(containerEl)
 				.setName(t().editors.rss.mergeAll)
@@ -784,6 +846,53 @@ export class CardSettingsModal extends HearthTabbedModal {
 					this.opts.rerender();
 				}),
 			);
+	}
+
+	/** Quick-add helper: turn an `owner/repo` (or a GitHub URL) into RSS sources
+	 * pointing at GitHub's built-in `releases.atom` / `commits.atom` feeds, so
+	 * the user never has to hand-write those URLs. */
+	private githubFeedAdder(containerEl: HTMLElement, sources: RssSource[]): void {
+		const setting = new Setting(containerEl)
+			.setName(t().editors.rss.github)
+			.setDesc(t().editors.rss.githubDesc)
+			.setClass("hearth-rss-github");
+
+		setting.addText((txt) => {
+			txt
+				.setPlaceholder(t().editors.rss.githubPlaceholder)
+				.setValue(this.ghRepo)
+				.onChange((v) => {
+					this.ghRepo = v;
+				});
+			txt.inputEl.addClass("hearth-rss-github-repo");
+		});
+
+		setting.addDropdown((d) => {
+			d.addOption("releases", t().editors.rss.githubReleases);
+			d.addOption("commits", t().editors.rss.githubCommits);
+			d.addOption("both", t().editors.rss.githubBoth);
+			d.setValue(this.ghFeedType).onChange((v) => {
+				this.ghFeedType = v as "releases" | "commits" | "both";
+			});
+		});
+
+		setting.addButton((b) =>
+			b
+				.setButtonText(t().editors.rss.githubAdd)
+				.setCta()
+				.onClick(() => {
+					const repo = parseGithubRepo(this.ghRepo);
+					if (!repo) {
+						new Notice(t().editors.rss.githubInvalid);
+						return;
+					}
+					sources.push(...githubFeedSources(repo, this.ghFeedType));
+					this.ghRepo = "";
+					this.opts.save();
+					this.opts.rerender();
+					this.render();
+				}),
+		);
 	}
 
 	private calculatorEditor(containerEl: HTMLElement): void {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -762,6 +762,17 @@ export const en = {
 			urlPlaceholder: "https://example.com/feed.xml",
 			addFeed: "Add feed",
 			removeFeed: "Remove feed",
+			github: "Add from GitHub",
+			githubDesc:
+				"Enter a repository as owner/repo (or paste its URL) and pick what to follow — Hearth builds the Atom feed for you.",
+			githubPlaceholder: "owner/repo",
+			githubReleases: "Releases",
+			githubCommits: "Commits",
+			githubBoth: "Releases & commits",
+			githubAdd: "Add repo",
+			githubInvalid: "Enter a repository as owner/repo.",
+			githubReleasesName: "{repo} releases",
+			githubCommitsName: "{repo} commits",
 			mergeAll: "Combined “All” tab",
 			mergeAllDesc:
 				"Add a leading tab that merges every feed into one stream, newest first.",

--- a/styles.css
+++ b/styles.css
@@ -2958,6 +2958,26 @@
 	justify-content: stretch;
 }
 
+/* RSS "Add from GitHub" quick-add: its three controls (repo input, feed-type
+   dropdown, Add button) need more room than a right-aligned control strip
+   gives — otherwise they squeeze the name/description into a sliver. Stack the
+   controls under the label, lay them out left-to-right, and let the repo input
+   take the slack (wrapping on narrow dialogs). */
+.hearth-rss-github {
+	display: block;
+}
+
+.hearth-rss-github .setting-item-control {
+	margin-top: 8px;
+	justify-content: flex-start;
+	flex-wrap: wrap;
+}
+
+.hearth-rss-github-repo {
+	flex: 1 1 12em;
+	min-width: 0;
+}
+
 /* Dataview query editor: a monospaced, full-width code box. */
 .hearth-dataview-input {
 	width: 100%;


### PR DESCRIPTION
## What does this PR do?

Adds an **"Add from GitHub"** shortcut to the RSS card editor so users can follow a repository's releases or commits without hand-writing feed URLs.

In the RSS card editor (Content tab, below the feed list):

1. **Repo input** — enter a repository as `owner/repo` (also accepts a pasted GitHub URL or a `git@…` SSH remote — all collapse to owner/repo).
2. **Dropdown** — choose **Releases**, **Commits**, or **Releases & commits**.
3. **Add repo** button — builds the matching GitHub Atom feeds and adds them as RSS sources:
   - `https://github.com/:owner/:repo/releases.atom`
   - `https://github.com/:owner/:repo/commits.atom`

Each added source gets a friendly tab name (e.g. `ondreu/Hearth releases`). Invalid input (missing owner or repo) shows a notice instead of adding a broken feed.

### Implementation

- `src/editors.ts` — two pure helpers (`parseGithubRepo`, `githubFeedSources`) plus a `githubFeedAdder` UI method wired into `rssEditor`. Input state lives on the modal so it survives the in-place rerenders that adding a feed triggers.
- `src/locales/en.ts` — new i18n strings (English is the source-of-truth locale; the typed `Translations` shape gives future locales compile-time coverage).
- `CHANGELOG.md` — noted under the in-progress `[1.11.0]` → Added.

## Related issue

<!-- None linked. -->

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

Also verified: `npm run lint` (0 errors) and `npm test` (99 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NRiPsFDMLBKeSRodcBKTy

---
_Generated by [Claude Code](https://claude.ai/code/session_018NRiPsFDMLBKeSRodcBKTy)_