### PR TITLE
Add per-dashboard "Default on mobile" flag (#120)

### DIFF
--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -316,6 +316,24 @@ class DashboardSettingsModal extends HearthTabbedModal {
 			);
 
 		new Setting(containerEl)
+			.setName(t().dashboards.modal.mobileDefault)
+			.setDesc(t().dashboards.modal.mobileDefaultDesc)
+			.addToggle((tg) =>
+				tg.setValue(dash.mobileDefault ?? false).onChange((v) => {
+					// Only one board is the mobile default; enabling this one clears
+					// the flag on the others so the first-match lookup is unambiguous.
+					if (v) {
+						for (const d of this.view.plugin.settings.dashboards) {
+							d.mobileDefault = d === dash ? true : undefined;
+						}
+					} else {
+						dash.mobileDefault = undefined;
+					}
+					this.commit();
+				}),
+			);
+
+		new Setting(containerEl)
 			.setName(t().dashboards.modal.linkedWorkspace)
 			.setDesc(t().dashboards.modal.linkedWorkspaceDesc)
 			.addDropdown((dd) => {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -161,6 +161,9 @@ export const en = {
 			linkedWorkspaceDesc:
 				"Auto-switch to this dashboard when this workspace loads. Requires the core Workspaces plugin.",
 			linkedWorkspaceNone: "None",
+			mobileDefault: "Default on mobile",
+			mobileDefaultDesc:
+				"Open this dashboard when Hearth loads on a phone or tablet. Only one board can be the mobile default; enabling this clears it on the others.",
 			titleVisibility: "Title visibility",
 			titleVisibilityDesc:
 				"Show or hide only the title/logo block for this dashboard. Search visibility is separate.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { addIcon, apiVersion, Plugin, setIcon, TFolder, WorkspaceLeaf, Notice } from "obsidian";
+import { addIcon, apiVersion, Platform, Plugin, setIcon, TFolder, WorkspaceLeaf, Notice } from "obsidian";
 import { HomeView, VIEW_TYPE_HOME } from "./view";
 import { DEFAULT_SETTINGS, fillMissingDefaults, HomeSettings, migrateSettings } from "./types";
 import { HomeSettingTab } from "./settings";
@@ -111,6 +111,7 @@ export default class HearthPlugin extends Plugin {
 		);
 
 		this.app.workspace.onLayoutReady(() => {
+			this.applyMobileDefaultDashboard();
 			if (this.settings.openOnStartup) void this.activateView();
 			// Pop the release-notes dialog after an update (but not on a fresh
 			// install). Runs once layout is ready so it doesn't fight startup.
@@ -144,6 +145,20 @@ export default class HearthPlugin extends Plugin {
 			(d) => d.linkedWorkspace === active,
 		);
 		if (match) this.setActiveDashboard(match.id);
+	}
+
+	/** On mobile, switch to the first dashboard flagged as the mobile default so
+	 * a phone/tablet opens on the board tuned for a small screen (#120). Applied
+	 * in memory only, without saving: `activeDashboardId` is a single field shared
+	 * with desktop through synced settings, so persisting the mobile choice would
+	 * drag the desktop's active board along with it on the next sync. Any already
+	 * open home view is re-rendered to reflect the switch. */
+	private applyMobileDefaultDashboard() {
+		if (!Platform.isMobile) return;
+		const mobile = this.settings.dashboards.find((d) => d.mobileDefault);
+		if (!mobile || this.settings.activeDashboardId === mobile.id) return;
+		this.settings.activeDashboardId = mobile.id;
+		this.refreshViews();
 	}
 
 	/** Switch the active dashboard and refresh any open home views. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -733,6 +733,11 @@ export interface Dashboard {
 	/** Name of a core-Workspace; loading that workspace auto-switches to this
 	 * dashboard (one-way, workspace → dashboard). Undefined = not linked. */
 	linkedWorkspace?: string;
+	/** Marks this board as the one to open on phones/tablets. When Hearth loads
+	 * on mobile it switches to the first dashboard with this flag, so a board
+	 * tuned for a small screen can be the mobile default without being the
+	 * desktop default. Undefined/false = not a mobile default. */
+	mobileDefault?: boolean;
 }
 
 export type ChromeVisibility = "always" | "hover";


### PR DESCRIPTION
Closes #120.

## What
Adds a per-dashboard **"Default on mobile"** toggle (dashboard settings modal → General tab). When Hearth loads on a phone or tablet, it opens the board flagged as the mobile default — so a dashboard tuned for a small screen can be the mobile default without being the desktop default.

## How
- `Dashboard.mobileDefault?: boolean` added to the type.
- Toggle in the dashboard settings modal. **Single-select**: enabling it on one board clears the flag on the others, so the first-match lookup is unambiguous.
- On `onLayoutReady`, `applyMobileDefaultDashboard()` switches to the first flagged board **only on mobile**.

### Why the switch isn't persisted
`activeDashboardId` is a single field shared with desktop through synced settings. If the mobile switch were saved, it would drag the desktop's active board along on the next sync. So the mobile default is applied **in memory only** (no `saveData`); any already-open home view is re-rendered to reflect it. Duplicating a dashboard does not copy the flag (same treatment as `linkedWorkspace`), avoiding two mobile defaults.

## Testing
- `npm run typecheck`, `npm run lint` (0 errors), `npm run test` (169 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe)_