### PR TITLE
Add per-dashboard header customization

### DIFF
--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -4,7 +4,15 @@ import {
 	type BackgroundConfig,
 	type BackgroundKind,
 	type Dashboard,
+	type DashboardHeaderConfig,
+	type HeaderAlign,
 	CARD_RADIUS_MAX,
+	HEADER_MARGIN_TOP_MAX,
+	HEADER_MARGIN_TOP_MIN,
+	HEADER_SCALE_MAX,
+	HEADER_SCALE_MIN,
+	HEADER_SPACING_BELOW_MAX,
+	HEADER_SPACING_BELOW_MIN,
 	DEFAULT_SETTINGS,
 	newDashboardId,
 	cloneCard,
@@ -18,13 +26,19 @@ import { t } from "./i18n";
  * look as the global background. */
 const DEFAULT_DASH_BG_OPACITY = DEFAULT_SETTINGS.backgroundOpacity;
 const DEFAULT_DASH_BG_BLUR = DEFAULT_SETTINGS.backgroundBlur;
+const DEFAULT_HEADER_SCALE = 1;
+const DEFAULT_HEADER_MARGIN_TOP = 24;
+const DEFAULT_HEADER_SPACING_BELOW = 28;
 
 /**
  * The top-left dashboard switcher: a button per dashboard (its emoji/icon or its
  * 1-based number) plus a "+" to add one. Clicking switches to it; right-clicking
  * opens a menu to edit its settings or delete it.
  */
-export function renderDashboardSwitcher(view: HomeView, container: HTMLElement): void {
+export function renderDashboardSwitcher(
+	view: HomeView,
+	container: HTMLElement,
+): void {
 	const s = view.plugin.settings;
 	const zone = container.createDiv("hearth-dash-switcher-zone");
 	zone.toggleClass("is-auto-hide", s.dashboardSwitcherVisibility === "hover");
@@ -100,7 +114,11 @@ export function renderDashboardSwitcher(view: HomeView, container: HTMLElement):
 }
 
 /** Context menu for a single dashboard button: settings and delete. */
-function showDashboardMenu(view: HomeView, dash: Dashboard, evt: MouseEvent): void {
+function showDashboardMenu(
+	view: HomeView,
+	dash: Dashboard,
+	evt: MouseEvent,
+): void {
 	const s = view.plugin.settings;
 	const menu = new Menu();
 
@@ -131,6 +149,7 @@ function showDashboardMenu(view: HomeView, dash: Dashboard, evt: MouseEvent): vo
 				if (dash.cardOpacity != null) copy.cardOpacity = dash.cardOpacity;
 				if (dash.cardBlur != null) copy.cardBlur = dash.cardBlur;
 				if (dash.cardRadius != null) copy.cardRadius = dash.cardRadius;
+				if (dash.header) copy.header = { ...dash.header };
 				if (dash.background) copy.background = { ...dash.background };
 				const i = s.dashboards.findIndex((d) => d.id === dash.id);
 				s.dashboards.splice(i + 1, 0, copy);
@@ -209,6 +228,7 @@ class DashboardSettingsModal extends HearthTabbedModal {
 		const tabs = t().dashboards.modal.tabs;
 		return [
 			{ id: "general", label: tabs.general, icon: "settings-2" },
+			{ id: "header", label: tabs.header, icon: "heading" },
 			{ id: "layout", label: tabs.layout, icon: "layout-dashboard" },
 			{ id: "style", label: tabs.style, icon: "palette" },
 			{ id: "background", label: tabs.background, icon: "image" },
@@ -219,6 +239,9 @@ class DashboardSettingsModal extends HearthTabbedModal {
 		switch (tabId) {
 			case "general":
 				this.generalSection(body);
+				break;
+			case "header":
+				this.headerSection(body);
 				break;
 			case "layout":
 				this.layoutSection(body);
@@ -235,7 +258,10 @@ class DashboardSettingsModal extends HearthTabbedModal {
 	/** Persistent footer shared by every tab: close the modal. */
 	protected hearthRenderFooter(footer: HTMLElement): void {
 		new Setting(footer).addButton((b) =>
-			b.setButtonText(t().dashboards.modal.done).setCta().onClick(() => this.close()),
+			b
+				.setButtonText(t().dashboards.modal.done)
+				.setCta()
+				.onClick(() => this.close()),
 		);
 	}
 
@@ -284,6 +310,233 @@ class DashboardSettingsModal extends HearthTabbedModal {
 			);
 	}
 
+	private ensureHeader(): DashboardHeaderConfig {
+		return (this.dash.header ??= {});
+	}
+
+	private clearEmptyHeader(): void {
+		const header = this.dash.header;
+		if (!header) return;
+		if (Object.values(header).every((v) => v === undefined)) {
+			this.dash.header = undefined;
+		}
+	}
+
+	private setHeaderOverride<K extends keyof DashboardHeaderConfig>(
+		key: K,
+		value: DashboardHeaderConfig[K] | undefined,
+	): void {
+		if (value === undefined) {
+			if (this.dash.header) delete this.dash.header[key];
+			this.clearEmptyHeader();
+			return;
+		}
+		this.ensureHeader()[key] = value;
+	}
+
+	/** Per-dashboard title/logo block overrides. Search visibility stays separate. */
+	private headerSection(containerEl: HTMLElement): void {
+		const dash = this.dash;
+		const s = this.view.plugin.settings;
+		const header = dash.header;
+
+		new Setting(containerEl)
+			.setName(t().dashboards.modal.titleVisibility)
+			.setDesc(t().dashboards.modal.titleVisibilityDesc)
+			.addDropdown((d) => {
+				d.addOption(
+					"default",
+					t().dashboards.modal.titleVisibilityDefault(
+						s.showTitle
+							? t().dashboards.modal.visibilityShown
+							: t().dashboards.modal.visibilityHidden,
+					),
+				);
+				d.addOption("show", t().dashboards.modal.visibilityShow);
+				d.addOption("hide", t().dashboards.modal.visibilityHide);
+				d.setValue(
+					header?.showTitle === undefined
+						? "default"
+						: header.showTitle
+							? "show"
+							: "hide",
+				);
+				d.onChange((v) => {
+					this.setHeaderOverride(
+						"showTitle",
+						v === "default" ? undefined : v === "show",
+					);
+					this.commit();
+					this.render();
+				});
+			});
+
+		this.overrideHeaderText(
+			containerEl,
+			t().dashboards.modal.titleText,
+			t().dashboards.modal.titleTextDesc,
+			header?.title,
+			s.title,
+			(v) => {
+				this.setHeaderOverride("title", v);
+				this.commit();
+			},
+		);
+
+		this.overrideHeaderText(
+			containerEl,
+			t().dashboards.modal.logoText,
+			t().dashboards.modal.logoTextDesc,
+			header?.logo,
+			s.logo,
+			(v) => {
+				this.setHeaderOverride("logo", v);
+				this.commit();
+			},
+		);
+
+		new Setting(containerEl)
+			.setName(t().dashboards.modal.titleAlign)
+			.setDesc(t().dashboards.modal.titleAlignDesc)
+			.addDropdown((d) => {
+				d.addOption("default", t().dashboards.modal.alignDefault);
+				d.addOption("left", t().dashboards.modal.alignLeft);
+				d.addOption("center", t().dashboards.modal.alignCenter);
+				d.addOption("right", t().dashboards.modal.alignRight);
+				d.setValue(header?.align ?? "default");
+				d.onChange((v) => {
+					this.setHeaderOverride(
+						"align",
+						v === "default" ? undefined : (v as HeaderAlign),
+					);
+					this.commit();
+					this.render();
+				});
+			});
+
+		this.overrideHeaderSlider(
+			containerEl,
+			t().dashboards.modal.titleSize,
+			header?.titleScale,
+			DEFAULT_HEADER_SCALE,
+			HEADER_SCALE_MIN,
+			HEADER_SCALE_MAX,
+			0.05,
+			(v) => {
+				this.setHeaderOverride("titleScale", v);
+				this.commit();
+			},
+		);
+
+		this.overrideHeaderSlider(
+			containerEl,
+			t().dashboards.modal.logoSize,
+			header?.logoScale,
+			DEFAULT_HEADER_SCALE,
+			HEADER_SCALE_MIN,
+			HEADER_SCALE_MAX,
+			0.05,
+			(v) => {
+				this.setHeaderOverride("logoScale", v);
+				this.commit();
+			},
+		);
+
+		this.overrideHeaderSlider(
+			containerEl,
+			t().dashboards.modal.titleTopMargin,
+			header?.marginTop,
+			DEFAULT_HEADER_MARGIN_TOP,
+			HEADER_MARGIN_TOP_MIN,
+			HEADER_MARGIN_TOP_MAX,
+			1,
+			(v) => {
+				this.setHeaderOverride("marginTop", v);
+				this.commit();
+			},
+		);
+
+		this.overrideHeaderSlider(
+			containerEl,
+			t().dashboards.modal.headerSpacingBelow,
+			header?.spacingBelow,
+			DEFAULT_HEADER_SPACING_BELOW,
+			HEADER_SPACING_BELOW_MIN,
+			HEADER_SPACING_BELOW_MAX,
+			1,
+			(v) => {
+				this.setHeaderOverride("spacingBelow", v);
+				this.commit();
+			},
+		);
+	}
+
+	private overrideHeaderText(
+		containerEl: HTMLElement,
+		name: string,
+		desc: string,
+		current: string | undefined,
+		fallback: string,
+		set: (value: string | undefined) => void,
+	): void {
+		const overriding = current !== undefined;
+		const row = new Setting(containerEl)
+			.setName(name)
+			.setDesc(
+				overriding
+					? desc
+					: t().dashboards.modal.usingDefaultText(fallback || "∅"),
+			)
+			.addToggle((tg) =>
+				tg.setValue(overriding).onChange((v) => {
+					set(v ? fallback : undefined);
+					this.render();
+				}),
+			);
+		if (overriding) {
+			row.addText((tx) =>
+				tx.setValue(current).onChange((v) => {
+					set(v);
+				}),
+			);
+		}
+	}
+
+	private overrideHeaderSlider(
+		containerEl: HTMLElement,
+		name: string,
+		current: number | undefined,
+		fallback: number,
+		min: number,
+		max: number,
+		step: number,
+		set: (value: number | undefined) => void,
+	): void {
+		const overriding = typeof current === "number";
+		const row = new Setting(containerEl)
+			.setName(name)
+			.setDesc(
+				overriding
+					? t().dashboards.modal.overriding
+					: t().dashboards.modal.usingDefault(fallback),
+			)
+			.addToggle((tg) =>
+				tg.setValue(overriding).onChange((v) => {
+					set(v ? fallback : undefined);
+					this.render();
+				}),
+			);
+		if (overriding) {
+			row.addSlider((sl) =>
+				sl
+					.setLimits(min, max, step)
+					.setValue(current)
+					.setDynamicTooltip()
+					.onChange((v) => set(v)),
+			);
+		}
+	}
+
 	/** Content width and fit-to-page, each an override of the global default. */
 	private layoutSection(containerEl: HTMLElement): void {
 		const dash = this.dash;
@@ -310,12 +563,20 @@ class DashboardSettingsModal extends HearthTabbedModal {
 				d.addOption(
 					"default",
 					t().dashboards.modal.fitDefault(
-						s.fitToPage ? t().dashboards.modal.fitStateFit : t().dashboards.modal.fitStateScroll,
+						s.fitToPage
+							? t().dashboards.modal.fitStateFit
+							: t().dashboards.modal.fitStateScroll,
 					),
 				);
 				d.addOption("fit", t().dashboards.modal.fitOptionFit);
 				d.addOption("scroll", t().dashboards.modal.fitOptionScroll);
-				d.setValue(dash.fitToPage === undefined ? "default" : dash.fitToPage ? "fit" : "scroll");
+				d.setValue(
+					dash.fitToPage === undefined
+						? "default"
+						: dash.fitToPage
+							? "fit"
+							: "scroll",
+				);
 				d.onChange((v) => {
 					dash.fitToPage = v === "default" ? undefined : v === "fit";
 					this.commit();
@@ -418,9 +679,11 @@ class DashboardSettingsModal extends HearthTabbedModal {
 			.setName(t().dashboards.modal.background)
 			.setDesc(t().dashboards.modal.backgroundDesc)
 			.addDropdown((d) => {
-				Object.entries(t().dashboards.backgroundOptions).forEach(([k, label]) => {
-					d.addOption(k, label);
-				});
+				Object.entries(t().dashboards.backgroundOptions).forEach(
+					([k, label]) => {
+						d.addOption(k, label);
+					},
+				);
 				d.setValue(bg ? bg.kind : "default").onChange((v) => {
 					if (v === "default") {
 						dash.background = undefined;
@@ -457,8 +720,26 @@ class DashboardSettingsModal extends HearthTabbedModal {
 				);
 		}
 
-		this.bgNumber(containerEl, t().dashboards.modal.opacity, bg, "opacity", 0, 1, 0.05, DEFAULT_DASH_BG_OPACITY);
-		this.bgNumber(containerEl, t().dashboards.modal.blur, bg, "blur", 0, 40, 1, DEFAULT_DASH_BG_BLUR);
+		this.bgNumber(
+			containerEl,
+			t().dashboards.modal.opacity,
+			bg,
+			"opacity",
+			0,
+			1,
+			0.05,
+			DEFAULT_DASH_BG_OPACITY,
+		);
+		this.bgNumber(
+			containerEl,
+			t().dashboards.modal.blur,
+			bg,
+			"blur",
+			0,
+			40,
+			1,
+			DEFAULT_DASH_BG_BLUR,
+		);
 	}
 
 	/** A per-dashboard background slider (opacity/blur) with a reset button that

--- a/src/header.ts
+++ b/src/header.ts
@@ -2,7 +2,17 @@ import { type Component, Platform, setIcon } from "obsidian";
 import type { HomeView } from "./view";
 import { SearchSection } from "./search";
 import { HEARTH_ICON_ID } from "./icon";
-import { effectiveShowSearch } from "./types";
+import {
+	effectiveHeaderAlign,
+	effectiveHeaderLogoScale,
+	effectiveHeaderMarginTop,
+	effectiveHeaderSpacingBelow,
+	effectiveHeaderTitleScale,
+	effectiveLogo,
+	effectiveShowSearch,
+	effectiveShowTitle,
+	effectiveTitle,
+} from "./types";
 import { t } from "./i18n";
 
 /** The search engine used by the “Search online” button action.
@@ -22,9 +32,22 @@ export function renderHeader(view: HomeView, container: HTMLElement, component: 
 	const s = view.plugin.settings;
 	const mobileOnly = Platform.isMobile && s.mobileSearchOnly;
 
-	if (s.showTitle) {
+	container.addClass(`is-title-align-${effectiveHeaderAlign(s)}`);
+	const spacingBelow = effectiveHeaderSpacingBelow(s);
+	if (spacingBelow !== undefined) {
+		container.style.setProperty("--hearth-header-spacing-below", `${spacingBelow}px`);
+	}
+
+	if (effectiveShowTitle(s)) {
 		const titleRow = container.createDiv("hearth-title");
-		const logo = s.logo.trim();
+		titleRow.style.setProperty("--hearth-title-scale", String(effectiveHeaderTitleScale(s)));
+		titleRow.style.setProperty("--hearth-logo-scale", String(effectiveHeaderLogoScale(s)));
+		const marginTop = effectiveHeaderMarginTop(s);
+		if (marginTop !== undefined) {
+			titleRow.style.setProperty("--hearth-title-margin-top", `${marginTop}px`);
+		}
+
+		const logo = effectiveLogo(s).trim();
 		// A custom emoji/text logo is shown verbatim; otherwise fall back to the
 		// Hearth crystal icon as the brand mark.
 		if (logo === "") {
@@ -33,7 +56,7 @@ export function renderHeader(view: HomeView, container: HTMLElement, component: 
 		} else {
 			titleRow.createSpan({ cls: "hearth-logo", text: logo });
 		}
-		titleRow.createSpan({ cls: "hearth-title-text", text: s.title });
+		titleRow.createSpan({ cls: "hearth-title-text", text: effectiveTitle(s) });
 	}
 
 	if (!effectiveShowSearch(s)) return;

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -59,6 +59,9 @@ const RANGE = {
 	cardH: { min: 1, max: 60 },
 	cardBlur: { min: 0, max: 24 },
 	cardRadius: { min: 0, max: 14 },
+	headerScale: { min: 0.6, max: 1.8 },
+	headerMarginTop: { min: 0, max: 96 },
+	headerSpacingBelow: { min: 0, max: 96 },
 };
 
 const CARD_KINDS: CardKind[] = [
@@ -165,6 +168,15 @@ function clampNum(
 	fallback: number,
 ): number {
 	return Math.max(min, Math.min(max, Math.round(num(value, fallback))));
+}
+
+function clampFloat(
+	value: unknown,
+	min: number,
+	max: number,
+	fallback: number,
+): number {
+	return Math.max(min, Math.min(max, num(value, fallback)));
 }
 
 function str(value: unknown): string | undefined {
@@ -677,6 +689,52 @@ function sanitizeDashboard(
 	}
 	if (typeof r.fitToPage === "boolean") dash.fitToPage = r.fitToPage;
 	if (typeof r.showSearch === "boolean") dash.showSearch = r.showSearch;
+	const rawHeader = r.header;
+	if (rawHeader && typeof rawHeader === "object") {
+		const h = rawHeader as Record<string, unknown>;
+		const header: NonNullable<Dashboard["header"]> = {};
+		if (typeof h.showTitle === "boolean") header.showTitle = h.showTitle;
+		const title = str(h.title);
+		if (title !== undefined) header.title = title;
+		const logo = str(h.logo);
+		if (logo !== undefined) header.logo = logo;
+		if (h.align === "left" || h.align === "center" || h.align === "right") {
+			header.align = h.align;
+		}
+		if (typeof h.titleScale === "number") {
+			header.titleScale = clampFloat(
+				h.titleScale,
+				RANGE.headerScale.min,
+				RANGE.headerScale.max,
+				1,
+			);
+		}
+		if (typeof h.logoScale === "number") {
+			header.logoScale = clampFloat(
+				h.logoScale,
+				RANGE.headerScale.min,
+				RANGE.headerScale.max,
+				1,
+			);
+		}
+		if (typeof h.marginTop === "number") {
+			header.marginTop = clampNum(
+				h.marginTop,
+				RANGE.headerMarginTop.min,
+				RANGE.headerMarginTop.max,
+				0,
+			);
+		}
+		if (typeof h.spacingBelow === "number") {
+			header.spacingBelow = clampNum(
+				h.spacingBelow,
+				RANGE.headerSpacingBelow.min,
+				RANGE.headerSpacingBelow.max,
+				0,
+			);
+		}
+		if (Object.keys(header).length > 0) dash.header = header;
+	}
 	if (typeof r.maxWidth === "number") {
 		dash.maxWidth = clampNum(
 			r.maxWidth,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -140,6 +140,7 @@ export const en = {
 			/** Tabs across the top of the dashboard settings modal. */
 			tabs: {
 				general: "General",
+				header: "Header",
 				layout: "Layout",
 				style: "Style",
 				background: "Background",
@@ -154,6 +155,30 @@ export const en = {
 			lucidePlaceholder: "home",
 			showSearch: "Show search section",
 			showSearchDesc: "Show the search and command bar with its results and filter buttons on this dashboard.",
+			titleVisibility: "Title visibility",
+			titleVisibilityDesc:
+				"Show or hide only the title/logo block for this dashboard. Search visibility is separate.",
+			titleVisibilityDefault: (state: string) => `Use global default (${state})`,
+			visibilityShown: "shown",
+			visibilityHidden: "hidden",
+			visibilityShow: "Show title",
+			visibilityHide: "Hide title",
+			titleText: "Title text",
+			titleTextDesc: "Override the global title text for this dashboard.",
+			logoText: "Logo text",
+			logoTextDesc:
+				"Override the global logo for this dashboard. Empty uses the Hearth crystal icon.",
+			titleAlign: "Title alignment",
+			titleAlignDesc:
+				"Align only the title/logo block. The search bar keeps its own layout.",
+			alignDefault: "Default (center)",
+			alignLeft: "Left",
+			alignCenter: "Center",
+			alignRight: "Right",
+			titleSize: "Title size",
+			logoSize: "Logo size",
+			titleTopMargin: "Title top margin",
+			headerSpacingBelow: "Spacing below title/header",
 			contentWidth: "Content width",
 			fitToPage: "Fit to page",
 			fitToPageDesc: "Override scrolling for this board.",
@@ -169,6 +194,10 @@ export const en = {
 			overriding: "Overriding the global default.",
 			usingGlobal: (value: number | string) =>
 				`Using global default (${value}).`,
+			usingDefault: (value: number | string) =>
+				`Using default (${value}).`,
+			usingDefaultText: (value: string) =>
+				`Using default (${value}).`,
 			background: "Background",
 			backgroundDesc: "Override the global background for this dashboard.",
 			backgroundValue: "Background value",

--- a/src/types.ts
+++ b/src/types.ts
@@ -521,6 +521,28 @@ export interface BackgroundConfig {
 
 /** A named dashboard: one arrangeable board of cards. The vault can hold several
  * and switch between them from the top-left switcher. */
+export type HeaderAlign = "left" | "center" | "right";
+
+export interface DashboardHeaderConfig {
+	/** Override the global title visibility (undefined = use global). */
+	showTitle?: boolean;
+	/** Override the global title text for this dashboard. */
+	title?: string;
+	/** Override the global logo text/icon for this dashboard. Empty = Hearth icon. */
+	logo?: string;
+	/** Align only the title/logo block; search remains controlled separately. */
+	align?: HeaderAlign;
+	/** Title size multiplier, clamped to a conservative range. */
+	titleScale?: number;
+	/** Logo size multiplier, clamped to a conservative range. */
+	logoScale?: number;
+	/** Title block top margin in pixels. Undefined keeps the stylesheet default. */
+	marginTop?: number;
+	/** Spacing below the whole header block in pixels. Undefined keeps the
+	 * stylesheet default. */
+	spacingBelow?: number;
+}
+
 export interface Dashboard {
 	id: string;
 	name: string;
@@ -546,6 +568,8 @@ export interface Dashboard {
 	cardBlur?: number;
 	/** Override the card corner radius (px) for this board (undefined = global). */
 	cardRadius?: number;
+	/** Per-dashboard overrides for the title/logo block. */
+	header?: DashboardHeaderConfig;
 	/** Show the dashboard search/command section (undefined = visible). */
 	showSearch?: boolean;
 }
@@ -842,6 +866,75 @@ export function effectiveFitToPage(s: HomeSettings): boolean {
 /** Whether the active board should show the search/command section. */
 export function effectiveShowSearch(s: HomeSettings): boolean {
 	return activeDashboard(s).showSearch ?? true;
+}
+
+export const HEADER_SCALE_MIN = 0.6;
+export const HEADER_SCALE_MAX = 1.8;
+export const HEADER_MARGIN_TOP_MIN = 0;
+export const HEADER_MARGIN_TOP_MAX = 96;
+export const HEADER_SPACING_BELOW_MIN = 0;
+export const HEADER_SPACING_BELOW_MAX = 96;
+
+function clampHeaderScale(v: unknown): number {
+	return typeof v === "number" && !Number.isNaN(v)
+		? Math.max(HEADER_SCALE_MIN, Math.min(HEADER_SCALE_MAX, v))
+		: 1;
+}
+
+function clampHeaderMarginTop(v: unknown): number | undefined {
+	return typeof v === "number" && !Number.isNaN(v)
+		? Math.max(HEADER_MARGIN_TOP_MIN, Math.min(HEADER_MARGIN_TOP_MAX, Math.round(v)))
+		: undefined;
+}
+
+function clampHeaderSpacingBelow(v: unknown): number | undefined {
+	return typeof v === "number" && !Number.isNaN(v)
+		? Math.max(
+				HEADER_SPACING_BELOW_MIN,
+				Math.min(HEADER_SPACING_BELOW_MAX, Math.round(v)),
+			)
+		: undefined;
+}
+
+/** Whether the active board should show the title/logo block. */
+export function effectiveShowTitle(s: HomeSettings): boolean {
+	return activeDashboard(s).header?.showTitle ?? s.showTitle;
+}
+
+/** Title text for the active board's title/logo block. */
+export function effectiveTitle(s: HomeSettings): string {
+	return activeDashboard(s).header?.title ?? s.title;
+}
+
+/** Logo text for the active board's title/logo block. Empty = Hearth icon. */
+export function effectiveLogo(s: HomeSettings): string {
+	return activeDashboard(s).header?.logo ?? s.logo;
+}
+
+/** Alignment for the active board's title/logo block; search layout is separate. */
+export function effectiveHeaderAlign(s: HomeSettings): HeaderAlign {
+	const align = activeDashboard(s).header?.align;
+	return align === "left" || align === "right" ? align : "center";
+}
+
+/** Title size multiplier for the active board's title/logo block. */
+export function effectiveHeaderTitleScale(s: HomeSettings): number {
+	return clampHeaderScale(activeDashboard(s).header?.titleScale);
+}
+
+/** Logo size multiplier for the active board's title/logo block. */
+export function effectiveHeaderLogoScale(s: HomeSettings): number {
+	return clampHeaderScale(activeDashboard(s).header?.logoScale);
+}
+
+/** Optional title block top margin override in pixels. Undefined keeps CSS default. */
+export function effectiveHeaderMarginTop(s: HomeSettings): number | undefined {
+	return clampHeaderMarginTop(activeDashboard(s).header?.marginTop);
+}
+
+/** Optional spacing below the whole header block in pixels. Undefined keeps CSS default. */
+export function effectiveHeaderSpacingBelow(s: HomeSettings): number | undefined {
+	return clampHeaderSpacingBelow(activeDashboard(s).header?.spacingBelow);
 }
 
 /** Effective content max-width for the active board (per-dashboard override or global). */

--- a/src/view.ts
+++ b/src/view.ts
@@ -5,7 +5,13 @@ import { renderDashboard } from "./dashboard";
 import { renderDashboardSwitcher } from "./dashboards";
 import { renderMobileActionBar } from "./mobileactions";
 import { applyBackground } from "./background";
-import { effectiveFitToPage, effectiveMaxWidth, effectiveShowSearch, renderCards } from "./types";
+import {
+	effectiveFitToPage,
+	effectiveMaxWidth,
+	effectiveShowSearch,
+	effectiveShowTitle,
+	renderCards,
+} from "./types";
 import { HEARTH_ICON_ID } from "./icon";
 import { t } from "./i18n";
 
@@ -130,7 +136,7 @@ export class HomeView extends ItemView {
 
 		if (!mobileOnly) renderDashboardSwitcher(this, inner);
 
-		if (this.plugin.settings.showTitle || effectiveShowSearch(this.plugin.settings)) {
+		if (effectiveShowTitle(this.plugin.settings) || effectiveShowSearch(this.plugin.settings)) {
 			const header = inner.createDiv("hearth-header");
 			renderHeader(this, header, child);
 		}

--- a/styles.css
+++ b/styles.css
@@ -51,7 +51,7 @@
 	width: 100%;
 	display: flex;
 	flex-direction: column;
-	gap: 28px;
+	gap: var(--hearth-inner-gap, 28px);
 }
 
 .hearth-fit .hearth-inner {
@@ -66,6 +66,10 @@
 	flex-direction: column;
 	align-items: center;
 	gap: 18px;
+	margin-bottom: calc(
+		var(--hearth-header-spacing-below, var(--hearth-inner-gap, 28px)) -
+		var(--hearth-inner-gap, 28px)
+	);
 	/* Sit above the dashboard so the search dropdown overlay isn't covered. */
 	position: relative;
 	z-index: 50;
@@ -109,12 +113,31 @@
 	font-weight: 700;
 	letter-spacing: -0.02em;
 	color: var(--text-normal);
-	margin-top: 2vh;
+	margin-top: var(--hearth-title-margin-top, 2vh);
+}
+
+.hearth-header.is-title-align-left .hearth-title {
+	align-self: flex-start;
+	text-align: left;
+}
+
+.hearth-header.is-title-align-center .hearth-title {
+	align-self: center;
+	text-align: center;
+}
+
+.hearth-header.is-title-align-right .hearth-title {
+	align-self: flex-end;
+	text-align: right;
 }
 
 .hearth-logo {
-	font-size: 0.9em;
+	font-size: calc(0.9em * var(--hearth-logo-scale, 1));
 	line-height: 1;
+}
+
+.hearth-title-text {
+	font-size: calc(1em * var(--hearth-title-scale, 1));
 }
 
 .hearth-logo-icon {
@@ -2514,7 +2537,8 @@
 	background: color-mix(in srgb, var(--background-primary) 88%, transparent);
 	backdrop-filter: blur(6px);
 	border-bottom: 1px solid var(--background-modifier-border);
-	border-radius: var(--hearth-card-radius, 14px) var(--hearth-card-radius, 14px) 0 0;
+	border-radius: var(--hearth-card-radius, 14px)
+		var(--hearth-card-radius, 14px) 0 0;
 }
 
 .hearth-card-title-input {
@@ -2685,7 +2709,7 @@
 }
 
 .hearth-compact .hearth-inner {
-	gap: 16px;
+	--hearth-inner-gap: 16px;
 }
 
 .hearth-compact .hearth-header {
@@ -2693,7 +2717,7 @@
 }
 
 .hearth-compact .hearth-title {
-	margin-top: 0;
+	margin-top: var(--hearth-title-margin-top, 0);
 }
 
 .hearth-compact .hearth-card-head {


### PR DESCRIPTION
## Summary

Adds constrained per-dashboard header/title customization while preserving the existing global defaults.

Per dashboard, users can now optionally override:

- title visibility
- title text
- logo text/icon
- title alignment
- title size
- logo size
- title top spacing
- spacing below the header block

Search visibility remains independent from title/header visibility, so dashboards can use combinations like title + search, title only, search only, or neither.

## Notes

- Existing global title/logo settings remain the fallback.
- Per-dashboard values are only applied when explicitly overridden.
- Import/export sanitizes the new header fields.
- Dashboard duplication preserves explicit header overrides.

Closes #74.

## Validation

- `npm run lint` — no errors, existing warnings only
- `npm run build`
- `npm test` — 99 passed, 1 skipped
