### PR TITLE
feat(bookmarks): render bookmark groups as collapsible folders (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   that note's body. The card's title and metadata line is left untouched (#71).
 - **Card border width setting.** A new global setting controls the width of
   card borders (#78).
+- **Bookmark groups (folders).** The Bookmarks card now mirrors Obsidian's own
+  bookmarks pane: groups render as collapsible folders (click the header to
+  expand or collapse) and sub-groups nest to any depth, instead of every
+  bookmark being flattened into one list. This also fixes bookmarks inside a
+  group appearing twice — the card previously re-flattened Obsidian's already
+  flat `getBookmarks()` list — and drops groups left empty after orphaned
+  file/folder bookmarks are hidden (#82).
 
 ### Fixed
 

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -1369,70 +1369,125 @@ function renderWeb(card: DashboardCard, body: HTMLElement, component: Component)
 
 // ---- Bookmarks (Obsidian core) -----------------------------------------
 
-function flattenBookmarks(items: BookmarkItem[], out: BookmarkItem[]): void {
+/** Recursively drop bookmarks whose target no longer exists and groups left with
+ * nothing live inside them, returning a fresh, pruned copy of the tree.
+ *
+ * Obsidian keeps a file/folder bookmark in its store even after the target is
+ * deleted (the entry only goes away if the bookmark itself is removed), but its
+ * native pane hides those orphans. We mirror that so the card never shows dead,
+ * unclickable rows (see issue #41). A group whose whole subtree prunes away is
+ * dropped too, rather than leaving an empty folder in the card. */
+function pruneBookmarks(items: BookmarkItem[], view: HomeView): BookmarkItem[] {
+	const out: BookmarkItem[] = [];
 	for (const item of items) {
-		if (item.type === "group" && item.items) {
-			flattenBookmarks(item.items, out);
-		} else {
-			out.push(item);
+		if (item.type === "group") {
+			const children = pruneBookmarks(item.items ?? [], view);
+			if (children.length > 0) out.push({ ...item, items: children });
+			continue;
 		}
+		if ((item.type === "file" || item.type === "folder") && item.path) {
+			if (view.app.vault.getAbstractFileByPath(item.path) === null) continue;
+		}
+		out.push(item);
 	}
+	return out;
 }
 
 function renderBookmarks(view: HomeView, body: HTMLElement): void {
 	const plugin = view.app.internalPlugins.getPluginById("bookmarks");
 	const instance = plugin?.instance as
-		| { getBookmarks?: () => BookmarkItem[] }
+		| { items?: BookmarkItem[]; getBookmarks?: () => BookmarkItem[] }
 		| undefined;
 
-	if (!plugin?.enabled || !instance?.getBookmarks) {
+	if (!plugin?.enabled || !instance) {
 		emptyState(body, "bookmark", t().cards.empty.bookmarksEnable);
 		return;
 	}
 
-	const items: BookmarkItem[] = [];
-	flattenBookmarks(instance.getBookmarks() ?? [], items);
+	// `instance.items` is the *nested* bookmark tree: a group holds its children
+	// under `items`. `getBookmarks()`, by contrast, returns a flat list that
+	// promotes every grouped bookmark to the top level while the group node keeps
+	// its own children — so walking that as a tree renders grouped bookmarks
+	// twice (issue #82). Use the tree; fall back to the flat list (leaves only)
+	// on the off chance an older build doesn't expose `items`.
+	const roots = Array.isArray(instance.items)
+		? instance.items
+		: (instance.getBookmarks?.() ?? []).filter((i) => i.type !== "group");
+	const tree = pruneBookmarks(roots, view);
 
-	// Obsidian keeps a file/folder bookmark in its store even after the target is
-	// deleted (the entry only goes away if the bookmark itself is removed), but its
-	// native pane hides those orphans. `getBookmarks()` returns the raw store, so we
-	// drop file/folder bookmarks whose target no longer exists to match Obsidian and
-	// avoid rendering dead, unclickable rows (see issue #41).
-	const live = items.filter((item) => {
-		if ((item.type === "file" || item.type === "folder") && item.path) {
-			return view.app.vault.getAbstractFileByPath(item.path) !== null;
-		}
-		return true;
-	});
-
-	if (live.length === 0) {
+	if (tree.length === 0) {
 		emptyState(body, "bookmark", t().cards.empty.bookmarksEmpty);
 		return;
 	}
 
-	const list = body.createDiv("hearth-list");
-	for (const item of live) {
-		const label =
-			item.title ||
-			item.path ||
-			item.url ||
-			item.query ||
-			t().cards.bookmarks.untitled;
-		const row = list.createDiv("hearth-list-item");
-		const iconEl = row.createDiv("hearth-list-icon");
-		if (item.type === "url" && item.url) {
-			renderFavicon(iconEl, item.url);
+	renderBookmarkItems(view, body.createDiv("hearth-list"), tree);
+}
+
+/** Render a level of the bookmark tree into `container`, recursing into groups
+ * so the card mirrors Obsidian's own collapsible folder layout. */
+function renderBookmarkItems(
+	view: HomeView,
+	container: HTMLElement,
+	items: BookmarkItem[],
+): void {
+	for (const item of items) {
+		if (item.type === "group") {
+			renderBookmarkGroup(view, container, item);
 		} else {
-			const icon =
-				item.type === "folder" ? "folder" :
-				item.type === "search" ? "search" : "file-text";
-			setIcon(iconEl, icon);
+			renderBookmarkLeaf(view, container, item);
 		}
-		row.createDiv({ cls: "hearth-list-label", text: label });
-		const open = () => openBookmark(view, item);
-		row.addEventListener("click", open);
-		makeClickable(row, open, label);
 	}
+}
+
+/** A collapsible folder: a header row that toggles its nested children, which
+ * are themselves rendered recursively so sub-groups nest to any depth. */
+function renderBookmarkGroup(
+	view: HomeView,
+	container: HTMLElement,
+	group: BookmarkItem,
+): void {
+	const label = group.title || t().cards.bookmarks.untitled;
+	const wrap = container.createDiv("hearth-bookmark-group");
+	const header = wrap.createDiv("hearth-list-item hearth-bookmark-group-header");
+	setIcon(header.createDiv("hearth-list-icon hearth-bookmark-chevron"), "chevron-right");
+	setIcon(header.createDiv("hearth-list-icon"), "folder");
+	header.createDiv({ cls: "hearth-list-label", text: label });
+
+	const children = wrap.createDiv("hearth-bookmark-group-children");
+	renderBookmarkItems(view, children, group.items ?? []);
+
+	const toggle = () => wrap.classList.toggle("is-collapsed");
+	header.addEventListener("click", toggle);
+	makeClickable(header, toggle, label);
+}
+
+/** A single (non-group) bookmark row: file, folder, url, search or graph. */
+function renderBookmarkLeaf(
+	view: HomeView,
+	container: HTMLElement,
+	item: BookmarkItem,
+): void {
+	const label =
+		item.title ||
+		item.path ||
+		item.url ||
+		item.query ||
+		t().cards.bookmarks.untitled;
+	const row = container.createDiv("hearth-list-item");
+	const iconEl = row.createDiv("hearth-list-icon");
+	if (item.type === "url" && item.url) {
+		renderFavicon(iconEl, item.url);
+	} else {
+		const icon =
+			item.type === "folder" ? "folder" :
+			item.type === "search" ? "search" :
+			item.type === "graph" ? "git-fork" : "file-text";
+		setIcon(iconEl, icon);
+	}
+	row.createDiv({ cls: "hearth-list-label", text: label });
+	const open = () => openBookmark(view, item);
+	row.addEventListener("click", open);
+	makeClickable(row, open, label);
 }
 
 /** Show a site favicon for a URL bookmark, falling back to the globe icon if the

--- a/styles.css
+++ b/styles.css
@@ -1172,6 +1172,39 @@
 	text-overflow: ellipsis;
 }
 
+/* Bookmark groups (folders): collapsible, nesting to any depth like Obsidian's
+   own bookmarks pane. The group wraps a header row over its children. */
+.hearth-bookmark-group,
+.hearth-bookmark-group-children {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+/* Indent each nested level so the tree structure reads at a glance. Because
+   groups nest in the DOM, the padding compounds one step per level. */
+.hearth-bookmark-group-children {
+	padding-left: 16px;
+}
+
+.hearth-bookmark-group-header {
+	gap: 4px;
+}
+
+.hearth-bookmark-chevron {
+	color: var(--text-faint);
+	transition: transform 0.12s ease;
+}
+
+/* Chevron points right when collapsed, rotates down when open. */
+.hearth-bookmark-group:not(.is-collapsed) > .hearth-bookmark-group-header .hearth-bookmark-chevron {
+	transform: rotate(90deg);
+}
+
+.hearth-bookmark-group.is-collapsed > .hearth-bookmark-group-children {
+	display: none;
+}
+
 /* Tasks card */
 .hearth-task-text {
 	flex: 1;


### PR DESCRIPTION
## What does this PR do?

The Bookmarks card now mirrors Obsidian's own bookmarks pane: **groups render as collapsible folders** (click a folder header to expand/collapse) and sub-groups nest to any depth, instead of every bookmark being flattened into one flat list.

This also fixes the duplication reported in #82. Root cause: the card walked Obsidian's `getBookmarks()`, which — per the internal API — returns a **flat** list that promotes every grouped bookmark to the top level *while each group node still carries its own children*. Hearth then re-flattened that list by recursing into the group nodes, so each grouped bookmark was counted twice (loose bookmarks, which aren't in a group node, appeared once — exactly the reported symptom).

The fix renders the nested `instance.items` tree (the source-of-truth structure that groups actually nest under) rather than the flat `getBookmarks()` output:

- Groups become collapsible folder rows (chevron + folder icon + title); children render underneath, indented, recursing so sub-groups nest to any depth.
- Orphan pruning (hiding `file`/`folder` bookmarks whose target was deleted, from #41) now runs recursively through the tree, and a group left empty after pruning is dropped rather than showing an empty folder.
- Falls back to the flat list (leaves only, group nodes filtered out) if an older build doesn't expose `items`, so it degrades gracefully.
- Adds a `git-fork` icon for `graph`-type bookmarks (previously fell through to the generic file icon).

## Related issue

Closes #82

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (also: `npm test` → 99 passed / 1 skipped, `npm run lint` → 0 errors)
- [ ] I've tested this in an actual vault — verified via build + unit tests plus a simulation of the flat-vs-nested walk (old logic reproduces the duplicate, new logic renders each bookmark once under its folder). Worth a manual check in a live vault with grouped bookmarks before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLF5wxZFahdz7wmvnvSay4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLF5wxZFahdz7wmvnvSay4)_