### PR TITLE
Add card border width setting

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -26,6 +26,7 @@ import {
 	activeCards,
 	cloneCard,
 	type DashboardCard,
+	effectiveCardBorderWidth,
 	effectiveCardOpacity,
 	effectiveCardRadius,
 	effectiveColumns,
@@ -87,6 +88,7 @@ export function renderDashboard(
 	// mask in grid.ts reads the resolved value back off the grid so its rounding
 	// matches. Merged-edge corners still flatten to 0 regardless (see styles.css).
 	grid.style.setProperty("--hearth-card-radius", `${effectiveCardRadius(s)}px`);
+	grid.style.setProperty("--card-border-width", `${effectiveCardBorderWidth(s)}px`);
 	const fit = effectiveFitToPage(s);
 	// In fit-to-page mode the board is locked to one screen, so leave the
 	// min-height to CSS (which clips the overflow). Otherwise grow the board

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -7,6 +7,7 @@ import {
 	type DashboardHeaderConfig,
 	type HeaderAlign,
 	CARD_RADIUS_MAX,
+	CARD_BORDER_WIDTH_MAX,
 	HEADER_MARGIN_TOP_MAX,
 	HEADER_MARGIN_TOP_MIN,
 	HEADER_SCALE_MAX,
@@ -149,6 +150,8 @@ function showDashboardMenu(
 				if (dash.cardOpacity != null) copy.cardOpacity = dash.cardOpacity;
 				if (dash.cardBlur != null) copy.cardBlur = dash.cardBlur;
 				if (dash.cardRadius != null) copy.cardRadius = dash.cardRadius;
+				if (dash.cardBorderWidth != null)
+					copy.cardBorderWidth = dash.cardBorderWidth;
 				if (dash.header) copy.header = { ...dash.header };
 				if (dash.background) copy.background = { ...dash.background };
 				const i = s.dashboards.findIndex((d) => d.id === dash.id);
@@ -629,6 +632,20 @@ class DashboardSettingsModal extends HearthTabbedModal {
 			1,
 			(v) => {
 				dash.cardRadius = v;
+				this.commit();
+			},
+		);
+
+		this.overrideSlider(
+			containerEl,
+			t().dashboards.modal.cardBorderWidth,
+			dash.cardBorderWidth,
+			s.cardBorderWidth,
+			0,
+			CARD_BORDER_WIDTH_MAX,
+			1,
+			(v) => {
+				dash.cardBorderWidth = v;
 				this.commit();
 			},
 		);

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -22,6 +22,7 @@ import {
 	type TaskSortRule,
 	type TasksConfig,
 	activeDashboard,
+	CARD_BORDER_WIDTH_MAX,
 } from "./types";
 import { isEmbeddableBaseViewName } from "./bases";
 import { t } from "./i18n";
@@ -59,6 +60,7 @@ const RANGE = {
 	cardH: { min: 1, max: 60 },
 	cardBlur: { min: 0, max: 24 },
 	cardRadius: { min: 0, max: 14 },
+	cardBorderWidth: { min: 0, max: CARD_BORDER_WIDTH_MAX },
 	headerScale: { min: 0.6, max: 1.8 },
 	headerMarginTop: { min: 0, max: 96 },
 	headerSpacingBelow: { min: 0, max: 96 },
@@ -144,6 +146,7 @@ export function exportSettings(s: HomeSettings): string {
 		cardOpacity: s.cardOpacity,
 		cardBlur: s.cardBlur,
 		cardRadius: s.cardRadius,
+		cardBorderWidth: s.cardBorderWidth,
 
 		// Search filters
 		hiddenFilters: s.hiddenFilters,
@@ -762,6 +765,14 @@ function sanitizeDashboard(
 			s.cardRadius,
 		);
 	}
+	if (typeof r.cardBorderWidth === "number") {
+		dash.cardBorderWidth = clampNum(
+			r.cardBorderWidth,
+			RANGE.cardBorderWidth.min,
+			RANGE.cardBorderWidth.max,
+			s.cardBorderWidth,
+		);
+	}
 	const bg = sanitizeBackground(r.background);
 	if (bg) dash.background = bg;
 	return dash;
@@ -1000,6 +1011,14 @@ function applySettings(s: HomeSettings, data: Record<string, unknown>): void {
 			RANGE.cardRadius.min,
 			RANGE.cardRadius.max,
 			s.cardRadius,
+		);
+	}
+	if (typeof data.cardBorderWidth === "number") {
+		s.cardBorderWidth = clampNum(
+			data.cardBorderWidth,
+			RANGE.cardBorderWidth.min,
+			RANGE.cardBorderWidth.max,
+			s.cardBorderWidth,
 		);
 	}
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -57,7 +57,8 @@ export const en = {
 		layoutImportError: (error: string) => `Hearth: ${error}`,
 		settingsExported: "Hearth: settings exported.",
 		settingsImported: "Hearth: settings imported.",
-		exportedToVault: (file: string) => `Hearth: saved ${file} to your vault's root folder.`,
+		exportedToVault: (file: string) =>
+			`Hearth: saved ${file} to your vault's root folder.`,
 		exportFailed: "Hearth: couldn't save the export file.",
 		cardCopied: "Card copied to the dashboard.",
 	},
@@ -190,6 +191,7 @@ export const en = {
 			cardOpacity: "Card opacity",
 			cardBlur: "Card blur",
 			cardRadius: "Card corner radius",
+			cardBorderWidth: "Card border",
 			done: "Done",
 			overriding: "Overriding the global default.",
 			usingGlobal: (value: number | string) =>
@@ -432,6 +434,9 @@ export const en = {
 			cardRadius: "Card corner radius",
 			cardRadiusDesc:
 				"How rounded card corners are, in pixels. 14 is the default; lower makes corners sharper.",
+			cardBorderWidth: "Card border",
+			cardBorderWidthDesc:
+				"Thickness of the card border and header divider, in pixels. 0 hides the border.",
 			cards: "Cards",
 			cardsDesc:
 				"Add and configure cards on the dashboard itself: open the home view, " +
@@ -445,7 +450,8 @@ export const en = {
 			export: "Export layout",
 			exportDesc: "Download the current dashboard layout as a JSON file.",
 			exportButton: "Export file",
-			exportMobileTooltip: "On mobile the file is saved to your vault's root folder.",
+			exportMobileTooltip:
+				"On mobile the file is saved to your vault's root folder.",
 			import: "Import layout",
 			importDesc:
 				"Choose a previously exported layout file. This replaces your current dashboards.",
@@ -1183,7 +1189,9 @@ export const en = {
 		notAnObject: "Layout must be a JSON object.",
 		noValidDashboards: "Layout contained no valid dashboards.",
 		noValidCards: "Layout contained no valid cards.",
-		notAHearthLayout: 'Not a Hearth layout — no "dashboards" or "cards" array found.',
-		notHearthSettings: 'Not a Hearth settings backup — no "hearthSettings" marker or layout found.',
+		notAHearthLayout:
+			'Not a Hearth layout — no "dashboards" or "cards" array found.',
+		notHearthSettings:
+			'Not a Hearth settings backup — no "hearthSettings" marker or layout found.',
 	},
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,7 +2,7 @@ import { type App, type ButtonComponent, Notice, Platform, PluginSettingTab, set
 import type HearthPlugin from "./main";
 import { FILE_TYPE_GROUPS, fileTypeLabel } from "./filetypes";
 import { CommandPickerModal } from "./pickers";
-import { type BackgroundKind, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, type MobileActionButton } from "./types";
+import { type BackgroundKind, CARD_BORDER_WIDTH_MAX, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, type MobileActionButton } from "./types";
 import { exportLayout, exportSettings, importLayout, importSettings } from "./layout";
 import { confirmAction, downloadTextFile, pickTextFile } from "./ui";
 import { isOmnisearchAvailable, OMNISEARCH_PLUGIN_ID } from "./omnisearch";
@@ -17,7 +17,8 @@ type NumericSettingKey =
 	| "backgroundBlur"
 	| "cardOpacity"
 	| "cardBlur"
-	| "cardRadius";
+	| "cardRadius"
+	| "cardBorderWidth";
 
 /** Keys of HomeSettings whose default lives in DEFAULT_SETTINGS as a string and
  * would be awkward to reconstruct by hand (frontmatter field names, the search
@@ -1057,6 +1058,20 @@ export class HomeSettingTab extends PluginSettingTab {
 					await this.save();
 				});
 			this.addSliderReset(cardRadius, sl, "cardRadius");
+		});
+
+		const cardBorderWidth = new Setting(containerEl)
+			.setName(t().settings.dashboard.cardBorderWidth)
+			.setDesc(t().settings.dashboard.cardBorderWidthDesc);
+		cardBorderWidth.addSlider((sl) => {
+			sl.setLimits(0, CARD_BORDER_WIDTH_MAX, 1)
+				.setValue(s.cardBorderWidth)
+				.setDynamicTooltip()
+				.onChange(async (v) => {
+					s.cardBorderWidth = v;
+					await this.save();
+				});
+			this.addSliderReset(cardBorderWidth, sl, "cardBorderWidth");
 		});
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -568,6 +568,8 @@ export interface Dashboard {
 	cardBlur?: number;
 	/** Override the card corner radius (px) for this board (undefined = global). */
 	cardRadius?: number;
+	/** Override the card border width (px) for this board (undefined = global). */
+	cardBorderWidth?: number;
 	/** Per-dashboard overrides for the title/logo block. */
 	header?: DashboardHeaderConfig;
 	/** Show the dashboard search/command section (undefined = visible). */
@@ -634,6 +636,9 @@ export interface HomeSettings {
 	 * design default of 14; larger is disallowed so nothing that assumes the
 	 * baseline rounding (merged-edge sharpening, the frost mask) breaks. */
 	cardRadius: number;
+	/** Card border width in pixels. 0 removes the visible card border and the
+	 * header divider line. */
+	cardBorderWidth: number;
 
 	// ---- Search filters ----
 	/** Group ids the user has hidden from the auto-detected filter row. */
@@ -714,6 +719,8 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	// The design baseline corner radius; also the maximum (only sharper is
 	// allowed) so it matches the hardcoded 14 the layout was tuned around.
 	cardRadius: 14,
+	// Default card border width preserves the classic 1px look.
+	cardBorderWidth: 1,
 
 	hiddenFilters: [],
 
@@ -974,6 +981,7 @@ export function resolveCardBlur(s: HomeSettings, card: DashboardCard): number {
  * allows: rounding beyond this was never tuned for (merged-edge sharpening, the
  * frosted-glass mask, arrange outlines) so only sharper is offered. */
 export const CARD_RADIUS_MAX = 14;
+export const CARD_BORDER_WIDTH_MAX = 8;
 
 /** Effective card corner radius (px) for the active board (per-dashboard
  * override or global), clamped to [0, CARD_RADIUS_MAX]. Applied board-wide via
@@ -984,6 +992,15 @@ export function effectiveCardRadius(s: HomeSettings): number {
 	return typeof v === "number" && !Number.isNaN(v)
 		? Math.max(0, Math.min(CARD_RADIUS_MAX, v))
 		: CARD_RADIUS_MAX;
+}
+
+/** Effective card border width (px) for the active board (per-dashboard
+ * override or global), clamped to [0, CARD_BORDER_WIDTH_MAX]. */
+export function effectiveCardBorderWidth(s: HomeSettings): number {
+	const v = activeDashboard(s).cardBorderWidth ?? s.cardBorderWidth;
+	return typeof v === "number" && !Number.isNaN(v)
+		? Math.max(0, Math.min(CARD_BORDER_WIDTH_MAX, Math.round(v)))
+		: 1;
 }
 
 /** Remove a card from whichever list holds it (a board or the pinned set). */
@@ -1089,6 +1106,7 @@ export function migrateSettings(s: HomeSettings, raw: Record<string, unknown>): 
 	if (typeof s.cardOpacity !== "number") s.cardOpacity = 0.5;
 	if (typeof s.cardBlur !== "number") s.cardBlur = 7;
 	if (typeof s.cardRadius !== "number") s.cardRadius = CARD_RADIUS_MAX;
+	if (typeof s.cardBorderWidth !== "number") s.cardBorderWidth = 1;
 	if (typeof s.backgroundOpacity !== "number") s.backgroundOpacity = 0.35;
 	if (typeof s.backgroundBlur !== "number") s.backgroundBlur = 2;
 	// Fit-to-page is the default for fresh installs; existing users keep their

--- a/styles.css
+++ b/styles.css
@@ -479,7 +479,8 @@
 	/* --hearth-card-radius (px) is set per-board by renderDashboard; the 14px
 	 * fallback keeps the design baseline when it isn't set. */
 	border-radius: var(--hearth-card-radius, 14px);
-	border: 1px solid var(--background-modifier-border);
+	border: var(--card-border-width, 1px) solid
+		var(--background-modifier-border);
 	/* --card-opacity (0..1) tints the card surface without dimming content. */
 	background: color-mix(
 		in srgb,
@@ -565,7 +566,8 @@
 	display: flex;
 	align-items: center;
 	padding: 10px 14px;
-	border-bottom: 1px solid var(--background-modifier-border);
+	border-bottom: var(--card-border-width, 1px) solid
+		var(--background-modifier-border);
 }
 
 .hearth-card-title {
@@ -2460,21 +2462,24 @@
 }
 
 /* Collapse the shared border between touching cards so there's no double line
- * — the two surfaces meet flush and look like a single tile. The card's own
- * background fills the now-borderless edge (box-sizing is border-box).
- * Deliberately placed after the accent rules so a touching edge goes
- * borderless even on accent-coloured cards. */
+ * — the two surfaces meet flush and look like a single tile. Remove the shared
+ * border width rather than making it transparent: at thicker border widths a
+ * transparent border still occupies space and reads as a notch/pike where
+ * merged edges meet the rounded outer frame. With border-box sizing this does
+ * not expand cards outward; it only lets the card background fill the shared
+ * edge inside the existing card box. Deliberately placed after the accent rules
+ * so a touching edge goes borderless even on accent-coloured cards. */
 .hearth-card.merge-top {
-	border-top-color: transparent;
+	border-top-width: 0;
 }
 .hearth-card.merge-bottom {
-	border-bottom-color: transparent;
+	border-bottom-width: 0;
 }
 .hearth-card.merge-left {
-	border-left-color: transparent;
+	border-left-width: 0;
 }
 .hearth-card.merge-right {
-	border-right-color: transparent;
+	border-right-width: 0;
 }
 
 /* Drop the drop-shadow on any card that shares a full edge with a neighbour.


### PR DESCRIPTION
## Summary

Adds a constrained global setting for card border width.

The setting controls:

- the outer card border
- the card header divider

Defaults preserve the current look:

- `1px` remains the default
- `0px` hides the visible border/divider
- higher values provide a stronger outline

Closes #76.

## Layout / sizing verification

I specifically checked the sizing concern around thicker borders.

Cards already use:

```css
.hearth-card {
  position: absolute;
  box-sizing: border-box;
}
```

The dashboard grid assigns card position and size via fixed inline geometry (`left`, `top`, `width`, `height`). Because the card uses `box-sizing: border-box`, increasing `border-width` is contained inside the assigned card box rather than expanding the card outward.

The header divider also uses the same border-width variable. This can slightly reduce the available inner body space for titled cards at higher values, but it does not change the outer card dimensions; the card body remains scrollable.

I also checked that merged edges, card radius, accent colors, and card backgrounds still operate independently of the border width setting.

## Validation

- `npm run lint` — no errors, existing warnings only
- `npm run build`
- `npm test` — 99 passed, 1 skipped
