### PR TITLE
Refresh dashboard on focus and on vault changes (#110)

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -372,6 +372,11 @@ export const en = {
 			focusSearchOnOpenDesc:
 				"Place the cursor in the search field whenever a home view opens, so " +
 				"you can start typing right away. Desktop only.",
+			liveRefresh: "Live refresh on vault changes",
+			liveRefreshDesc:
+				"Keep an open home view current as the vault changes — Recent, Bookmarks " +
+				"and saved-query cards update without reopening the tab. Switching back to " +
+				"the Hearth tab always refreshes it regardless of this setting.",
 			mobileSearchOnly: "Mobile mode (search only)",
 			mobileSearchOnlyDesc:
 				"On phones and tablets, hide the dashboard and show only the search " +

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { addIcon, apiVersion, Platform, Plugin, setIcon, TFolder, WorkspaceLeaf, Notice } from "obsidian";
+import { addIcon, apiVersion, debounce, Platform, Plugin, setIcon, TFolder, WorkspaceLeaf, Notice } from "obsidian";
 import { HomeView, VIEW_TYPE_HOME } from "./view";
 import { DEFAULT_SETTINGS, fillMissingDefaults, HomeSettings, migrateSettings } from "./types";
 import { HomeSettingTab } from "./settings";
@@ -26,6 +26,18 @@ export default class HearthPlugin extends Plugin {
 	/** The ribbon crystal, kept so the icon can be swapped when the
 	 * themeColorTarget setting changes. */
 	private ribbonEl?: HTMLElement;
+
+	/** Home-view leaves that have already been the active leaf at least once.
+	 * Their first activation was the fresh onOpen render, so the focus refresh
+	 * (#110) skips it and only re-renders on genuine re-focus (this also avoids
+	 * clobbering any search focus set on open). A WeakSet so closed leaves are
+	 * collected with no manual bookkeeping. */
+	private seenActiveHomeLeaves = new WeakSet<WorkspaceLeaf>();
+
+	/** Debounced live-refresh of open home views on vault changes (#110).
+	 * resetTimer=true so a burst of writes (a sync, a bulk edit) coalesces into a
+	 * single re-render ~600ms after the last change. */
+	private liveRefreshDebounced = debounce(() => this.runLiveRefresh(), 600, true);
 
 	async onload() {
 		// Temporary #52 diagnostic: one report has the settings pane blank with
@@ -97,10 +109,25 @@ export default class HearthPlugin extends Plugin {
 
 		this.addSettingTab(new HomeSettingTab(this.app, this));
 
-		// Replace freshly-opened empty tabs with the home view.
+		// Replace freshly-opened empty tabs with the home view, and refresh a home
+		// view whenever the user switches back to its tab (#110).
 		this.registerEvent(
-			this.app.workspace.on("active-leaf-change", (leaf) => this.maybeReplaceNewTab(leaf)),
+			this.app.workspace.on("active-leaf-change", (leaf) => {
+				this.maybeReplaceNewTab(leaf);
+				this.maybeRefreshOnFocus(leaf);
+			}),
 		);
+
+		// Opt-in live refresh: when enabled, re-render open home views a beat after
+		// the vault changes so Recent/Bookmarks/query cards stay current without
+		// reopening the tab. Registered unconditionally; the handler checks the
+		// setting so toggling it takes effect without a reload. Debounced so a burst
+		// of writes (a sync, a bulk edit) coalesces into a single re-render.
+		const onVaultChange = () => this.liveRefreshDebounced();
+		this.registerEvent(this.app.vault.on("create", onVaultChange));
+		this.registerEvent(this.app.vault.on("delete", onVaultChange));
+		this.registerEvent(this.app.vault.on("rename", onVaultChange));
+		this.registerEvent(this.app.vault.on("modify", onVaultChange));
 
 		// Follow core-Workspace loads: when the active workspace matches a
 		// dashboard's linked workspace, switch to that dashboard. There is no
@@ -336,6 +363,33 @@ export default class HearthPlugin extends Plugin {
 		this.app.workspace.getLeavesOfType(VIEW_TYPE_HOME).forEach((leaf) => {
 			const view = leaf.view;
 			if (view instanceof HomeView) view.render();
+		});
+	}
+
+	/** Re-render a home view when it becomes the active leaf again, so content
+	 * that changed while it was backgrounded (recents, bookmarks, saved-query
+	 * results) is current (#110). The first activation of a leaf was its fresh
+	 * onOpen render, so that one is skipped; genuine re-focus re-renders. Skipped
+	 * while the board is being arranged so a drag/resize isn't interrupted. */
+	private maybeRefreshOnFocus(leaf: WorkspaceLeaf | null) {
+		if (!leaf) return;
+		const view = leaf.view;
+		if (!(view instanceof HomeView)) return;
+		if (!this.seenActiveHomeLeaves.has(leaf)) {
+			this.seenActiveHomeLeaves.add(leaf);
+			return;
+		}
+		if (view.arrangeMode) return;
+		view.render();
+	}
+
+	/** Live-refresh handler behind {@link liveRefreshDebounced}. No-op unless the
+	 * setting is on; never rebuilds a board mid-arrange. */
+	private runLiveRefresh() {
+		if (!this.settings.liveRefresh) return;
+		this.app.workspace.getLeavesOfType(VIEW_TYPE_HOME).forEach((leaf) => {
+			const view = leaf.view;
+			if (view instanceof HomeView && !view.arrangeMode) view.render();
 		});
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -733,6 +733,16 @@ export class HomeSettingTab extends PluginSettingTab {
 					}),
 				);
 		}
+
+		new Setting(containerEl)
+			.setName(t().settings.behaviour.liveRefresh)
+			.setDesc(t().settings.behaviour.liveRefreshDesc)
+			.addToggle((tg) =>
+				tg.setValue(s.liveRefresh).onChange(async (v) => {
+					s.liveRefresh = v;
+					await this.save();
+				}),
+			);
 	}
 
 	// ---- Privacy & network ----------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -779,6 +779,12 @@ export interface HomeSettings {
 	 * mouse. Desktop only — auto-focusing on mobile would pop the on-screen
 	 * keyboard on every open. */
 	focusSearchOnOpen: boolean;
+	/** Live-refresh open home views when the vault changes (files created,
+	 * modified, deleted or renamed), so cards like Recent, Bookmarks and saved
+	 * queries update without reopening the tab. Debounced, and skipped while a
+	 * board is being arranged. Off by default; a home view already refreshes
+	 * whenever the user switches back to its tab regardless of this setting. */
+	liveRefresh: boolean;
 	/** On mobile, show only the search field and hide the dashboard. Has no
 	 * effect on desktop, where the full dashboard is always shown. */
 	mobileSearchOnly: boolean;
@@ -876,6 +882,7 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	openOnStartup: true,
 	replaceNewTabs: true,
 	focusSearchOnOpen: false,
+	liveRefresh: false,
 	mobileSearchOnly: false,
 	showMobileActionBar: true,
 	// Backfilled by migrateSettings so a fresh install gets the defaults below


### PR DESCRIPTION
Closes #110.

Open home views could show stale content: editing a note or changing a bookmark left the Recent / Bookmarks / saved-query cards untouched until the tab was closed and reopened. This adds two complementary refreshes.

## Focus refresh (always on)
Re-renders a home view when the user switches back to its tab — the reporter's "go back to Hearth and it should be current" workflow.
- The **first** activation of a leaf is its fresh `onOpen` render, so it's skipped (a `WeakSet<WorkspaceLeaf>` tracks seen leaves). Only genuine re-focus re-renders — this also avoids clobbering search focus set on open.
- Skipped while a board is being **arranged**, so a drag/resize is never interrupted.

## Live refresh (opt-in, default off)
For users who keep Hearth always visible in a split, a new **Behaviour → "Live refresh on vault changes"** toggle re-renders open home views a beat after the vault changes.
- Fires on vault `create` / `modify` / `delete` / `rename`.
- **Debounced** (~600ms, `resetTimer`) so a burst of writes (a sync, a bulk edit) coalesces into one re-render.
- Registered unconditionally; the handler checks the setting, so toggling it takes effect without a reload. Also skipped mid-arrange.

## Testing
- `npm run typecheck`, `npm run lint` (0 errors), `npm run test` (169 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe)_