### PR TITLE
Jump to the task's line when opening its note (#118)

### DIFF
--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -3782,11 +3782,15 @@ async function openTaskFile(view: HomeView, hit: TaskHit): Promise<void> {
 	if (hit.line < 0 && (await openInTaskNotes(view, hit.file))) return;
 
 	const leaf = view.app.workspace.getLeaf(true);
-	await leaf.openFile(hit.file);
+	// Scroll to the task's line via ephemeral state rather than a setCursor call
+	// right after openFile: in a freshly created leaf the editor isn't laid out
+	// yet, so an immediate scroll is discarded and the note opens at the top
+	// (#118). Obsidian applies `eState.line` once the MarkdownView has mounted,
+	// so the note lands on the task. The setCursor below then places the caret.
+	const openState = hit.line >= 0 ? { eState: { line: hit.line } } : undefined;
+	await leaf.openFile(hit.file, openState);
 	if (hit.line >= 0 && leaf.view instanceof MarkdownView) {
-		const pos = { line: hit.line, ch: 0 };
-		leaf.view.editor.setCursor(pos);
-		leaf.view.editor.scrollIntoView({ from: pos, to: pos }, true);
+		leaf.view.editor.setCursor({ line: hit.line, ch: 0 });
 	}
 }
 


### PR DESCRIPTION
Closes #118.

Opening a task's note — via the quick-view **"Jump to Note"** button, or a click when quick-view is off — landed at the **top** of the note instead of at the task, so a task buried in a long note meant scrolling to find it.

## Cause
`openTaskFile` already tried to scroll, but via a `setCursor` / `scrollIntoView` call issued **immediately** after `openFile`. In a freshly created leaf the editor isn't laid out yet, so that scroll is discarded and the note opens at the top.

## Fix
Pass the target line as **ephemeral state** (`openFile(file, { eState: { line } })`). Obsidian applies `eState.line` once the `MarkdownView` has mounted, reliably landing on the task line — the same mechanism Dataview task links and search results use. The caret is still placed via `setCursor` afterwards.

Only line-based tasks (checkbox / Kanban) carry a line; TaskNotes whole-file tasks and note-linked cards keep opening as before.

## Testing
- `npm run typecheck`, `npm run lint` (0 errors), `npm run test` (169 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe)_