### PR TITLE
fix: open files in place from the dashboard instead of a new tab (#84)

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -19,6 +19,16 @@ export const VIEW_TYPE_HOME = "hearth-home-view";
 
 export class HomeView extends ItemView {
 	plugin: HearthPlugin;
+	/**
+	 * Mark the dashboard as a navigable pane (the base `View` default is
+	 * `false`). A non-navigable leaf is treated like the file explorer or
+	 * calendar: Obsidian won't reuse it to open a file, so clicking a note in
+	 * the file explorer while the dashboard is focused spawns a *new* tab and
+	 * leaves the file explorer's selection stuck on that note (#84). With
+	 * navigation enabled, opening a file replaces the dashboard in place — the
+	 * dashboard behaves like any editor tab and the selection tracks correctly.
+	 */
+	navigation = true;
 	/** Whether the dashboard is in layout/arrange mode (drag & resize). */
 	arrangeMode = false;
 	/** In arrange mode, optionally hide the per-card headers (title input +


### PR DESCRIPTION
## What does this PR do?

Fixes the file-opening bug reported in #84. When the Hearth dashboard was focused and you clicked a note in the file explorer, Obsidian opened it in a **new tab** and left the file explorer's selection stuck on that note — re-clicking the same note did nothing until you opened a different file first.

The cause: `HomeView` never set the `navigation` property, so it inherited the base `View` default of `false`. Obsidian treats a non-navigable leaf like the file explorer or calendar — it won't reuse that leaf to open a file, and it doesn't advance the "active file" when the leaf is focused. That produced both symptoms: the new tab and the stale selection.

The fix sets `navigation = true` on `HomeView`, so the dashboard behaves like a regular editor tab: opening a file replaces the dashboard in place and the file explorer selection tracks correctly.

## Related issue

Closes #84

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] `npm run build` passes locally (typecheck + lint clean, tests pass)
- [x] I've tested this in an actual vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wq9SLrCbGhmxyv4HnYm8Ch)_