### PR TITLE
docs(releasing): document the release-train cadence; add /release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: release
+description: >-
+  Cut a Hearth beta or promote a beta to stable, following the release-train
+  cadence in RELEASING.md. Use whenever the request is to "cut a beta",
+  "promote (the) beta to stable", "release <version>", "open the next beta",
+  or "ship stable". Handles the stable/beta two-manifest split, the
+  beta-parity guard, cutting the release via a pushed tag OR via
+  workflow_dispatch when tag pushes are blocked, and landing the store
+  manifest on a protected main through a PR.
+---
+
+# Releasing Hearth
+
+Hearth ships on a **release train**, not a freeze-and-cut model. Internalise the
+cadence before touching anything — it is the source of every subtle rule below.
+
+## The cadence (mental model)
+
+```
+main ──●──●──●───────●──●──●───────●──●──▶   (never freezes; always moving)
+        \           /   ↑ next-cycle work    \
+         └ tag 1.12.0-beta.1                   └ tag 1.13.0-beta.1
+           (snapshot, soaks ~days)               (next snapshot)
+                       │
+                       └─ promote ─▶ tag 1.12.0  (version-only bump of the SNAPSHOT,
+                                                   NOT of main HEAD)
+```
+
+- A **beta tag is a snapshot** of `main` at cut time. It soaks with BRAT testers.
+- **While it soaks, `main` keeps moving** — those new commits are the *next*
+  version's work, not this one's.
+- **Promotion ships the snapshot**, byte-for-byte. It is a version-only bump
+  committed **on top of the beta-tested commit**, never a fresh build of `main`.
+- So at promotion time `main` will *always* be ahead of the beta. That is
+  normal and correct — it does **not** block promotion (see "drift" below).
+
+Always read `RELEASING.md` first; this skill is the operational runbook for it.
+
+## Preflight (do this every time, before deciding anything)
+
+```sh
+git fetch origin --tags
+node -p "require('./manifest.json').version"        # current STABLE
+node -p "require('./manifest-beta.json').version"   # current BETA line
+git tag -l "*-beta.*" --sort=-v:refname | head      # existing beta snapshots
+git log --oneline "$(git describe --tags --abbrev=0 --match '*-beta.*')"..origin/main -- src styles.css esbuild.config.mjs
+```
+
+Then classify the drift you see on `main` since the newest beta:
+
+- Commits are **next-version** work → normal train movement. Promote the beta
+  as-is; those commits become the next beta line.
+- Commits are **this-version** work (a fix/feature you intend to ship in the
+  stable you're about to cut) → they were never soaked. Do **not** fold them in
+  silently: cut a fresh `beta.N` from `main`, let it soak, and promote *that*.
+
+## Operation A — Cut a beta from `main`
+
+1. Bump **`manifest-beta.json` only** → `"version": "X.Y.Z-beta.N"`. Never touch
+   `manifest.json` (that is the store-facing stable manifest).
+2. Make sure `CHANGELOG.md`'s top `## [X.Y.Z]` section describes this beta line
+   and lists only what this build actually contains.
+3. Commit (`chore: cut X.Y.Z-beta.N` or `chore: beta X.Y.Z-beta.N`).
+4. Cut the release (see "Cutting the actual release" — the tag name **is** the
+   version, no `v` prefix). The workflow publishes it as a **pre-release**.
+
+## Operation B — Promote a beta to stable (+ open the next beta line)
+
+This is two commits on **two different bases** — do not try to do it as one
+commit on `main`, or the beta-parity guard will reject the stable tag.
+
+### B1. The stable promotion commit (base = the beta-tested commit)
+
+```sh
+git checkout -b promote-X.Y.Z <the X.Y.Z-beta.N commit>   # e.g. the tag itself
+# version-only bump, NO src/styles.css/esbuild changes:
+#   manifest.json   → "X.Y.Z"
+#   versions.json   → add "X.Y.Z": "<minAppVersion>"
+#   package.json    → "X.Y.Z"
+#   CHANGELOG.md     → finalise the [X.Y.Z] section (only what this build ships)
+git commit -am "chore: release X.Y.Z"
+# GUARD SELF-CHECK — must print nothing:
+git diff --stat "$(git tag -l 'X.Y.Z-*' | sort -V | tail -1)" HEAD -- src styles.css esbuild.config.mjs
+```
+
+Tag this commit `X.Y.Z`. It is fine (and expected) that this commit is not on
+`main` — the stable tag points at it; `main` moves on independently.
+
+### B2. Open the next beta line + update the store manifest (base = `main`)
+
+On a branch off current `main`, in one commit:
+
+- `manifest.json`      → `X.Y.Z`  (store now offers the freshly promoted stable)
+- `versions.json`      → add `"X.Y.Z": "<minAppVersion>"`
+- `package.json`       → `X.Y.Z`
+- `manifest-beta.json` → `X.(Y+1).0-beta.1`  (opens the next line)
+- `CHANGELOG.md`       → new `## [X.(Y+1).0]` section on top, holding the
+  next-version work already on `main`; make sure `[X.Y.Z]` lists only what the
+  stable actually ships (move mis-filed next-version entries up).
+
+Commit (`chore: release X.Y.Z, open X.(Y+1).0-beta.1`). Optionally tag the head
+`X.(Y+1).0-beta.1` if you want to cut beta.1 immediately — but a beta.1 with
+zero soak is only a placeholder; the meaningful soak build is whatever beta.N
+you cut later once you're ready to test.
+
+## Cutting the actual release
+
+`RELEASING.md`'s canonical path is **push the tag** (`git tag X.Y.Z && git push
+origin X.Y.Z`); the `Release Obsidian plugin` workflow does the rest.
+
+**If tag pushes are blocked** (in Claude Code on the web the egress proxy
+rejects `refs/tags/*` pushes with HTTP 403 — do not retry, it is policy), use
+the workflow's `workflow_dispatch` entry point instead, which is the same path
+every recent release used:
+
+```
+mcp__github__actions_run_trigger  method=run_workflow  workflow_id=release.yml
+  ref=<branch that carries the release commit>
+  inputs={ "version": "<exact tag>" }   # REQUIRED for betas, else it defaults to manifest.json
+```
+
+`gh release create` inside the workflow mints the tag on GitHub's side, so this
+sidesteps the blocked local push while still enforcing every guard. Push the
+branch that holds the commit first (branch pushes are allowed) so the dispatch
+ref exists. Verify with `mcp__github__list_releases` that the stable is
+`prerelease:false` (pinned latest) and the beta is `prerelease:true`.
+
+## Landing the store manifest on `main`
+
+The Obsidian community store reads `manifest.json` at **`main`'s HEAD**, so the
+promotion is not user-visible until the B2 commit is on `main`. `main` is
+branch-protected (requires the "Typecheck & build" check), so direct pushes are
+rejected — land it via a PR and merge once the check is green.
+
+## Guard self-checks (mirror what CI / the release workflow enforce)
+
+- **Tag ↔ manifest:** stable tag `X.Y.Z` must equal `manifest.json`; pre-release
+  tag must equal `manifest-beta.json`.
+- **Beta parity (stable only):** `git diff --quiet <newest X.Y.Z-*.beta tag>
+  HEAD -- src styles.css esbuild.config.mjs` must succeed. A version-only
+  promotion passes; a diverged `main` fails.
+- **versions.json** contains an entry for `manifest.json`'s version.
+- **manifest-beta.json** is a pre-release strictly ahead of `manifest.json` and
+  differs from it in `version` only.
+- **manifest.json** is always plain `x.y.z` (a beta there ships to every stable
+  user). Never four-segment (`1.8.1.4-beta` is invalid semver, is rejected, and
+  silently becomes "latest").
+- **CHANGELOG** top entry is the in-flight version, and each section lists only
+  what that build ships.
+- Run `node scripts/verify-manifests.mjs` on the `main`-facing branch to confirm
+  the manifest/version/changelog invariants before opening the PR.
+
+## Never
+
+- Never create a release by hand through the GitHub UI.
+- Never put a `-beta` version in `manifest.json`.
+- Never carry `src/` / `styles.css` / `esbuild.config.mjs` changes into a
+  promotion commit — promotion is version/label only.
+- Never delete old tags to "fix" a bad release; cut a new, correctly-versioned
+  one and let the channel checks reconcile the store.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,6 +30,30 @@ the community store never touches. CI enforces this: a non-`x.y.z` version in
 | `manifest-beta.json` | BRAT only | latest **beta** `x.y.z-beta.N` |
 | `versions.json` | store (compatibility fallback) | **stable** versions only |
 
+## Release cadence: a train, not a freeze
+
+Hearth releases run as a **train**. `main` never freezes:
+
+1. Work lands on `main` and is tested there commit by commit.
+2. When a version's worth of work is ready, **cut a beta snapshot** of `main`
+   (`x.y.z-beta.N`) and let it soak with BRAT testers for a few days.
+3. **Promote** that snapshot to stable `x.y.z` — a version-only bump of the
+   **beta-tested commit** (see below), not a fresh build of `main`.
+4. While the beta soaks, the *next* version's features keep merging into `main`;
+   they become the next beta line. Go to 2.
+
+Two consequences fall out of this and drive the rules below:
+
+- **At promotion time `main` is always ahead of the beta you're promoting.**
+  That drift is the next cycle's work — it is expected and does **not** block
+  promotion. What you ship as `x.y.z` is the soaked snapshot, and the
+  beta-parity guard makes sure of it.
+- **`manifest-beta.json` tracks the open line.** Promoting `x.y.z` is also when
+  you *open the next line* by bumping `manifest-beta.json` to `x.(y+1).0-beta.1`.
+  Opening a line (a manifest bump) is separate from cutting a soak build (the
+  tag you actually test): a `beta.1` tagged at open-time with no soak is just a
+  placeholder — the meaningful build is whatever `beta.N` you cut when ready.
+
 ## Versioning
 
 Obsidian requires plain [semver](https://semver.org/) `x.y.z` versions. The tag
@@ -79,11 +103,20 @@ becomes "latest" for all users. Use `1.9.0-beta.4`, not `1.8.1.4-beta`.
 > such beta exists). This is what stops a beta's un-tested code — a new feature,
 > a refactor — from riding a stable tag straight into the store.
 
-**First, make sure `main` hasn't drifted past the beta.** If commits touching
-`src/` / `styles.css` have landed since the last `x.y.z-beta.N` you shipped,
-those changes were **never beta-tested**. Do **not** promote — cut a fresh beta
-from current `main` (bump `manifest-beta.json`, tag `x.(y+1).0-beta.1` or the
-next `-beta.N`), let it soak, and promote _that_.
+**First, check what has drifted onto `main` since the beta.** Because the train
+never freezes (see "Release cadence"), `main` is normally ahead of the beta
+you're promoting — and that's fine when the drift is **next-version** work: it
+stays on `main` and becomes the next beta line, while you promote the soaked
+snapshot as-is.
+
+The drift only blocks promotion when it's **this-version** work: a fix or change
+you intend to ship *in the stable you're about to cut* that landed after the
+`x.y.z-beta.N` you soaked. Those changes were **never beta-tested**, so do
+**not** fold them into the promotion. Cut a fresh beta from current `main`
+(bump `manifest-beta.json` to the next `-beta.N`, tag it), let it soak, and
+promote _that_. The beta-parity guard enforces this either way — it will reject
+a stable tag whose build inputs differ from the beta, so this-version work
+cannot ride a promotion without its own beta.
 
 To promote:
 
@@ -103,6 +136,20 @@ To promote:
    ```
 4. The workflow verifies the tag matches `manifest.json`, confirms beta parity
    (above), builds, attaches the assets, and pins the tag as **latest**.
+5. **Land the store manifest on `main`, and open the next line.** The community
+   store reads `manifest.json` at `main`'s HEAD, so the promotion isn't
+   user-visible until `main` carries it. When `main` has already moved past the
+   beta (the usual train case), the tagged promotion commit from step 1 lives on
+   the beta line, **not** on `main` — so make a separate commit on `main` that
+   both bumps the store-facing files to the new stable **and** opens the next
+   beta line, e.g. `chore: release 1.9.0, open 1.10.0-beta.1`:
+   - `manifest.json` → `"1.9.0"`, `versions.json` += `"1.9.0"`, `package.json` → `"1.9.0"`
+   - `manifest-beta.json` → `"1.10.0-beta.1"`
+   - `CHANGELOG.md` → open a `## [1.10.0]` section for the next-version work
+     already on `main`, and make sure `[1.9.0]` lists only what the stable
+     actually ships (move any next-version entries up).
+   `main` is branch-protected, so land this through a PR (the `Typecheck &
+   build` check must pass), not a direct push.
 
 > Genuine emergency hotfix with no beta? Run the workflow from the **Actions
 > tab** (`workflow_dispatch`) with `allow_no_beta = true`. This is the only


### PR DESCRIPTION
## What does this PR do?

Makes the release process match Hearth's actual **release-train** cadence (main never freezes; betas are snapshots that soak while next-cycle work keeps landing) and adds a reusable skill so cutting/promoting is guided next time.

**`RELEASING.md`** — three surgical edits:
- New **"Release cadence: a train, not a freeze"** section: beta snapshots, soak, version-only promotion of the beta-tested commit, next cycle accumulating on `main` during soak.
- **Reframed the drift warning** from "main drifted → don't promote" to the real test — *next-version* drift is normal and promotes fine; only *this-version* work landed after the beta needs its own fresh beta. The beta-parity guard enforces it either way.
- **Added promote step 5**: open the next beta line (`manifest-beta.json` → `x.(y+1).0-beta.1`) and land the store manifest on the protected `main` via PR (the two-base reality — the tagged promotion commit sits on the beta line, `main` gets a separate store-manifest+open-next commit).

**`.claude/skills/release/SKILL.md`** (new) — invocable as `/release`. A runbook for cutting a beta or promoting to stable: the cadence, preflight drift-classification, both operations, guard self-checks, and the environment path (tag pushes are egress-blocked here → `workflow_dispatch` on a branch; protected `main` → PR).

Docs + skill only — no `src/`, `styles.css`, `esbuild.config.mjs`, or version-file changes. `node scripts/verify-manifests.mjs` passes.

## Related issue

n/a — process docs / tooling.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [x] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (`verify:manifests` clean; no code touched)
- [ ] I've tested this in an actual vault — **N/A**: documentation and a Claude Code skill only, no runtime code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPF4uyKifLMZPRdVmmoMSz)_