### PR TITLE
Fix frozen TaskNotes edit modal for existing tasks (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **TaskNotes tasks open in a working editor again.** Opening an existing
+  TaskNotes task from a Tasks card handed TaskNotes' edit modal the note's
+  `TFile` instead of its own task object, leaving the modal with a broken
+  change-detection baseline: every button but Delete was trapped and the window
+  couldn't be closed (#72). Hearth now resolves TaskNotes' task info for the
+  note first (via its cache manager or public API) and only opens the modal when
+  it can, falling back to opening the note otherwise.
+
 - **Task date parsing no longer spams the console — and understands wikilink
   dates.** When a task's date field held something moment.js couldn't parse
   natively (e.g. `📅 [[260801]] #sd`, a due date written as a daily-note link),

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -5795,32 +5795,64 @@ function renderLineRecurringCheckbox(
 	});
 }
 
-/** Best-effort: open a TaskNotes task in TaskNotes' own editor rather than the
- * raw Markdown note. TaskNotes exposes no stable public API, so this tries a
- * couple of plausible instance/api methods and returns whether one handled it;
- * the caller falls back to opening the file when it didn't. */
-function openInTaskNotes(view: HomeView, file: TFile): boolean {
-	const plugin = view.app.plugins.plugins[TASKNOTES_PLUGIN_ID] as
-		| Record<string, unknown>
-		| undefined;
-	if (!plugin) return false;
-	const targets: unknown[] = [plugin, plugin.api];
-	for (const target of targets) {
-		if (!target || typeof target !== "object") continue;
-		const obj = target as Record<string, unknown>;
-		for (const method of ["openTaskEditModal", "openTask"]) {
-			const fn = obj[method];
-			if (typeof fn === "function") {
-				try {
-					(fn as (f: TFile) => void).call(obj, file);
-					return true;
-				} catch {
-					// Wrong signature or internal error — fall through to file open.
-				}
-			}
+/** The slice of TaskNotes' plugin surface this uses. All optional and duck-typed:
+ * TaskNotes ships no stable public types, so each accessor is probed before use
+ * and may be absent or reshaped between versions. */
+interface TaskNotesLike {
+	openTaskEditModal?: (task: unknown) => unknown;
+	cacheManager?: { getTaskInfo?: (path: string) => unknown };
+	api?: { tasks?: { get?: (path: string) => unknown } };
+}
+
+/** Best-effort: open a TaskNotes task in TaskNotes' own edit modal rather than
+ * the raw Markdown note. TaskNotes exposes no stable public API, so this resolves
+ * the plugin's own task object for the file and hands it to `openTaskEditModal`,
+ * returning whether it handled the open; the caller falls back to opening the
+ * file when it didn't.
+ *
+ * The modal requires TaskNotes' `TaskInfo` (title/status/priority/…), not a
+ * `TFile`: passing the file leaves the modal with a broken change-detection
+ * baseline that traps every button but Delete (see issue #72). `openTaskEditModal`
+ * is async, so a bad argument never throws synchronously — resolving the info up
+ * front (and awaiting the open) is the only way to know we really handled it. */
+async function openInTaskNotes(view: HomeView, file: TFile): Promise<boolean> {
+	const plugin = view.app.plugins.plugins[TASKNOTES_PLUGIN_ID] as TaskNotesLike | undefined;
+	if (!plugin || typeof plugin.openTaskEditModal !== "function") return false;
+	const task = await resolveTaskNotesInfo(plugin, file.path);
+	if (!task) return false;
+	try {
+		await plugin.openTaskEditModal(task);
+		return true;
+	} catch {
+		// Internal error — fall through to a plain file open.
+		return false;
+	}
+}
+
+/** Resolve TaskNotes' `TaskInfo` for a note path via whichever accessor the
+ * installed version exposes: the cache manager first, then the public runtime
+ * API (`api.tasks.get`). Both are best-effort and may be absent or reshaped
+ * between TaskNotes versions, so failures fall through to the next. */
+async function resolveTaskNotesInfo(plugin: TaskNotesLike, path: string): Promise<unknown> {
+	const cache = plugin.cacheManager;
+	if (typeof cache?.getTaskInfo === "function") {
+		try {
+			const info = await cache.getTaskInfo(path);
+			if (info) return info;
+		} catch {
+			// Fall through to the public API.
 		}
 	}
-	return false;
+	const get = plugin.api?.tasks?.get;
+	if (typeof get === "function") {
+		try {
+			const info = await get(path);
+			if (info) return info;
+		} catch {
+			// No resolver worked.
+		}
+	}
+	return null;
 }
 
 async function openTask(view: HomeView, cfg: TasksConfig, hit: TaskHit, refresh: () => void): Promise<void> {
@@ -5846,7 +5878,7 @@ async function openTaskFile(view: HomeView, hit: TaskHit): Promise<void> {
 		return;
 	}
 	// TaskNotes tasks (no line) open in TaskNotes' own editor when possible.
-	if (hit.line < 0 && openInTaskNotes(view, hit.file)) return;
+	if (hit.line < 0 && (await openInTaskNotes(view, hit.file))) return;
 
 	const leaf = view.app.workspace.getLeaf(true);
 	await leaf.openFile(hit.file);


### PR DESCRIPTION
## What does this PR do?

Fixes the frozen/unresponsive TaskNotes edit modal reported in #72.

Opening an **existing** TaskNotes task from a Tasks card called TaskNotes'
`openTaskEditModal(file)` with the note's Obsidian `TFile`. TaskNotes' signature
is `openTaskEditModal(task: TaskInfo, …)` — it expects its own task object
(title/status/priority/due/…), not a file. TaskNotes builds the modal's
change-detection baseline from that object, so a `TFile` produced a broken
baseline: its overridden `close()` runs change detection before dismissing, and
with the bad baseline that path never reaches `super.close()`. The result
matches the report exactly — the X, Save, Cancel, Archive and Open Note buttons
were all trapped, and only **Delete** (which needs just `path`) worked.

Two details that explain the rest of the symptoms:
- **New tasks were fine** because creation goes through `executeCommandById(...)`,
  a proper command invocation with no argument-shape mismatch.
- **The existing `try/catch` fallback never fired** because `openTaskEditModal`
  is `async` and never throws synchronously, so Hearth reported success and never
  fell back to opening the note.

**The fix:** resolve TaskNotes' `TaskInfo` for the note first — via its cache
manager (`cacheManager.getTaskInfo`) or its public runtime API (`api.tasks.get`),
whichever the installed version exposes — and only open the modal when resolution
succeeds; otherwise fall back to opening the note. `openInTaskNotes` becomes
`async` so the open is awaited and genuine failures fall through. The accessors
are duck-typed and probed before use, so this stays robust across TaskNotes
versions (TaskNotes ships no stable public types). This mirrors TaskNotes' own
private `openTaskEditModalForFile` helper, which does the same
`getTaskInfo(path)` → `openTaskEditModal(taskInfo)` dance.

## Related issue

Closes #72

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (also `npm run typecheck`, `npm run lint`
  with 0 errors, and `npm test` — 99 passed / 1 skipped)
- [ ] I've tested this in an actual vault — not done in this environment; the fix
  is verified by build/typecheck/lint/tests and against the TaskNotes source, but
  a real-vault check against a TaskNotes install is still worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016erKxMm54pNrhBtiYyLjTn)_