### PR TITLE
Add "Focus search on open" option (#115)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"esbuild": "^0.28.1",
 				"eslint": "^9.39.5",
 				"eslint-plugin-obsidianmd": "^0.4.1",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"tslib": "^2.6.2",
 				"typescript": "^5.4.0",
 				"typescript-eslint": "^8.63.0",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -365,6 +365,10 @@ export const en = {
 			openOnStartupDesc: "Open the home view when the vault loads.",
 			replaceNewTabs: "Replace new tabs",
 			replaceNewTabsDesc: "Show the home view instead of an empty new tab.",
+			focusSearchOnOpen: "Focus search on open",
+			focusSearchOnOpenDesc:
+				"Place the cursor in the search field whenever a home view opens, so " +
+				"you can start typing right away. Desktop only.",
 			mobileSearchOnly: "Mobile mode (search only)",
 			mobileSearchOnlyDesc:
 				"On phones and tablets, hide the dashboard and show only the search " +

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -721,6 +721,18 @@ export class HomeSettingTab extends PluginSettingTab {
 					await this.save();
 				}),
 			);
+
+		if (!Platform.isMobile) {
+			new Setting(containerEl)
+				.setName(t().settings.behaviour.focusSearchOnOpen)
+				.setDesc(t().settings.behaviour.focusSearchOnOpenDesc)
+				.addToggle((tg) =>
+					tg.setValue(s.focusSearchOnOpen).onChange(async (v) => {
+						s.focusSearchOnOpen = v;
+						await this.save();
+					}),
+				);
+		}
 	}
 
 	// ---- Privacy & network ----------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -769,6 +769,11 @@ export interface HomeSettings {
 	// ---- Behaviour ----
 	openOnStartup: boolean;
 	replaceNewTabs: boolean;
+	/** Place keyboard focus in the search field whenever a home view opens, so a
+	 * new Hearth tab can be typed into straight away without reaching for the
+	 * mouse. Desktop only — auto-focusing on mobile would pop the on-screen
+	 * keyboard on every open. */
+	focusSearchOnOpen: boolean;
 	/** On mobile, show only the search field and hide the dashboard. Has no
 	 * effect on desktop, where the full dashboard is always shown. */
 	mobileSearchOnly: boolean;
@@ -865,6 +870,7 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 
 	openOnStartup: true,
 	replaceNewTabs: true,
+	focusSearchOnOpen: false,
 	mobileSearchOnly: false,
 	showMobileActionBar: true,
 	// Backfilled by migrateSettings so a fresh install gets the defaults below

--- a/src/view.ts
+++ b/src/view.ts
@@ -58,6 +58,20 @@ export class HomeView extends ItemView {
 	async onOpen(): Promise<void> {
 		this.render();
 		this.trackViewport();
+		this.maybeFocusSearch();
+	}
+
+	/**
+	 * When enabled, move keyboard focus into the search field as the view opens
+	 * so a freshly-opened Hearth tab is ready to type into (#115). Only runs from
+	 * onOpen — not on every re-render — so a background refresh never steals focus
+	 * while the user is working. Desktop only: focusing an input on mobile pops
+	 * the on-screen keyboard, which would be jarring on every open.
+	 */
+	private maybeFocusSearch(): void {
+		if (!this.plugin.settings.focusSearchOnOpen || Platform.isMobile) return;
+		const input = this.contentEl.querySelector<HTMLInputElement>(".hearth-search-input");
+		if (input) input.focus();
 	}
 
 	/**


### PR DESCRIPTION
Closes #115.

## What
Adds an opt-in **Behaviour → "Focus search on open"** setting. When enabled, keyboard focus is placed in the search field whenever a home view opens, so a freshly-opened Hearth tab (e.g. `Cmd/Ctrl+T`) can be typed into straight away without reaching for the mouse.

## How
- `focusSearchOnOpen: boolean` added to `HomeSettings` (default `false`, so existing behaviour is unchanged).
- `HomeView.onOpen` focuses `.hearth-search-input` when the setting is on. Focus is applied **only from `onOpen`**, never on every `render()`, so a background refresh can't steal focus while the user is working.
- **Desktop only** — auto-focusing an input on mobile pops the on-screen keyboard on every open, which would be jarring; the setting row is hidden on mobile and the focus call is guarded with `Platform.isMobile`.

## Testing
- `npm run typecheck`, `npm run lint` (0 errors), `npm run test` (169 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe)_