### PR TITLE
Add three "Open note/URL in" settings for current-tab opening (#106)

### DIFF
--- a/src/cards/bookmarks.ts
+++ b/src/cards/bookmarks.ts
@@ -1,6 +1,7 @@
 import { setIcon, TFile, TFolder } from "obsidian";
 import { emptyState } from "../cardbodies";
 import { t } from "../i18n";
+import { openNoteFromCard } from "../navigation";
 import { type BookmarkItem } from "../obsidian-ext";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -175,7 +176,7 @@ function openBookmark(view: HomeView, item: BookmarkItem): void {
 	}
 	if (item.path) {
 		const file = view.app.vault.getAbstractFileByPath(item.path);
-		if (file instanceof TFile) void view.app.workspace.getLeaf(true).openFile(file);
+		if (file instanceof TFile) openNoteFromCard(view, file);
 	}
 }
 

--- a/src/cards/daily.ts
+++ b/src/cards/daily.ts
@@ -8,6 +8,7 @@ import {
 	watchedCardPath,
 } from "../cardbodies";
 import { t } from "../i18n";
+import { openNoteFromCard } from "../navigation";
 import { type DashboardCard } from "../types";
 import { type HomeView } from "../view";
 import { type CardDefinition, type CardEditorContext } from "./definition";
@@ -63,7 +64,7 @@ export function renderDaily(
 		});
 		setIcon(open, "square-pen");
 		open.addEventListener("click", () => {
-			void view.app.workspace.getLeaf(true).openFile(file);
+			openNoteFromCard(view, file);
 		});
 	}
 

--- a/src/cards/favorites.ts
+++ b/src/cards/favorites.ts
@@ -3,6 +3,7 @@ import { emptyState } from "../cardbodies";
 import { moveItem } from "../editors";
 import { iconForFile } from "../filetypes";
 import { t } from "../i18n";
