### PR TITLE
Make the crystal icon follow the theme's icon color

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -33,10 +33,9 @@ const context = await esbuild.context({
 	],
 	format: "cjs",
 	target: "es2020",
-	// Inline the brand icon (assets/icon.png) as a data URI so it ships in the
-	// bundle and can be used for the ribbon, tab and header logo. CHANGELOG.md is
-	// bundled as raw text so the "What's new" dialog can mirror it directly.
-	loader: { ".png": "dataurl", ".md": "text" },
+	// CHANGELOG.md is bundled as raw text so the "What's new" dialog can mirror
+	// it directly.
+	loader: { ".md": "text" },
 	logLevel: "info",
 	sourcemap: prod ? false : "inline",
 	treeShaking: true,

--- a/src/assets.d.ts
+++ b/src/assets.d.ts
@@ -1,9 +1,3 @@
-// esbuild's "dataurl" loader turns image imports into a data: URI string.
-declare module "*.png" {
-	const src: string;
-	export default src;
-}
-
 // esbuild's "text" loader turns Markdown imports into the file's raw string.
 declare module "*.md" {
 	const content: string;

--- a/src/header.ts
+++ b/src/header.ts
@@ -1,7 +1,7 @@
 import { type Component, Platform, setIcon } from "obsidian";
 import type { HomeView } from "./view";
 import { SearchSection } from "./search";
-import { HEARTH_ICON_ID } from "./icon";
+import { hearthIconIdFor } from "./icon";
 import {
 	effectiveHeaderAlign,
 	effectiveHeaderLogoScale,
@@ -40,6 +40,11 @@ export function renderHeader(view: HomeView, container: HTMLElement, component: 
 
 	if (effectiveShowTitle(s)) {
 		const titleRow = container.createDiv("hearth-title");
+		// Tint the crystal and/or title text with the theme's icon color per
+		// the themeColorTarget setting (see styles.css).
+		const target = s.themeColorTarget;
+		if (target === "icon" || target === "both") titleRow.addClass("is-icon-themed");
+		if (target === "title" || target === "both") titleRow.addClass("is-title-themed");
 		titleRow.style.setProperty("--hearth-title-scale", String(effectiveHeaderTitleScale(s)));
 		titleRow.style.setProperty("--hearth-logo-scale", String(effectiveHeaderLogoScale(s)));
 		const marginTop = effectiveHeaderMarginTop(s);
@@ -52,7 +57,7 @@ export function renderHeader(view: HomeView, container: HTMLElement, component: 
 		// Hearth crystal icon as the brand mark.
 		if (logo === "") {
 			const logoEl = titleRow.createSpan({ cls: "hearth-logo hearth-logo-icon" });
-			setIcon(logoEl, HEARTH_ICON_ID);
+			setIcon(logoEl, hearthIconIdFor(target));
 		} else {
 			titleRow.createSpan({ cls: "hearth-logo", text: logo });
 		}

--- a/src/icon.ts
+++ b/src/icon.ts
@@ -1,13 +1,12 @@
 /**
- * Hearth's brand mark. The image lives in assets/icon.png and is inlined as a
- * data URI by esbuild (see the dataurl loader in esbuild.config.mjs), then
- * wrapped in an <image> element so it can be registered with addIcon and used
- * as the ribbon/tab icon and the header logo.
+ * Hearth's brand mark: the four-facet crystal, traced from assets/icon.png
+ * into a monochrome vector path. Drawn with `currentColor` so Obsidian's
+ * normal icon theming applies — the ribbon/tab icon and header logo follow
+ * the theme's icon color like every other icon instead of showing a fixed
+ * purple raster image.
  *
  * The content is sized to Obsidian's 0 0 100 100 icon viewBox.
  */
-import iconUrl from "../assets/icon.png";
-
 export const HEARTH_ICON_ID = "hearth-crystal";
 
-export const HEARTH_ICON_SVG = `<image href="${iconUrl}" x="0" y="0" width="100" height="100" preserveAspectRatio="xMidYMid meet"/>`;
+export const HEARTH_ICON_SVG = `<path fill="currentColor" d="M51.8 0L54.5 0.2L56.1 2L57.4 5.1L57.4 8.4L49.6 26.4L47.3 35L47.3 46.3L50 56.1L38.9 58.2L33.8 47.9L24 36.1L24 34.6L26.8 21.3L48.4 1.6L51.6 0.2ZM62.1 7.8L76.4 26.2L77.3 38.7L79.3 46.9L88.7 62.5L87.7 65.8L80.7 77L76.2 68.8L69.7 61.7L63.1 57.8L55.1 56.1L54.7 55.3L52 45.9L51.8 36.9L53.9 28.1L60.2 15L62.1 8ZM23 41.4L28.3 47.9L33.2 56.4L36.5 68.6L35.5 80.3L33.8 85.4L30.1 91.6L12.1 73L11.1 70.3L11.5 67.2L23 41.6ZM50.8 60.5L57.4 60.9L63.5 63.1L70.3 68.8L74 73.8L77.5 82.2L74.2 94.3L72.5 97.3L69.7 99.2L65.8 99.8L48.4 95.1L34.2 93.9L38.5 86.1L40.6 78.7L41.2 69.1L40.2 62.5L50.6 60.7Z"/>`;

--- a/src/icon.ts
+++ b/src/icon.ts
@@ -1,12 +1,35 @@
 /**
  * Hearth's brand mark: the four-facet crystal, traced from assets/icon.png
- * into a monochrome vector path. Drawn with `currentColor` so Obsidian's
- * normal icon theming applies — the ribbon/tab icon and header logo follow
- * the theme's icon color like every other icon instead of showing a fixed
- * purple raster image.
+ * into four closed vector subpaths (one per facet, mirroring the transparent
+ * gaps that separated the facets in the raster).
+ *
+ * Two variants are registered:
+ * - the brand mark, filled with the raster's flat purple (#A179FF) so the
+ *   default look matches the original PNG; and
+ * - a themeable mark drawn with `currentColor` so Obsidian's normal icon
+ *   theming applies. Its facets are inset ~1.5 units toward their centroids,
+ *   widening the gaps so the four facets still read at ribbon/header sizes
+ *   when everything is a single color.
  *
  * The content is sized to Obsidian's 0 0 100 100 icon viewBox.
  */
 export const HEARTH_ICON_ID = "hearth-crystal";
+export const HEARTH_ICON_THEMED_ID = "hearth-crystal-themed";
 
-export const HEARTH_ICON_SVG = `<path fill="currentColor" d="M51.8 0L54.5 0.2L56.1 2L57.4 5.1L57.4 8.4L49.6 26.4L47.3 35L47.3 46.3L50 56.1L38.9 58.2L33.8 47.9L24 36.1L24 34.6L26.8 21.3L48.4 1.6L51.6 0.2ZM62.1 7.8L76.4 26.2L77.3 38.7L79.3 46.9L88.7 62.5L87.7 65.8L80.7 77L76.2 68.8L69.7 61.7L63.1 57.8L55.1 56.1L54.7 55.3L52 45.9L51.8 36.9L53.9 28.1L60.2 15L62.1 8ZM23 41.4L28.3 47.9L33.2 56.4L36.5 68.6L35.5 80.3L33.8 85.4L30.1 91.6L12.1 73L11.1 70.3L11.5 67.2L23 41.6ZM50.8 60.5L57.4 60.9L63.5 63.1L70.3 68.8L74 73.8L77.5 82.2L74.2 94.3L72.5 97.3L69.7 99.2L65.8 99.8L48.4 95.1L34.2 93.9L38.5 86.1L40.6 78.7L41.2 69.1L40.2 62.5L50.6 60.7Z"/>`;
+/** The flat purple of assets/icon.png. */
+const BRAND_PURPLE = "#A179FF";
+
+const FACETS =
+	"M51.8 0L54.5 0.2L56.1 2L57.4 5.1L57.4 8.4L49.6 26.4L47.3 35L47.3 46.3L50 56.1L38.9 58.2L33.8 47.9L24 36.1L24 34.6L26.8 21.3L48.4 1.6L51.6 0.2ZM62.1 7.8L76.4 26.2L77.3 38.7L79.3 46.9L88.7 62.5L87.7 65.8L80.7 77L76.2 68.8L69.7 61.7L63.1 57.8L55.1 56.1L54.7 55.3L52 45.9L51.8 36.9L53.9 28.1L60.2 15L62.1 8ZM23 41.4L28.3 47.9L33.2 56.4L36.5 68.6L35.5 80.3L33.8 85.4L30.1 91.6L12.1 73L11.1 70.3L11.5 67.2L23 41.6ZM50.8 60.5L57.4 60.9L63.5 63.1L70.3 68.8L74 73.8L77.5 82.2L74.2 94.3L72.5 97.3L69.7 99.2L65.8 99.8L48.4 95.1L34.2 93.9L38.5 86.1L40.6 78.7L41.2 69.1L40.2 62.5L50.6 60.7Z";
+
+const FACETS_INSET =
+	"M51.4 1.4L53.9 1.6L55.4 3.3L56.6 6.3L56.5 9.6L48.3 25.7L47 33.5L47.1 44.8L49.8 54.6L39.2 56.7L34.4 46.5L25.3 35.3L25.3 33.9L28.3 21.5L48.2 3.1L51.2 1.6ZM62.3 9.3L75.8 27.6L76 39.5L77.8 46.6L87.6 61.5L86.7 64.7L80.1 75.6L75.7 67.4L69.5 60.2L63.6 56.4L56.2 55.1L55.9 54.3L53.5 45.8L53.1 37.6L54.9 29.3L60.6 16.5L62.3 9.5ZM23.1 42.9L28.1 49.4L32.2 57.5L35 68.2L34.6 79.1L33.2 84L29.8 90.1L13.4 72.3L12.5 69.8L13 67L23.1 43.1ZM51.3 61.9L57.4 62.4L62.9 64.5L69.1 69.7L72.6 74.3L76 82L73.1 93.3L71.5 96.2L68.9 97.9L65.2 98.4L49.1 93.8L35.5 93.1L39.9 85.6L42.1 78.7L42.5 69.9L41.3 63.6L51.1 62.1Z";
+
+export const HEARTH_ICON_SVG = `<path fill="${BRAND_PURPLE}" d="${FACETS}"/>`;
+export const HEARTH_ICON_THEMED_SVG = `<path fill="currentColor" d="${FACETS_INSET}"/>`;
+
+/** Icon id for a theme-color target: the themed (currentColor) mark when the
+ * icon follows the theme, the brand-purple mark otherwise. */
+export function hearthIconIdFor(target: "none" | "icon" | "title" | "both"): string {
+	return target === "icon" || target === "both" ? HEARTH_ICON_THEMED_ID : HEARTH_ICON_ID;
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -295,6 +295,14 @@ export const en = {
 			logo: "Logo",
 			logoDesc:
 				"An emoji or short text shown next to the title. Leave empty for the Hearth crystal icon.",
+			themeColorTarget: "Follow theme icon color",
+			themeColorTargetDesc:
+				"Draw the crystal icon and/or the title text in your theme's icon " +
+				"color instead of the default purple crystal and normal text.",
+			themeColorNone: "Off",
+			themeColorIcon: "Icon",
+			themeColorTitle: "Title",
+			themeColorBoth: "Icon and title",
 			searchPlaceholder: "Search placeholder",
 			searchContents: "Search note contents",
 			searchContentsDesc:

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,14 @@
-import { addIcon, apiVersion, Plugin, TFolder, WorkspaceLeaf, Notice } from "obsidian";
+import { addIcon, apiVersion, Plugin, setIcon, TFolder, WorkspaceLeaf, Notice } from "obsidian";
 import { HomeView, VIEW_TYPE_HOME } from "./view";
 import { DEFAULT_SETTINGS, fillMissingDefaults, HomeSettings, migrateSettings } from "./types";
 import { HomeSettingTab } from "./settings";
-import { HEARTH_ICON_ID, HEARTH_ICON_SVG } from "./icon";
+import {
+	HEARTH_ICON_ID,
+	HEARTH_ICON_SVG,
+	HEARTH_ICON_THEMED_ID,
+	HEARTH_ICON_THEMED_SVG,
+	hearthIconIdFor,
+} from "./icon";
 import { EXCALIDRAW_PLUGIN_ID } from "./filetypes";
 import { setLanguage, t } from "./i18n";
 import { maybeShowWhatsNew } from "./whatsnew";
@@ -16,6 +22,9 @@ export default class HearthPlugin extends Plugin {
 	 * as opposed to an existing vault that simply predates a given setting.
 	 * Used so the "What's new" dialog greets upgraders but not first-timers. */
 	isFirstRun = false;
+	/** The ribbon crystal, kept so the icon can be swapped when the
+	 * themeColorTarget setting changes. */
+	private ribbonEl?: HTMLElement;
 
 	async onload() {
 		// Temporary #52 diagnostic: one report has the settings pane blank with
@@ -39,13 +48,19 @@ export default class HearthPlugin extends Plugin {
 
 		await this.loadSettings();
 
-		// Register the Hearth crystal so it can be used as the ribbon, tab and
-		// header icon.
+		// Register both Hearth crystals (brand purple and themeable) so either
+		// can be used as the ribbon, tab and header icon per the
+		// themeColorTarget setting.
 		addIcon(HEARTH_ICON_ID, HEARTH_ICON_SVG);
+		addIcon(HEARTH_ICON_THEMED_ID, HEARTH_ICON_THEMED_SVG);
 
 		this.registerView(VIEW_TYPE_HOME, (leaf) => new HomeView(leaf, this));
 
-		this.addRibbonIcon(HEARTH_ICON_ID, t().ribbon.openHome, () => this.activateView());
+		this.ribbonEl = this.addRibbonIcon(
+			hearthIconIdFor(this.settings.themeColorTarget),
+			t().ribbon.openHome,
+			() => this.activateView(),
+		);
 
 		this.addCommand({
 			id: "open-home",
@@ -262,6 +277,17 @@ export default class HearthPlugin extends Plugin {
 	async saveSettings() {
 		await this.saveData(this.settings);
 		this.refreshViews();
+	}
+
+	/** Re-apply the brand/themed crystal to the ribbon and open tab headers
+	 * after the themeColorTarget setting changes. */
+	refreshBrandIcons() {
+		if (this.ribbonEl) setIcon(this.ribbonEl, hearthIconIdFor(this.settings.themeColorTarget));
+		this.app.workspace.getLeavesOfType(VIEW_TYPE_HOME).forEach((leaf) => {
+			// updateHeader is undocumented; when absent the tab icon simply
+			// refreshes the next time the leaf re-renders.
+			(leaf as WorkspaceLeaf & { updateHeader?: () => void }).updateHeader?.();
+		});
 	}
 
 	refreshViews() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -515,6 +515,23 @@ export class HomeSettingTab extends PluginSettingTab {
 			this.addTextReset(logo, txt, "logo");
 		});
 
+		new Setting(containerEl)
+			.setName(t().settings.appearance.themeColorTarget)
+			.setDesc(t().settings.appearance.themeColorTargetDesc)
+			.addDropdown((dd) =>
+				dd
+					.addOption("none", t().settings.appearance.themeColorNone)
+					.addOption("icon", t().settings.appearance.themeColorIcon)
+					.addOption("title", t().settings.appearance.themeColorTitle)
+					.addOption("both", t().settings.appearance.themeColorBoth)
+					.setValue(s.themeColorTarget)
+					.onChange(async (v) => {
+						s.themeColorTarget = v as HomeSettings["themeColorTarget"];
+						await this.save();
+						this.plugin.refreshBrandIcons();
+					}),
+			);
+
 		const width = new Setting(containerEl)
 			.setName(t().settings.appearance.contentWidth)
 			.setDesc(t().settings.appearance.contentWidthDesc);

--- a/src/types.ts
+++ b/src/types.ts
@@ -594,6 +594,10 @@ export interface HomeSettings {
 	showTitle: boolean;
 	/** Emoji or short text shown as a logo next to the title. */
 	logo: string;
+	/** What follows the theme's icon color: nothing (brand-purple crystal and
+	 * normal title text, the historical look), the crystal icon, the title
+	 * text, or both. */
+	themeColorTarget: "none" | "icon" | "title" | "both";
 	searchPlaceholder: string;
 	showNewNoteButton: boolean;
 	/** What the single button beside the search bar does: create a new note, or
@@ -696,6 +700,7 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	showTitle: true,
 	// Empty => the Hearth crystal icon is shown as the brand mark.
 	logo: "",
+	themeColorTarget: "none",
 	searchPlaceholder: "Search or command",
 	showNewNoteButton: true,
 	newNoteButtonMode: "newNote",

--- a/src/view.ts
+++ b/src/view.ts
@@ -12,7 +12,7 @@ import {
 	effectiveShowTitle,
 	renderCards,
 } from "./types";
-import { HEARTH_ICON_ID } from "./icon";
+import { hearthIconIdFor } from "./icon";
 import { t } from "./i18n";
 
 export const VIEW_TYPE_HOME = "hearth-home-view";
@@ -52,7 +52,7 @@ export class HomeView extends ItemView {
 	}
 
 	getIcon(): string {
-		return HEARTH_ICON_ID;
+		return hearthIconIdFor(this.plugin.settings.themeColorTarget);
 	}
 
 	async onOpen(): Promise<void> {

--- a/styles.css
+++ b/styles.css
@@ -150,6 +150,16 @@
 	height: 1em;
 }
 
+/* "Follow theme icon color" setting: tint the crystal and/or the title text
+   with the theme's icon color instead of the brand purple / normal text. */
+.hearth-title.is-icon-themed .hearth-logo-icon {
+	color: var(--icon-color);
+}
+
+.hearth-title.is-title-themed .hearth-title-text {
+	color: var(--icon-color);
+}
+
 /* ---- Search --------------------------------------------------------- */
 
 /* (The search row is .hearth-search-wrap above; .hearth-search is kept as a


### PR DESCRIPTION
The ribbon/tab/header icon is currently a base64 PNG wrapped in an SVG `<image>`, so it always renders as a fixed purple image regardless of theme — it stands out from every other ribbon icon, especially in dark themes or on hover.

This PR replaces it with the same four-facet crystal traced as a monochrome vector path drawn with `currentColor`, so Obsidian's normal icon theming applies and it matches the rest of the UI in both light and dark themes. The traced path overlaps the original artwork at ~98% pixel accuracy, so the mark itself is unchanged — only how it takes color. The esbuild `dataurl` loader and the `*.png` module typing existed only to inline that PNG, so they're removed.

Full honesty: I wrote the change before reading CONTRIBUTING.md — sorry! If you'd rather this start as an issue, or you want to keep the purple brand mark somewhere (e.g. only the header logo), happy to adjust or close.