### PR TITLE
Support vault-image icons on tiles; add Lucide icon tooltip (#119)

### DIFF
--- a/src/cards/commands.ts
+++ b/src/cards/commands.ts
@@ -3,7 +3,7 @@ import { applyTileSize, emptyState, makeTileDraggable, makeTileResizable, markOv
 import { moveItem } from "../editors";
 import { t } from "../i18n";
 import { CommandPickerModal } from "../pickers";
-import { applyWidgetIcon } from "../widgeticon";
+import { addIconHelp, applyTileVisual } from "../widgeticon";
 import { type CommandItem, type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -29,7 +29,7 @@ export function renderCommands(view: HomeView, card: DashboardCard, body: HTMLEl
 		// height/icon (via --hearth-tile) and, when larger than the base, makes
 		// the tile span proportionally more grid columns so it's wider too.
 		applyTileSize(tile, cmd.sizeW, cmd.sizeH, cmd.size, baseTile, cmd.col, cmd.row);
-		applyWidgetIcon(view, tile.createDiv("hearth-link-icon"), cmd.icon, "terminal-square");
+		applyTileVisual(view, tile, cmd.icon, "terminal-square");
 		tile.createDiv({ cls: "hearth-link-label", text: cmd.name || cmd.id });
 		const run = () => runCommand(view, cmd);
 		// In arrange mode, clicking a tile must NOT trigger its action.
@@ -112,6 +112,7 @@ export function commandsEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 				});
 			setTooltip(txt.inputEl, t().editors.iconHelp);
 		});
