### PR TITLE
fix(bookmarks): show file name instead of full path for unnamed bookmarks (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **Unnamed bookmarks show the file name, not the full path.** A file or folder
+  bookmark without its own name previously rendered as its whole vault path,
+  which overflowed the card when the path was long. It now shows just the
+  target's basename — matching Obsidian's own bookmarks pane — and still falls
+  back to the last path segment if the target can't be resolved (#92).
 - **TaskNotes tasks open in a working editor again.** Opening an existing
   TaskNotes task from a Tasks card handed TaskNotes' edit modal the note's
   `TFile` instead of its own task object, leaving the modal with a broken

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hearth",
-	"version": "1.10.0",
+	"version": "1.12.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hearth",
-			"version": "1.10.0",
+			"version": "1.12.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^20.11.0",

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -1464,6 +1464,17 @@ function renderBookmarkGroup(
 	makeClickable(header, toggle, label);
 }
 
+/** The name Obsidian shows for an unnamed file/folder bookmark: the target's
+ * basename, not its full path. Resolving through the vault strips the `.md`
+ * extension from notes (like Obsidian) and keeps the extension on other files;
+ * if the target can't be resolved we fall back to the last path segment. */
+function bookmarkPathName(view: HomeView, path: string): string {
+	const file = view.app.vault.getAbstractFileByPath(path);
+	if (file instanceof TFile) return file.basename;
+	if (file instanceof TFolder) return file.name;
+	return path.split("/").pop() || path;
+}
+
 /** A single (non-group) bookmark row: file, folder, url, search or graph. */
 function renderBookmarkLeaf(
 	view: HomeView,
@@ -1472,7 +1483,7 @@ function renderBookmarkLeaf(
 ): void {
 	const label =
 		item.title ||
-		item.path ||
+		(item.path ? bookmarkPathName(view, item.path) : undefined) ||
 		item.url ||
 		item.query ||
 		t().cards.bookmarks.untitled;


### PR DESCRIPTION
## Summary

Fixes #92. A Bookmarks card entry that has no name of its own rendered its **full vault path**, which overflows the card when the path is long. Per the issue discussion, unnamed bookmarks should mimic Obsidian's own bookmarks pane and show the **file name** instead.

## Change

In `renderBookmarkLeaf` (`src/cards.ts`), the label fallback chain previously went `title || path || url || query || untitled`, so the raw `path` was used verbatim. A new `bookmarkPathName` helper now resolves the target through the vault and returns:

- a `TFile`'s `basename` — which also strips the `.md` extension for notes, matching Obsidian, and keeps the extension on other files;
- a `TFolder`'s `name`;
- otherwise the last `/`-separated segment of the path as a safe fallback.

Named bookmarks are unaffected (the explicit `title` still wins), and url/search/graph bookmarks keep their existing labels.

## Testing

- `npm test` — all existing tests pass.
- `npm run lint` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTn2y4ej8aUKMDi2Mz1f38)_