### PR TITLE
Link a dashboard to a core Workspace (auto-switch)

### DIFF
--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -19,6 +19,7 @@ import {
 	cloneCard,
 } from "./types";
 import { confirmAction } from "./ui";
+import type { WorkspacesInstance } from "./obsidian-ext";
 import { HearthTabbedModal, type HearthModalTab } from "./tabbedmodal";
 import { t } from "./i18n";
 
@@ -154,6 +155,8 @@ function showDashboardMenu(
 					copy.cardBorderWidth = dash.cardBorderWidth;
 				if (dash.header) copy.header = { ...dash.header };
 				if (dash.background) copy.background = { ...dash.background };
+				// linkedWorkspace is intentionally not copied: two dashboards
+				// linked to the same workspace would race on auto-switch.
 				const i = s.dashboards.findIndex((d) => d.id === dash.id);
 				s.dashboards.splice(i + 1, 0, copy);
 				s.activeDashboardId = copy.id;
@@ -311,6 +314,26 @@ class DashboardSettingsModal extends HearthTabbedModal {
 					this.commit();
 				}),
 			);
+
+		new Setting(containerEl)
+			.setName(t().dashboards.modal.linkedWorkspace)
+			.setDesc(t().dashboards.modal.linkedWorkspaceDesc)
+			.addDropdown((dd) => {
+				dd.addOption("", t().dashboards.modal.linkedWorkspaceNone);
+				const instance = this.view.app.internalPlugins.getPluginById(
+					"workspaces",
+				)?.instance as WorkspacesInstance | undefined;
+				const names = Object.keys(instance?.workspaces ?? {});
+				// A link to a deleted/renamed workspace stays listed so it shows
+				// as selected instead of silently falling back to "None".
+				if (dash.linkedWorkspace && !names.includes(dash.linkedWorkspace))
+					names.push(dash.linkedWorkspace);
+				for (const n of names) dd.addOption(n, n);
+				dd.setValue(dash.linkedWorkspace ?? "").onChange((v) => {
+					dash.linkedWorkspace = v || undefined;
+					this.commit();
+				});
+			});
 	}
 
 	private ensureHeader(): DashboardHeaderConfig {

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -695,6 +695,9 @@ function sanitizeDashboard(
 	}
 	if (typeof r.fitToPage === "boolean") dash.fitToPage = r.fitToPage;
 	if (typeof r.showSearch === "boolean") dash.showSearch = r.showSearch;
+	const linkedWorkspace = str(r.linkedWorkspace);
+	if (linkedWorkspace !== undefined && linkedWorkspace.trim())
+		dash.linkedWorkspace = linkedWorkspace;
 	const rawHeader = r.header;
 	if (rawHeader && typeof rawHeader === "object") {
 		const h = rawHeader as Record<string, unknown>;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -156,6 +156,10 @@ export const en = {
 			lucidePlaceholder: "home",
 			showSearch: "Show search section",
 			showSearchDesc: "Show the search and command bar with its results and filter buttons on this dashboard.",
+			linkedWorkspace: "Linked workspace",
+			linkedWorkspaceDesc:
+				"Auto-switch to this dashboard when this workspace loads. Requires the core Workspaces plugin.",
+			linkedWorkspaceNone: "None",
 			titleVisibility: "Title visibility",
 			titleVisibilityDesc:
 				"Show or hide only the title/logo block for this dashboard. Search visibility is separate.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,13 +128,18 @@ export default class HearthPlugin extends Plugin {
 		void leaf.setViewState({ type: VIEW_TYPE_HOME });
 	}
 
+	/** Name of the workspace we last reacted to, so the link fires once per
+	 * workspace load instead of pinning the dashboard on every layout-change. */
+	private lastWorkspace?: string;
+
 	/** Switch to the dashboard linked to the currently loaded core-Workspace,
 	 * if any. One-way sync: workspace → dashboard, never the reverse. */
 	private followLinkedWorkspace() {
 		const instance = this.app.internalPlugins.getPluginById("workspaces")
 			?.instance as WorkspacesInstance | undefined;
 		const active = instance?.activeWorkspace;
-		if (!active) return;
+		if (!active || active === this.lastWorkspace) return;
+		this.lastWorkspace = active;
 		const match = this.settings.dashboards.find(
 			(d) => d.linkedWorkspace === active,
 		);

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
 	HEARTH_ICON_THEMED_SVG,
 	hearthIconIdFor,
 } from "./icon";
+import type { WorkspacesInstance } from "./obsidian-ext";
 import { EXCALIDRAW_PLUGIN_ID } from "./filetypes";
 import { setLanguage, t } from "./i18n";
 import { maybeShowWhatsNew } from "./whatsnew";
@@ -101,6 +102,14 @@ export default class HearthPlugin extends Plugin {
 			this.app.workspace.on("active-leaf-change", (leaf) => this.maybeReplaceNewTab(leaf)),
 		);
 
+		// Follow core-Workspace loads: when the active workspace matches a
+		// dashboard's linked workspace, switch to that dashboard. There is no
+		// dedicated "workspace loaded" event, so listen to layout-change;
+		// setActiveDashboard no-ops when the dashboard is already active.
+		this.registerEvent(
+			this.app.workspace.on("layout-change", () => this.followLinkedWorkspace()),
+		);
+
 		this.app.workspace.onLayoutReady(() => {
 			if (this.settings.openOnStartup) void this.activateView();
 			// Pop the release-notes dialog after an update (but not on a fresh
@@ -117,6 +126,19 @@ export default class HearthPlugin extends Plugin {
 		if (!leaf || !this.settings.replaceNewTabs) return;
 		if (leaf.getViewState().type !== "empty") return;
 		void leaf.setViewState({ type: VIEW_TYPE_HOME });
+	}
+
+	/** Switch to the dashboard linked to the currently loaded core-Workspace,
+	 * if any. One-way sync: workspace → dashboard, never the reverse. */
+	private followLinkedWorkspace() {
+		const instance = this.app.internalPlugins.getPluginById("workspaces")
+			?.instance as WorkspacesInstance | undefined;
+		const active = instance?.activeWorkspace;
+		if (!active) return;
+		const match = this.settings.dashboards.find(
+			(d) => d.linkedWorkspace === active,
+		);
+		if (match) this.setActiveDashboard(match.id);
 	}
 
 	/** Switch the active dashboard and refresh any open home views. */

--- a/src/obsidian-ext.d.ts
+++ b/src/obsidian-ext.d.ts
@@ -48,6 +48,13 @@ declare module "obsidian" {
 	}
 }
 
+/** Shape of the core "Workspaces" plugin instance we care about: the saved
+ * workspaces keyed by name, and the name of the last-loaded one. */
+export interface WorkspacesInstance {
+	workspaces?: Record<string, unknown>;
+	activeWorkspace?: string;
+}
+
 // Shape of an Obsidian core "Bookmarks" item we care about. `type` is one of
 // "file" | "folder" | "search" | "group" | "url" (and possibly others), kept as
 // a plain string since the literals collapse into it anyway.

--- a/src/types.ts
+++ b/src/types.ts
@@ -584,6 +584,9 @@ export interface Dashboard {
 	header?: DashboardHeaderConfig;
 	/** Show the dashboard search/command section (undefined = visible). */
 	showSearch?: boolean;
+	/** Name of a core-Workspace; loading that workspace auto-switches to this
+	 * dashboard (one-way, workspace → dashboard). Undefined = not linked. */
+	linkedWorkspace?: string;
 }
 
 export type ChromeVisibility = "always" | "hover";


### PR DESCRIPTION
**The problem:** I use Obsidian's core Workspaces plugin to switch between contexts (work, writing, research), and I keep a Hearth dashboard per context. But loading a workspace doesn't change which dashboard Hearth shows, so every switch means also manually clicking the right dashboard in the switcher.

**What this adds:** each dashboard gets an optional "Linked workspace", chosen from a dropdown of the saved core Workspaces in the dashboard settings modal (General tab, defaults to "None"). When that workspace loads, Hearth switches to the linked dashboard automatically.

Design notes:
- One-way sync only (workspace → dashboard); Hearth never touches workspaces.
- Listens on `layout-change` since there's no dedicated workspace-loaded event; `setActiveDashboard` already no-ops when unchanged, so this is cheap.
- The link survives layout export/import, and duplicating a dashboard deliberately doesn't copy it (two dashboards on one workspace would race).
- Old saved dashboards are unaffected — the field is optional, no migration.

Full honesty: I wrote this before reading CONTRIBUTING.md — sorry! I know behaviour changes should ideally start as an issue, so happy to convert this to one, or rework it if it collides with something you have in flight.