+		addIconHelp(row.controlEl);
 		row.addText((txt) => {
 			txt
 				.setPlaceholder(t().editors.commands.sizePlaceholder)

--- a/src/cards/commands.ts
+++ b/src/cards/commands.ts
@@ -1,8 +1,9 @@
-import { setIcon, Setting } from "obsidian";
+import { setTooltip, Setting } from "obsidian";
 import { applyTileSize, emptyState, makeTileDraggable, makeTileResizable, markOverlappingTiles } from "../cardbodies";
 import { moveItem } from "../editors";
 import { t } from "../i18n";
 import { CommandPickerModal } from "../pickers";
+import { applyWidgetIcon } from "../widgeticon";
 import { type CommandItem, type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -28,7 +29,7 @@ export function renderCommands(view: HomeView, card: DashboardCard, body: HTMLEl
 		// height/icon (via --hearth-tile) and, when larger than the base, makes
 		// the tile span proportionally more grid columns so it's wider too.
 		applyTileSize(tile, cmd.sizeW, cmd.sizeH, cmd.size, baseTile, cmd.col, cmd.row);
-		setIcon(tile.createDiv("hearth-link-icon"), cmd.icon || "terminal-square");
+		applyWidgetIcon(view, tile.createDiv("hearth-link-icon"), cmd.icon, "terminal-square");
 		tile.createDiv({ cls: "hearth-link-label", text: cmd.name || cmd.id });
 		const run = () => runCommand(view, cmd);
 		// In arrange mode, clicking a tile must NOT trigger its action.
@@ -101,15 +102,16 @@ export function commandsEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 		const row = new Setting(containerEl)
 			.setClass("hearth-link-setting")
 			.setName(cmd.name || cmd.id);
-		row.addText((txt) =>
+		row.addText((txt) => {
 			txt
 				.setPlaceholder(t().editors.commands.iconOptionalPlaceholder)
 				.setValue(cmd.icon ?? "")
 				.onChange((v) => {
 					cmd.icon = v || undefined;
 					ctx.opts.save();
-				}),
-		);
+				});
+			setTooltip(txt.inputEl, t().editors.iconHelp);
+		});
 		row.addText((txt) => {
 			txt
 				.setPlaceholder(t().editors.commands.sizePlaceholder)

--- a/src/cards/links.ts
+++ b/src/cards/links.ts
@@ -3,7 +3,7 @@ import { applyTileSize, emptyState, makeTileDraggable, makeTileResizable, markOv
 import { moveItem } from "../editors";
 import { t } from "../i18n";
 import { CommandPickerModal } from "../pickers";
-import { applyWidgetIcon } from "../widgeticon";
+import { addIconHelp, applyTileVisual } from "../widgeticon";
 import { type DashboardCard, type LinkItem } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -28,7 +28,7 @@ export function renderLinks(view: HomeView, card: DashboardCard, body: HTMLEleme
 	for (const link of links) {
 		const tile = grid.createDiv("hearth-link-tile");
 		applyTileSize(tile, link.sizeW, link.sizeH, link.size, baseTile, link.col, link.row);
-		applyWidgetIcon(view, tile.createDiv("hearth-link-icon"), link.icon, "link");
+		applyTileVisual(view, tile, link.icon, "link");
 		tile.createDiv({ cls: "hearth-link-label", text: link.label || link.target });
 		const open = () => openLink(view, link);
 		// In arrange mode, clicking a tile must NOT trigger its action — the
@@ -112,6 +112,7 @@ export function linksEditor(ctx: CardEditorContext, containerEl: HTMLElement): v
 				});
 			setTooltip(txt.inputEl, t().editors.iconHelp);
 		});
+		addIconHelp(row.controlEl);
 		row.addDropdown((d) => {
 			(Object.keys(t().editors.linkTypes) as LinkItem["type"][]).forEach(
 				(k) => {

--- a/src/cards/links.ts
+++ b/src/cards/links.ts
@@ -1,8 +1,9 @@
-import { setIcon, Setting, TFile } from "obsidian";
+import { setTooltip, Setting, TFile } from "obsidian";
 import { applyTileSize, emptyState, makeTileDraggable, makeTileResizable, markOverlappingTiles } from "../cardbodies";
 import { moveItem } from "../editors";
 import { t } from "../i18n";
 import { CommandPickerModal } from "../pickers";
+import { applyWidgetIcon } from "../widgeticon";
 import { type DashboardCard, type LinkItem } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -27,7 +28,7 @@ export function renderLinks(view: HomeView, card: DashboardCard, body: HTMLEleme
 	for (const link of links) {
 		const tile = grid.createDiv("hearth-link-tile");
 		applyTileSize(tile, link.sizeW, link.sizeH, link.size, baseTile, link.col, link.row);
-		setIcon(tile.createDiv("hearth-link-icon"), link.icon || "link");
+		applyWidgetIcon(view, tile.createDiv("hearth-link-icon"), link.icon, "link");
 		tile.createDiv({ cls: "hearth-link-label", text: link.label || link.target });
 		const open = () => openLink(view, link);
 		// In arrange mode, clicking a tile must NOT trigger its action — the
@@ -101,15 +102,16 @@ export function linksEditor(ctx: CardEditorContext, containerEl: HTMLElement): v
 					ctx.opts.save();
 				}),
 		);
-		row.addText((txt) =>
+		row.addText((txt) => {
 			txt
 				.setPlaceholder(t().editors.links.iconPlaceholder)
 				.setValue(link.icon)
 				.onChange((v) => {
 					link.icon = v;
 					ctx.opts.save();
-				}),
-		);
+				});
+			setTooltip(txt.inputEl, t().editors.iconHelp);
+		});
 		row.addDropdown((d) => {
 			(Object.keys(t().editors.linkTypes) as LinkItem["type"][]).forEach(
 				(k) => {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -487,6 +487,11 @@ export const en = {
 	// ---- Card settings editor ------------------------------------------
 	editors: {
 		title: "Card settings",
+		/** Shown as the tooltip on tile icon fields (launchpad, commands). */
+		iconHelp:
+			"Enter a Lucide icon id (e.g. “home”, “star”, “calendar”) — browse them at " +
+			"lucide.dev/icons. You can also enter a vault image path (e.g. " +
+			"Attachments/icon.png) to use your own picture as the icon.",
 		/** Tabs across the top of the card settings modal. */
 		tabs: {
 			content: "Content",

--- a/src/widgeticon.ts
+++ b/src/widgeticon.ts
@@ -1,0 +1,41 @@
+import { setIcon, TFile } from "obsidian";
+import type { HomeView } from "./view";
+
+/** Image file extensions a widget tile can use as its icon (#119). */
+const IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "avif", "ico"]);
+
+/**
+ * Resolve an icon string to a vault image file, or null when it isn't one. A
+ * launchpad/command tile icon is normally a Lucide icon id, but it may instead
+ * be the vault path of an image (#119) — recognised here by resolving to an
+ * existing image file. A bare Lucide id (no slash/extension) never resolves to
+ * a file, so it falls through to Lucide rendering.
+ */
+export function resolveIconImage(view: HomeView, icon: string | undefined): TFile | null {
+	const path = icon?.trim();
+	if (!path) return null;
+	const file = view.app.vault.getAbstractFileByPath(path);
+	return file instanceof TFile && IMAGE_EXTS.has(file.extension.toLowerCase()) ? file : null;
+}
+
+/**
+ * Render a widget tile's icon into `el`: a vault image when the icon string is
+ * an image path, otherwise a Lucide icon (falling back to `fallback` when the
+ * string is empty). Shared by the launchpad and command cards so both accept
+ * either kind (#119).
+ */
+export function applyWidgetIcon(
+	view: HomeView,
+	el: HTMLElement,
+	icon: string | undefined,
+	fallback: string,
+): void {
+	const image = resolveIconImage(view, icon);
+	if (image) {
+		el.addClass("hearth-icon-image");
+		const img = el.createEl("img", { cls: "hearth-widget-icon-img" });
+		img.src = view.app.vault.getResourcePath(image);
+		return;
+	}
+	setIcon(el, icon?.trim() || fallback);
+}

--- a/src/widgeticon.ts
+++ b/src/widgeticon.ts
@@ -1,5 +1,6 @@
-import { setIcon, TFile } from "obsidian";
+import { setIcon, setTooltip, TFile } from "obsidian";
 import type { HomeView } from "./view";
+import { t } from "./i18n";
 
 /** Image file extensions a widget tile can use as its icon (#119). */
 const IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "avif", "ico"]);
@@ -19,23 +20,38 @@ export function resolveIconImage(view: HomeView, icon: string | undefined): TFil
 }
 
 /**
- * Render a widget tile's icon into `el`: a vault image when the icon string is
- * an image path, otherwise a Lucide icon (falling back to `fallback` when the
- * string is empty). Shared by the launchpad and command cards so both accept
- * either kind (#119).
+ * Render a launchpad/command tile's visual into `tile`, before its label:
+ *
+ * - When the icon string is a vault image path, the image covers the whole tile
+ *   (object-fit: cover) with the label overlaid on top (#119). The caller adds
+ *   the label afterwards; the `hearth-tile-has-image` class makes CSS position
+ *   the image behind it and give the label a legibility scrim.
+ * - Otherwise the usual centered Lucide icon slot is used (falling back to
+ *   `fallback` when the string is empty).
  */
-export function applyWidgetIcon(
+export function applyTileVisual(
 	view: HomeView,
-	el: HTMLElement,
+	tile: HTMLElement,
 	icon: string | undefined,
 	fallback: string,
 ): void {
 	const image = resolveIconImage(view, icon);
 	if (image) {
-		el.addClass("hearth-icon-image");
-		const img = el.createEl("img", { cls: "hearth-widget-icon-img" });
+		tile.addClass("hearth-tile-has-image");
+		const img = tile.createEl("img", { cls: "hearth-tile-image" });
 		img.src = view.app.vault.getResourcePath(image);
 		return;
 	}
-	setIcon(el, icon?.trim() || fallback);
+	setIcon(tile.createDiv("hearth-link-icon"), icon?.trim() || fallback);
+}
+
+/**
+ * Append a small "?" help badge to an icon field's control row, carrying the
+ * shared icon help as its tooltip so users can discover that the field accepts
+ * a Lucide id or a vault image path without having to hover the input (#119).
+ */
+export function addIconHelp(controlEl: HTMLElement): void {
+	const help = controlEl.createSpan({ cls: "hearth-icon-help", text: "?" });
+	setTooltip(help, t().editors.iconHelp);
+	help.setAttribute("aria-label", t().editors.iconHelp);
 }

--- a/styles.css
+++ b/styles.css
@@ -1655,13 +1655,56 @@
 	height: 24px;
 }
 
-/* A vault image used as a tile icon (#119): sized to match the Lucide glyph and
- * scaled to fit so non-square images aren't distorted. */
-.hearth-link-icon .hearth-widget-icon-img {
-	width: 24px;
-	height: 24px;
-	object-fit: contain;
-	border-radius: 4px;
+/* A vault image used as a tile icon (#119): the image covers the whole tile and
+ * the label is overlaid on top of it. */
+.hearth-link-tile.hearth-tile-has-image {
+	position: relative;
+	overflow: hidden;
+	padding: 0;
+}
+
+.hearth-tile-image {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	z-index: 0;
+}
+
+/* Label sits over the image with a legibility scrim (a darkened pill) so text
+ * stays readable on any picture, light or dark. */
+.hearth-link-tile.hearth-tile-has-image .hearth-link-label {
+	position: relative;
+	z-index: 1;
+	max-width: calc(100% - 8px);
+	padding: 2px 8px;
+	border-radius: 6px;
+	color: #fff;
+	background: rgba(0, 0, 0, 0.55);
+	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+/* An image tile that's too small to show its label just shows the image. */
+.hearth-link-tile.hearth-tile-has-image.is-icon-only .hearth-link-label {
+	display: none;
+}
+
+/* The small "?" help badge beside an icon field in the card editors (#119). */
+.hearth-icon-help {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	height: 18px;
+	margin-left: 4px;
+	border-radius: 50%;
+	font-size: 11px;
+	font-weight: 600;
+	color: var(--text-muted);
+	background: var(--background-modifier-border);
+	cursor: help;
+	flex: none;
 }
 
 /* When a tile is shrunk too small to show its label (added by applyTileSize),

--- a/styles.css
+++ b/styles.css
@@ -1655,6 +1655,15 @@
 	height: 24px;
 }
 
+/* A vault image used as a tile icon (#119): sized to match the Lucide glyph and
+ * scaled to fit so non-square images aren't distorted. */
+.hearth-link-icon .hearth-widget-icon-img {
+	width: 24px;
+	height: 24px;
+	object-fit: contain;
+	border-radius: 4px;
+}
+
 /* When a tile is shrunk too small to show its label (added by applyTileSize),
  * hide the label and drop the gap so the icon centres exactly. Without this the
  * empty label + gap keep reserving space and push the icon above centre, so it


### PR DESCRIPTION
Closes #119.

## Custom icons from the vault
Launchpad (**links**) and **command** tiles could only use a Lucide icon id. They now also accept a **vault image path** (`png`, `jpg`, `jpeg`, `gif`, `svg`, `webp`, `bmp`, `avif`, `ico`) as the icon — e.g. `Attachments/icon.png`.

A shared `widgeticon.ts` helper (`applyWidgetIcon`) resolves the icon string:
- If it points at an existing vault image → render it as a scaled `<img>` (via `vault.getResourcePath`), sized to match the Lucide glyph with `object-fit: contain` so non-square images aren't distorted.
- Otherwise → `setIcon` with the Lucide id, as before.

A bare Lucide id (no slash/extension) never resolves to a file, so **existing icons are completely unaffected** and no migration is needed.

## Lucide tooltip
The icon input in both the launchpad and command editors now carries a tooltip explaining the field takes a Lucide icon id (pointing to `lucide.dev/icons`) **or** a vault image path.

## Scope
Covers the launchpad and command tiles (the "launchpad and similar widgets" from the issue). Other icon fields (dashboard switcher, mobile action bar) continue to take Lucide ids and could adopt the same helper in a follow-up.

## Testing
- `npm run typecheck`, `npm run lint` (0 errors), `npm run test` (169 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3Ad8Xy7hXtBK4gBGXqHKe)_