+import { openNoteFromCard } from "../navigation";
 import { FilePickerModal } from "../pickers";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -25,7 +26,7 @@ export function renderFavorites(view: HomeView, body: HTMLElement): void {
 		if (file instanceof TFile) {
 			setIcon(card.createDiv("hearth-fav-icon"), iconForFile(file));
 			card.createDiv({ cls: "hearth-fav-name", text: file.basename });
-			const open = () => void view.app.workspace.getLeaf(true).openFile(file);
+			const open = () => openNoteFromCard(view, file);
 			card.addEventListener("click", open);
 			makeClickable(card, open, file.basename);
 		} else {

--- a/src/cards/heatmap.ts
+++ b/src/cards/heatmap.ts
@@ -1,6 +1,7 @@
 import { Setting } from "obsidian";
 import { activityByDay, createDailyNoteAt, dailyNotesOptions, heatLevel, moment } from "../cardbodies";
 import { t } from "../i18n";
+import { openNoteFromCard } from "../navigation";
 import { type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -54,7 +55,7 @@ export function renderHeatmap(view: HomeView, card: DashboardCard, body: HTMLEle
 			if (options) {
 				const activate = () => {
 					void createDailyNoteAt(view, day, options).then((f) => {
-						if (f) void view.app.workspace.getLeaf(true).openFile(f);
+						if (f) openNoteFromCard(view, f);
 					});
 				};
 				cellEl.addEventListener("click", activate);

--- a/src/cards/links.ts
+++ b/src/cards/links.ts
@@ -2,7 +2,7 @@ import { setTooltip, Setting, TFile } from "obsidian";
 import { applyTileSize, emptyState, makeTileDraggable, makeTileResizable, markOverlappingTiles } from "../cardbodies";
 import { moveItem } from "../editors";
 import { t } from "../i18n";
-import { openLinkFromCard, openNoteFromCard } from "../navigation";
+import { openLinkFromCard, openNoteFromCard, openUrlFromCard } from "../navigation";
 import { CommandPickerModal } from "../pickers";
 import { addIconHelp, applyTileVisual } from "../widgeticon";
 import { type DashboardCard, type LinkItem } from "../types";
@@ -62,7 +62,7 @@ export function renderLinks(view: HomeView, card: DashboardCard, body: HTMLEleme
 function openLink(view: HomeView, link: LinkItem): void {
 	switch (link.type) {
 		case "url":
-			if (link.target) window.open(link.target, "_blank");
+			if (link.target) openUrlFromCard(view, link.target);
 			break;
 		case "command":
 			if (link.target) view.app.commands.executeCommandById(link.target);

--- a/src/cards/links.ts
+++ b/src/cards/links.ts
@@ -2,6 +2,7 @@ import { setTooltip, Setting, TFile } from "obsidian";
 import { applyTileSize, emptyState, makeTileDraggable, makeTileResizable, markOverlappingTiles } from "../cardbodies";
 import { moveItem } from "../editors";
 import { t } from "../i18n";
+import { openLinkFromCard, openNoteFromCard } from "../navigation";
 import { CommandPickerModal } from "../pickers";
 import { addIconHelp, applyTileVisual } from "../widgeticon";
 import { type DashboardCard, type LinkItem } from "../types";
@@ -68,8 +69,8 @@ function openLink(view: HomeView, link: LinkItem): void {
 			break;
 		case "note": {
 			const file = view.app.vault.getAbstractFileByPath(link.target);
-			if (file instanceof TFile) void view.app.workspace.getLeaf(true).openFile(file);
-			else if (link.target) void view.app.workspace.openLinkText(link.target, "", true);
+			if (file instanceof TFile) openNoteFromCard(view, file);
+			else if (link.target) openLinkFromCard(view, link.target);
 			break;
 		}
 	}

--- a/src/cards/recent.ts
+++ b/src/cards/recent.ts
@@ -3,6 +3,7 @@ import { emptyState } from "../cardbodies";
 import { addResetButton } from "../editors";
 import { FILE_TYPE_GROUPS, fileTypeLabel, FOLDERS_GROUP_ID, groupForFile, iconForFile } from "../filetypes";
 import { t } from "../i18n";
+import { openNoteFromCard } from "../navigation";
 import { type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -39,7 +40,7 @@ export function renderRecent(view: HomeView, card: DashboardCard, body: HTMLElem
 		const row = list.createDiv("hearth-list-item");
 		setIcon(row.createDiv("hearth-list-icon"), iconForFile(file));
 		row.createDiv({ cls: "hearth-list-label", text: file.basename });
-		const open = () => void view.app.workspace.getLeaf(true).openFile(file);
+		const open = () => openNoteFromCard(view, file);
 		row.addEventListener("click", open);
 		makeClickable(row, open, file.basename);
 	}

--- a/src/cards/search.ts
+++ b/src/cards/search.ts
@@ -3,6 +3,7 @@ import { emptyState } from "../cardbodies";
 import { addResetButton } from "../editors";
 import { iconForFile } from "../filetypes";
 import { t } from "../i18n";
+import { openNoteFromCard } from "../navigation";
 import { runQuery, searchFileContents, type QueryHit } from "../query";
 import { type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
@@ -60,7 +61,7 @@ function renderQueryList(view: HomeView, body: HTMLElement, list: QueryHit[]): v
 		row.createDiv({ cls: "hearth-list-label", text: name });
 		if (hit.badge) row.createDiv({ cls: "hearth-task-status", text: hit.badge.label });
 		const open = () => {
-			if (hit.file instanceof TFile) void view.app.workspace.getLeaf(true).openFile(hit.file);
+			if (hit.file instanceof TFile) openNoteFromCard(view, hit.file);
 		};
 		row.addEventListener("click", open);
 		makeClickable(row, open, name);
@@ -78,7 +79,7 @@ function renderQueryTiles(view: HomeView, body: HTMLElement, list: QueryHit[]): 
 		const name = hit.file instanceof TFile ? hit.file.basename : hit.file.name;
 		tile.createDiv({ cls: "hearth-link-label", text: name });
 		const open = () => {
-			if (hit.file instanceof TFile) void view.app.workspace.getLeaf(true).openFile(hit.file);
+			if (hit.file instanceof TFile) openNoteFromCard(view, hit.file);
 		};
 		tile.addEventListener("click", open);
 		makeClickable(tile, open, name);

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -1,0 +1,49 @@
+import { TFile } from "obsidian";
+import type HearthPlugin from "./main";
+
+/**
+ * Enforce the "Open note from explorer" setting (#106) on Obsidian's own
+ * native File Explorer pane — independent of, and never installed by, any of
+ * Hearth's own cards.
+ *
+ * Obsidian's File Explorer isn't part of the public plugin API, so this
+ * relies on its DOM structure (`.nav-file-title[data-path]` inside a
+ * `[data-type="file-explorer"]` leaf) — a convention that's been stable for
+ * years and widely relied on by community plugins/snippets, but not
+ * guaranteed. A single capturing click listener is registered once, at
+ * plugin load, and cleaned up automatically on unload via
+ * `plugin.registerDomEvent`; it no-ops immediately whenever the setting is
+ * "default", so nobody who hasn't opted in pays any cost or sees any
+ * behaviour change.
+ *
+ * Only a plain, unmodified left click is intercepted — Ctrl/Cmd/Shift/Alt
+ * clicks (and middle-click, which fires "auxclick" instead of "click") are
+ * left to Obsidian's own handling so manual new-tab/split-pane gestures keep
+ * working exactly as before.
+ */
+export function registerExplorerOpenOverride(plugin: HearthPlugin): void {
+	plugin.registerDomEvent(
+		document,
+		"click",
+		(evt: MouseEvent) => {
+			const setting = plugin.settings.openNoteInExplorer;
+			if (setting === "default") return;
+			if (evt.defaultPrevented || evt.button !== 0) return;
+			if (evt.ctrlKey || evt.metaKey || evt.shiftKey || evt.altKey) return;
+
+			const target = evt.target as HTMLElement | null;
+			const titleEl = target?.closest<HTMLElement>(".nav-file-title[data-path]");
+			if (!titleEl || !titleEl.closest('[data-type="file-explorer"]')) return;
+
+			const path = titleEl.dataset.path;
+			if (!path) return;
+			const file = plugin.app.vault.getAbstractFileByPath(path);
+			if (!(file instanceof TFile)) return;
+
+			evt.preventDefault();
+			evt.stopImmediatePropagation();
+			void plugin.app.workspace.getLeaf(setting !== "current").openFile(file);
+		},
+		{ capture: true },
+	);
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -372,14 +372,26 @@ export const en = {
 			focusSearchOnOpenDesc:
 				"Place the cursor in the search field whenever a home view opens, so " +
 				"you can start typing right away. Desktop only.",
-			openNoteIn: "Open notes in",
-			openNoteInDesc:
-				"Where a note opens when clicked from a card (Recent, Bookmarks, " +
-				"Favorites, saved queries, launchpad note tiles) or the search results. " +
-				"“Current tab” replaces the home view in place; external URLs always " +
-				"open in the browser.",
-			openNoteInTab: "New tab",
-			openNoteInCurrent: "Current tab (replace Hearth)",
+			openNoteInLink: "Open note from link",
+			openNoteInLinkDesc:
+				"Where a note opens when clicked from a Hearth card — Recent, " +
+				"Bookmarks, Favorites, saved queries, launchpad note tiles, the " +
+				"daily-note button, the activity heatmap, the top search bar, or a " +
+				"mobile action button. “Current tab” replaces the home view in place.",
+			openNoteInExplorer: "Open note from explorer",
+			openNoteInExplorerDesc:
+				"Where a note opens when clicked in Obsidian's own File Explorer pane " +
+				"(the file-tree sidebar) — independent of Hearth's own cards. " +
+				"“Default” leaves Obsidian's normal click handling untouched.",
+			openUrlIn: "Open URL",
+			openUrlInDesc:
+				"Where a URL-type launchpad or mobile-action link opens. Only takes " +
+				"effect when Obsidian's core Web Viewer plugin is enabled and set to " +
+				"open external links itself — otherwise links always open in your " +
+				"system browser.",
+			openInDefault: "Default (Obsidian's normal behavior)",
+			openInTab: "New tab",
+			openInCurrent: "Current tab (replace Hearth)",
 			mobileSearchOnly: "Mobile mode (search only)",
 			mobileSearchOnlyDesc:
 				"On phones and tablets, hide the dashboard and show only the search " +

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -372,6 +372,14 @@ export const en = {
 			focusSearchOnOpenDesc:
 				"Place the cursor in the search field whenever a home view opens, so " +
 				"you can start typing right away. Desktop only.",
+			openNoteIn: "Open notes in",
+			openNoteInDesc:
+				"Where a note opens when clicked from a card (Recent, Bookmarks, " +
+				"Favorites, saved queries, launchpad note tiles) or the search results. " +
+				"“Current tab” replaces the home view in place; external URLs always " +
+				"open in the browser.",
+			openNoteInTab: "New tab",
+			openNoteInCurrent: "Current tab (replace Hearth)",
 			mobileSearchOnly: "Mobile mode (search only)",
 			mobileSearchOnlyDesc:
 				"On phones and tablets, hide the dashboard and show only the search " +

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import type { WorkspacesInstance } from "./obsidian-ext";
 import { EXCALIDRAW_PLUGIN_ID } from "./filetypes";
 import { setLanguage, t } from "./i18n";
 import { maybeShowWhatsNew } from "./whatsnew";
+import { registerExplorerOpenOverride } from "./explorer";
 
 /** Core "Audio recorder" plugin id, used by the "Record voice" mobile action. */
 const AUDIO_RECORDER_PLUGIN_ID = "audio-recorder";
@@ -96,6 +97,8 @@ export default class HearthPlugin extends Plugin {
 		this.registerDashboardCommands();
 
 		this.addSettingTab(new HomeSettingTab(this.app, this));
+
+		registerExplorerOpenOverride(this);
 
 		// Replace freshly-opened empty tabs with the home view.
 		this.registerEvent(

--- a/src/mobileactions.ts
+++ b/src/mobileactions.ts
@@ -1,5 +1,6 @@
 import { setIcon, TFile } from "obsidian";
 import type { HomeView } from "./view";
+import { openLinkFromCard, openNoteFromCard } from "./navigation";
 import type { MobileActionButton } from "./types";
 
 /**
@@ -48,8 +49,8 @@ function runMobileAction(view: HomeView, btn: MobileActionButton): void {
 			break;
 		case "note": {
 			const file = view.app.vault.getAbstractFileByPath(target);
-			if (file instanceof TFile) void view.app.workspace.getLeaf(true).openFile(file);
-			else void view.app.workspace.openLinkText(target, "", true);
+			if (file instanceof TFile) openNoteFromCard(view, file);
+			else openLinkFromCard(view, target);
 			break;
 		}
 		case "command":

--- a/src/mobileactions.ts
+++ b/src/mobileactions.ts
@@ -1,6 +1,6 @@
 import { setIcon, TFile } from "obsidian";
 import type { HomeView } from "./view";
-import { openLinkFromCard, openNoteFromCard } from "./navigation";
+import { openLinkFromCard, openNoteFromCard, openUrlFromCard } from "./navigation";
 import type { MobileActionButton } from "./types";
 
 /**
@@ -45,7 +45,7 @@ function runMobileAction(view: HomeView, btn: MobileActionButton): void {
 	if (!target) return;
 	switch (btn.type ?? "command") {
 		case "url":
-			window.open(target, "_blank");
+			openUrlFromCard(view, target);
 			break;
 		case "note": {
 			const file = view.app.vault.getAbstractFileByPath(target);

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -4,22 +4,57 @@ import type { HomeView } from "./view";
 /**
  * Whether a note the user activated from a Hearth card should open in a new tab
  * or reuse the current (Hearth) tab. Central so every card obeys the one global
- * "Open notes in" setting (#106): "current" replaces the home view in place
- * (getLeaf(false) returns the active, navigable Hearth leaf); "tab" (the
+ * "Open note from link" setting (#106): "current" replaces the home view in
+ * place (getLeaf(false) returns the active, navigable Hearth leaf); "tab" (the
  * default) spawns a new tab (getLeaf(true)).
  */
 function wantNewLeaf(view: HomeView): boolean {
-	return view.plugin.settings.openNoteIn !== "current";
+	return view.plugin.settings.openNoteInLink !== "current";
 }
 
 /** Open a resolved note the user activated from a Hearth card, honoring the
- * global "Open notes in" setting. */
+ * "Open note from link" setting. */
 export function openNoteFromCard(view: HomeView, file: TFile): void {
 	void view.app.workspace.getLeaf(wantNewLeaf(view)).openFile(file);
 }
 
 /** Open a link by its link text (used when a target isn't a resolved TFile),
- * honoring the global "Open notes in" setting. */
+ * honoring the "Open note from link" setting. */
 export function openLinkFromCard(view: HomeView, linktext: string, sourcePath = ""): void {
 	void view.app.workspace.openLinkText(linktext, sourcePath, wantNewLeaf(view));
+}
+
+/**
+ * Internal id Obsidian registers its core "Web Viewer" plugin (and the view
+ * type it hosts) under. Not part of the public API — inferred from Obsidian's
+ * own hyphenated core-plugin naming convention (`file-explorer`,
+ * `daily-notes`, `audio-recorder`, …) and the `help.obsidian.md/plugins/web-viewer`
+ * slug. Unverified against a live install; if it's wrong, only the "current
+ * tab" branch below silently falls back to the system browser (see catch).
+ */
+const WEB_VIEWER_ID = "web-viewer";
+
+/** Open an external URL a user activated from a Hearth card (a URL-type
+ * launchpad/mobile-action link), honoring the "Open URL" setting (#106). When
+ * Obsidian's core Web Viewer plugin is enabled and the setting is "current",
+ * the Hearth tab is replaced with a Web Viewer leaf showing the URL. Otherwise
+ * the URL is handed to window.open exactly as before this setting existed —
+ * if Web Viewer's own "open external links" option is on, Obsidian intercepts
+ * that call itself and routes it into a Web Viewer tab; if Web Viewer isn't
+ * enabled, it opens in the system browser. */
+export function openUrlFromCard(view: HomeView, url: string): void {
+	const wantsCurrentTab = view.plugin.settings.openUrlIn === "current";
+	const webViewerEnabled = view.app.internalPlugins.getPluginById(WEB_VIEWER_ID)?.enabled ?? false;
+	if (wantsCurrentTab && webViewerEnabled) {
+		try {
+			const leaf = view.app.workspace.getLeaf(false);
+			void leaf.setViewState({ type: WEB_VIEWER_ID, active: true, state: { url } }).catch(() => {
+				window.open(url, "_blank");
+			});
+			return;
+		} catch {
+			// Fall through to the system browser below.
+		}
+	}
+	window.open(url, "_blank");
 }

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,0 +1,25 @@
+import type { TFile } from "obsidian";
+import type { HomeView } from "./view";
+
+/**
+ * Whether a note the user activated from a Hearth card should open in a new tab
+ * or reuse the current (Hearth) tab. Central so every card obeys the one global
+ * "Open notes in" setting (#106): "current" replaces the home view in place
+ * (getLeaf(false) returns the active, navigable Hearth leaf); "tab" (the
+ * default) spawns a new tab (getLeaf(true)).
+ */
+function wantNewLeaf(view: HomeView): boolean {
+	return view.plugin.settings.openNoteIn !== "current";
+}
+
+/** Open a resolved note the user activated from a Hearth card, honoring the
+ * global "Open notes in" setting. */
+export function openNoteFromCard(view: HomeView, file: TFile): void {
+	void view.app.workspace.getLeaf(wantNewLeaf(view)).openFile(file);
+}
+
+/** Open a link by its link text (used when a target isn't a resolved TFile),
+ * honoring the global "Open notes in" setting. */
+export function openLinkFromCard(view: HomeView, linktext: string, sourcePath = ""): void {
+	void view.app.workspace.openLinkText(linktext, sourcePath, wantNewLeaf(view));
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -3,6 +3,7 @@ import type { HomeView } from "./view";
 import { FILE_TYPE_GROUPS, FileTypeGroup, fileTypeLabel, groupForFile, iconForFile, OTHER_GROUP_ID } from "./filetypes";
 import { QueryFilter, QueryHit, runQuery, searchFileContents } from "./query";
 import { isOmnisearchAvailable, searchWithOmnisearch } from "./omnisearch";
+import { openNoteFromCard } from "./navigation";
 import { t } from "./i18n";
 
 /** Recently opened-via-search files, kept in the vault's local storage (never
@@ -472,7 +473,7 @@ export class SearchSection {
 	private openFile(file: TAbstractFile): void {
 		if (file instanceof TFile) {
 			this.pushHistory(file.path);
-			void this.view.app.workspace.getLeaf(true).openFile(file);
+			openNoteFromCard(this.view, file);
 			this.hide();
 		} else if (file instanceof TFolder) {
 			// Reveal the folder in the file explorer.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -733,6 +733,19 @@ export class HomeSettingTab extends PluginSettingTab {
 					}),
 				);
 		}
+
+		new Setting(containerEl)
+			.setName(t().settings.behaviour.openNoteIn)
+			.setDesc(t().settings.behaviour.openNoteInDesc)
+			.addDropdown((d) => {
+				d.addOption("tab", t().settings.behaviour.openNoteInTab)
+					.addOption("current", t().settings.behaviour.openNoteInCurrent)
+					.setValue(s.openNoteIn)
+					.onChange(async (v) => {
+						s.openNoteIn = v as HomeSettings["openNoteIn"];
+						await this.save();
+					});
+			});
 	}
 
 	// ---- Privacy & network ----------------------------------------------

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -735,14 +735,41 @@ export class HomeSettingTab extends PluginSettingTab {
 		}
 
 		new Setting(containerEl)
-			.setName(t().settings.behaviour.openNoteIn)
-			.setDesc(t().settings.behaviour.openNoteInDesc)
+			.setName(t().settings.behaviour.openNoteInLink)
+			.setDesc(t().settings.behaviour.openNoteInLinkDesc)
 			.addDropdown((d) => {
-				d.addOption("tab", t().settings.behaviour.openNoteInTab)
-					.addOption("current", t().settings.behaviour.openNoteInCurrent)
-					.setValue(s.openNoteIn)
+				d.addOption("tab", t().settings.behaviour.openInTab)
+					.addOption("current", t().settings.behaviour.openInCurrent)
+					.setValue(s.openNoteInLink)
 					.onChange(async (v) => {
-						s.openNoteIn = v as HomeSettings["openNoteIn"];
+						s.openNoteInLink = v as HomeSettings["openNoteInLink"];
+						await this.save();
+					});
+			});
+
+		new Setting(containerEl)
+			.setName(t().settings.behaviour.openNoteInExplorer)
+			.setDesc(t().settings.behaviour.openNoteInExplorerDesc)
+			.addDropdown((d) => {
+				d.addOption("default", t().settings.behaviour.openInDefault)
+					.addOption("tab", t().settings.behaviour.openInTab)
+					.addOption("current", t().settings.behaviour.openInCurrent)
+					.setValue(s.openNoteInExplorer)
+					.onChange(async (v) => {
+						s.openNoteInExplorer = v as HomeSettings["openNoteInExplorer"];
+						await this.save();
+					});
+			});
+
+		new Setting(containerEl)
+			.setName(t().settings.behaviour.openUrlIn)
+			.setDesc(t().settings.behaviour.openUrlInDesc)
+			.addDropdown((d) => {
+				d.addOption("tab", t().settings.behaviour.openInTab)
+					.addOption("current", t().settings.behaviour.openInCurrent)
+					.setValue(s.openUrlIn)
+					.onChange(async (v) => {
+						s.openUrlIn = v as HomeSettings["openUrlIn"];
 						await this.save();
 					});
 			});

--- a/src/types.ts
+++ b/src/types.ts
@@ -779,12 +779,26 @@ export interface HomeSettings {
 	 * mouse. Desktop only — auto-focusing on mobile would pop the on-screen
 	 * keyboard on every open. */
 	focusSearchOnOpen: boolean;
-	/** Where a note opens when clicked from a Hearth card (Recent, Bookmarks,
-	 * Favorites, saved queries, launchpad note tiles, …) or the search results.
-	 * "tab" (default) opens it in a new tab; "current" reuses the Hearth tab,
-	 * replacing the home view in place (#106). External URLs always open in the
-	 * browser regardless. */
-	openNoteIn: "tab" | "current";
+	/** Where a note opens when clicked from a Hearth card — Recent, Bookmarks,
+	 * Favorites, saved queries, launchpad note tiles, the daily-note button,
+	 * the activity heatmap, the top search bar, or a mobile action button
+	 * (#106). "tab" (default) opens it in a new tab; "current" reuses the
+	 * Hearth tab, replacing the home view in place. */
+	openNoteInLink: "tab" | "current";
+	/** Where a note opens when clicked in Obsidian's own File Explorer pane
+	 * (the file-tree sidebar), independent of Hearth's own cards (#106).
+	 * "default" (the initial value) installs no override, leaving Obsidian's
+	 * stock click handling untouched; "tab"/"current" force every plain click
+	 * to open a new leaf / reuse the active one respectively. */
+	openNoteInExplorer: "default" | "tab" | "current";
+	/** Where a URL-type launchpad/mobile-action link opens (#106). Only takes
+	 * effect when Obsidian's core Web Viewer plugin is enabled: "current"
+	 * replaces the Hearth tab with a Web Viewer leaf showing the URL. "tab"
+	 * (default) hands the URL to window.open exactly as before — if Web
+	 * Viewer's own "open external links" option is on, Obsidian intercepts
+	 * that call itself and routes it into a Web Viewer tab; otherwise it opens
+	 * in the system browser. */
+	openUrlIn: "tab" | "current";
 	/** On mobile, show only the search field and hide the dashboard. Has no
 	 * effect on desktop, where the full dashboard is always shown. */
 	mobileSearchOnly: boolean;
@@ -882,7 +896,9 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	openOnStartup: true,
 	replaceNewTabs: true,
 	focusSearchOnOpen: false,
-	openNoteIn: "tab",
+	openNoteInLink: "tab",
+	openNoteInExplorer: "default",
+	openUrlIn: "tab",
 	mobileSearchOnly: false,
 	showMobileActionBar: true,
 	// Backfilled by migrateSettings so a fresh install gets the defaults below
@@ -1325,6 +1341,11 @@ export function migrateSettings(s: HomeSettings, raw: Record<string, unknown>): 
 	// The short-lived "split" pill mode was replaced by a plain single button
 	// whose action is chosen here; fall back to the original New-note behaviour.
 	if ((s.newNoteButtonMode as string) === "split") s.newNoteButtonMode = "newNote";
+	// Migrate the short-lived single "openNoteIn" field (drafted alongside this
+	// setting, never shipped in a release) into `openNoteInLink`.
+	if (typeof raw.openNoteIn === "string" && typeof raw.openNoteInLink !== "string") {
+		s.openNoteInLink = raw.openNoteIn as HomeSettings["openNoteInLink"];
+	}
 	// Drop the obsolete single-board field so it can't shadow the dashboards.
 	delete (s as unknown as { cards?: unknown }).cards;
 	return migratedCommandId;

--- a/src/types.ts
+++ b/src/types.ts
@@ -779,6 +779,12 @@ export interface HomeSettings {
 	 * mouse. Desktop only — auto-focusing on mobile would pop the on-screen
 	 * keyboard on every open. */
 	focusSearchOnOpen: boolean;
+	/** Where a note opens when clicked from a Hearth card (Recent, Bookmarks,
+	 * Favorites, saved queries, launchpad note tiles, …) or the search results.
+	 * "tab" (default) opens it in a new tab; "current" reuses the Hearth tab,
+	 * replacing the home view in place (#106). External URLs always open in the
+	 * browser regardless. */
+	openNoteIn: "tab" | "current";
 	/** On mobile, show only the search field and hide the dashboard. Has no
 	 * effect on desktop, where the full dashboard is always shown. */
 	mobileSearchOnly: boolean;
@@ -876,6 +882,7 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	openOnStartup: true,
 	replaceNewTabs: true,
 	focusSearchOnOpen: false,
+	openNoteIn: "tab",
 	mobileSearchOnly: false,
 	showMobileActionBar: true,
 	// Backfilled by migrateSettings so a fresh install gets the defaults below


### PR DESCRIPTION
Closes #106.

Per the issue thread, this replaces the single "Open notes in" toggle with the three separate behaviors actually discussed there:

- **Open note from link** — notes opened from Hearth's own cards (Recent, Bookmarks, Favorites, saved queries, launchpad note tiles, the daily-note button, the activity heatmap, the top search bar, mobile action buttons). Same as the original single setting, just renamed/scoped.
- **Open note from explorer** — a new override for Obsidian's own native File Explorer pane (the file-tree sidebar), completely independent of Hearth's cards. Defaults to **"Default"**, which installs no interception at all, so nobody's Explorer click behavior changes unless they deliberately opt in — Hearth never touched this before, so a different default would be a silent, sidebar-wide behavior change for every existing user.
- **Open URL** — governs URL-type launchpad/mobile-action links. "Current tab" only takes effect when Obsidian's core Web Viewer plugin is enabled (opens via `leaf.setViewState`); otherwise the URL is handed to `window.open` exactly as before — if Web Viewer's own "open external links" option is on, Obsidian intercepts that call itself.

Each dropdown offers **New tab** (default, except Explorer) / **Current tab (replace Hearth)**; Explorer additionally offers **Default**.

## How
- `navigation.ts`: `openNoteFromCard`/`openLinkFromCard` now read `openNoteInLink` (renamed from `openNoteIn`); a new `openUrlFromCard` implements the Web-Viewer-aware URL behavior.
- `explorer.ts` (new): a single capturing click listener on `.nav-file-title[data-path]` inside the native File Explorer, registered once at load and a no-op whenever the setting is `"default"`.
- `migrateSettings` carries over any pre-release `openNoteIn` value into `openNoteInLink`.

## Scope notes
- Only URL-type **Links/launchpad card** and **mobile action button** entries route through the "Open URL" setting — RSS items, Jira issue links, task-note URLs, the header's "search online" button, and rendered-markdown links are unchanged/out of scope, same as before.
- Dataview card results are rendered and handled by Dataview itself, outside Hearth's control.
- Task cards keep their own open flow (quick-view popover), untouched here.

## Caveats
- The Web Viewer integration relies on an internal plugin/view-type id (`web-viewer`) inferred from Obsidian's core-plugin naming convention — it isn't part of the public API and is unverified against a live install. If wrong, `getPluginById` simply returns `null` and the "current tab" URL behavior silently falls back to the system browser (no broken behavior, just the new option not activating) — worth confirming on a real vault with Web Viewer enabled.
- The File Explorer override depends on Obsidian's `.nav-file-title[data-path]` / `[data-type="file-explorer"]` DOM structure — long-stable and widely relied on by other community plugins, but likewise not a guaranteed public API.

## Testing
- `npm run typecheck`, `npm run lint` (0 errors), `npm run test` (169 passing), `npm run build` all green.
- The File Explorer/Web Viewer paths touch Obsidian APIs and DOM the project's test harness deliberately excludes ("pure logic only — no DOM, no jsdom, no Obsidian API mocks"), so they're unverified by automated tests — manual testing in a real vault is recommended, especially for the Web Viewer id guess above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe)_