### PR TITLE
Tasks card: status chip in the list, Kanban translucency to match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   task progresses its status. The checkbox swallows pointer events so ticking it
   on a draggable card doesn't start a drag. Recurring tasks keep their
   per-occurrence checkbox; checkbox- and Kanban-source tasks are unchanged (#111).
+- **Status chip on TaskNotes tasks in the list layout.** With the checkbox
+  replacing the old status badge, a task's actual status — open, in-progress,
+  waiting, whatever your setup uses — was no longer visible in the list; the
+  checkbox only says done or not. Each TaskNotes task now carries a small status
+  pill beside its priority chip, showing the raw frontmatter value (capitalized
+  for reading) with the full value in the tooltip. Checkbox- and Kanban-source
+  tasks keep their existing badges.
 - **Vault images as tile icons.** Launchpad and command tiles accepted only a
   Lucide icon id; they now also take a path to an image in your vault (png, jpg,
   svg, webp, …), which fills the whole tile with the label overlaid on a
@@ -64,8 +71,10 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   Sunday-based day offset, so in any locale whose week starts on Monday (Czech,
   most of Europe) occurrences landed on the wrong date — off by up to several
   days. The expansion is now locale-independent. The agenda view's
-  today-highlight is also toned down to a thin outline and a lightly tinted day
-  number; the month grid keeps its existing highlight.
+  today-highlight is also toned down to a thin row border and an
+  accent-coloured day number, with no filled pill behind it, so today reads as
+  part of the list rather than a block of colour; the month grid keeps its
+  existing highlight.
 - **Search filter chips no longer strand across the search bar.** With only a
   few filters, the chips were distributed edge-to-edge — one at the start, one
   in the middle, one at the end. They now sit in a left-aligned row whose gap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,10 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   replacing the old status badge, a task's actual status — open, in-progress,
   waiting, whatever your setup uses — was no longer visible in the list; the
   checkbox only says done or not. Each TaskNotes task now carries a small status
-  pill beside its priority chip, showing the raw frontmatter value (capitalized
-  for reading) with the full value in the tooltip. Checkbox- and Kanban-source
+  pill directly after its title, left-aligned against it so it reads as part of
+  the task while the priority and date chips stay on the right edge. It shows
+  the raw frontmatter value (capitalized for reading) with the full value in the
+  tooltip, and fades along with a completed row. Checkbox- and Kanban-source
   tasks keep their existing badges.
 - **Vault images as tile icons.** Launchpad and command tiles accepted only a
   Lucide icon id; they now also take a path to an image in your vault (png, jpg,
@@ -71,10 +73,8 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   Sunday-based day offset, so in any locale whose week starts on Monday (Czech,
   most of Europe) occurrences landed on the wrong date — off by up to several
   days. The expansion is now locale-independent. The agenda view's
-  today-highlight is also toned down to a thin row border and an
-  accent-coloured day number, with no filled pill behind it, so today reads as
-  part of the list rather than a block of colour; the month grid keeps its
-  existing highlight.
+  today-highlight is also toned down to a thin outline and a lightly tinted day
+  number; the month grid keeps its existing highlight.
 - **Search filter chips no longer strand across the search bar.** With only a
   few filters, the chips were distributed edge-to-edge — one at the start, one
   in the middle, one at the end. They now sit in a left-aligned row whose gap
@@ -83,6 +83,13 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Changed
 
+- **Kanban boards are as translucent as task lists.** The list layout draws no
+  surface of its own, so a translucent or frosted card shows straight through
+  it — but a Kanban board covered the same card with an opaque column plate and
+  opaque cards, reading as a solid slab on an otherwise see-through board.
+  Columns are now a light tint rather than a plate, and cards a translucent fill
+  with their hairline border defining the edge; both scale with the board's card
+  opacity, so they fade in step with the surface they sit on.
 - **Default background** swapped from an animated GIF to a static wallpaper;
   the GIF was needlessly power-hungry.
 - **Card architecture modularised into a registry** (internal, behaviour

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -303,12 +303,19 @@ function renderPriority(parent: HTMLElement, priority: string, dotOnly = false):
 
 /** A small pill showing a TaskNotes task's raw status value. The list layout's
  * completion checkbox only says done/not-done, so the actual status (open,
- * in-progress, waiting, …) needs a chip of its own beside the priority. */
-function renderTaskStatus(parent: HTMLElement, status: string): void {
+ * in-progress, waiting, …) needs a chip of its own. It's rendered straight
+ * after the task title and left-aligned against it (see the `has-statuschip`
+ * rules in styles.css) so it reads as part of the task rather than floating
+ * among the right-hand priority/date chips. */
+function renderTaskStatus(row: HTMLElement, status: string): void {
 	const label = status.trim();
 	if (!label) return;
-	const chip = parent.createDiv({ cls: "hearth-task-status hearth-task-statuschip", text: label });
+	const chip = row.createDiv({ cls: "hearth-task-status hearth-task-statuschip", text: label });
 	chip.setAttribute("title", `Status: ${label}`);
+	// Marks the row so the title stops growing to fill it, letting the chip sit
+	// against the title. Set here rather than matched with :has(), which is
+	// avoided in this stylesheet for its broad selector-invalidation cost.
+	row.addClass("has-statuschip");
 }
 
 
@@ -1159,14 +1166,14 @@ function renderTaskRow(
 
 	const label = row.createDiv({ cls: "hearth-list-label hearth-task-text" });
 	fillTaskText(view, label, hit.text || hit.file.basename, hit.file.path);
+	// TaskNotes tasks: the status is free-form (open / in-progress / waiting /
+	// …) and the checkbox can't express it, so show it right after the title.
+	if (hit.status) renderTaskStatus(row, hit.status);
 	// Kanban cards show the board column they belong to as a small badge.
 	if (hit.boardColumn) row.createDiv({ cls: "hearth-task-status hearth-task-column", text: hit.boardColumn });
 	// The list has room for a labelled priority chip (a bare dot is easy to
 	// miss); board cards stay dot-only for compactness.
 	if (hit.priority) renderPriority(row, hit.priority);
-	// TaskNotes tasks: the status is free-form (open / in-progress / waiting /
-	// …) and the checkbox can't express it, so show it next to the priority.
-	if (hit.status) renderTaskStatus(row, hit.status);
 	renderTaskDateChips(row, hit, today);
 	if (hit.description) renderTaskDescription(row, hit.description);
 

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -301,6 +301,17 @@ function renderPriority(parent: HTMLElement, priority: string, dotOnly = false):
 }
 
 
+/** A small pill showing a TaskNotes task's raw status value. The list layout's
+ * completion checkbox only says done/not-done, so the actual status (open,
+ * in-progress, waiting, …) needs a chip of its own beside the priority. */
+function renderTaskStatus(parent: HTMLElement, status: string): void {
+	const label = status.trim();
+	if (!label) return;
+	const chip = parent.createDiv({ cls: "hearth-task-status hearth-task-statuschip", text: label });
+	chip.setAttribute("title", `Status: ${label}`);
+}
+
+
 /** Render a task's date indicators into `parent`: start (🛫), scheduled (⏳),
  * the due/next-occurrence label, and the done date (✅). Start/scheduled/done
  * chips are shown only for Kanban cards (the source that parses them); the due
@@ -1153,6 +1164,9 @@ function renderTaskRow(
 	// The list has room for a labelled priority chip (a bare dot is easy to
 	// miss); board cards stay dot-only for compactness.
 	if (hit.priority) renderPriority(row, hit.priority);
+	// TaskNotes tasks: the status is free-form (open / in-progress / waiting /
+	// …) and the checkbox can't express it, so show it next to the priority.
+	if (hit.status) renderTaskStatus(row, hit.status);
 	renderTaskDateChips(row, hit, today);
 	if (hit.description) renderTaskDescription(row, hit.description);
 

--- a/styles.css
+++ b/styles.css
@@ -2319,15 +2319,11 @@
 	color: var(--text-normal);
 }
 
+/* Today in the agenda is marked lightly: the day number takes the accent
+   colour, with no filled pill behind it, so the row reads as part of the list
+   instead of a block of colour (the row border below carries the rest). */
 .hearth-agenda-row.is-today .hearth-agenda-daynum {
 	color: var(--interactive-accent);
-	background: color-mix(in srgb, var(--interactive-accent) 16%, transparent);
-	border-radius: 999px;
-	width: 24px;
-	height: 24px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
 	font-weight: 700;
 }
 
@@ -2362,7 +2358,7 @@
 }
 
 .hearth-agenda-row.is-today {
-	outline: 1px solid color-mix(in srgb, var(--interactive-accent) 45%, transparent);
+	outline: 1px solid color-mix(in srgb, var(--interactive-accent) 30%, transparent);
 	outline-offset: -1px;
 }
 
@@ -3406,6 +3402,18 @@
 .hearth-task-column {
 	background: var(--background-modifier-hover);
 	color: var(--text-muted);
+}
+
+/* The TaskNotes status chip in the list layout, sitting beside the priority
+   chip. Raw frontmatter values are usually lowercase ("open", "in-progress"),
+   so capitalize them to read like the priority label next to it. */
+.hearth-task-statuschip {
+	text-transform: capitalize;
+}
+
+/* A completed task's status chip recedes with the rest of the row. */
+.hearth-task.is-done .hearth-task-statuschip {
+	color: var(--text-faint);
 }
 
 /* "Add card" control at the bottom of a Kanban column (Kanban source). */

--- a/styles.css
+++ b/styles.css
@@ -2319,11 +2319,15 @@
 	color: var(--text-normal);
 }
 
-/* Today in the agenda is marked lightly: the day number takes the accent
-   colour, with no filled pill behind it, so the row reads as part of the list
-   instead of a block of colour (the row border below carries the rest). */
 .hearth-agenda-row.is-today .hearth-agenda-daynum {
 	color: var(--interactive-accent);
+	background: color-mix(in srgb, var(--interactive-accent) 16%, transparent);
+	border-radius: 999px;
+	width: 24px;
+	height: 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	font-weight: 700;
 }
 
@@ -2358,7 +2362,7 @@
 }
 
 .hearth-agenda-row.is-today {
-	outline: 1px solid color-mix(in srgb, var(--interactive-accent) 30%, transparent);
+	outline: 1px solid color-mix(in srgb, var(--interactive-accent) 45%, transparent);
 	outline-offset: -1px;
 }
 
@@ -3327,12 +3331,22 @@
 	align-items: flex-start;
 }
 
+/* Columns read as tinted lanes, not opaque plates. The list layout draws no
+ * surface of its own, so the card's translucency and frost show through it; a
+ * solid --background-secondary column covered all of that and made a Kanban
+ * card look like a slab next to an otherwise see-through board. The lane tint
+ * is therefore both weakened and scaled by the board's --card-opacity, so it
+ * fades in step with the card surface it sits on. */
 .hearth-kanban-col {
 	flex: 1 0 140px;
 	min-width: 130px;
 	display: flex;
 	flex-direction: column;
-	background: var(--background-secondary);
+	background: color-mix(
+		in srgb,
+		var(--background-secondary) calc(var(--card-opacity, 1) * 40%),
+		transparent
+	);
 	border-radius: 8px;
 	max-height: 100%;
 }
@@ -3368,8 +3382,15 @@
 	border-radius: 6px;
 }
 
+/* Cards on the lane: a translucent fill (scaled by --card-opacity for the same
+ * reason as the column) with the hairline border doing the work of defining the
+ * card, rather than an opaque --background-primary tile. */
 .hearth-kanban-card {
-	background: var(--background-primary);
+	background: color-mix(
+		in srgb,
+		var(--background-primary) calc(var(--card-opacity, 1) * 55%),
+		transparent
+	);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 6px;
 	padding: 6px 8px;
@@ -3404,11 +3425,25 @@
 	color: var(--text-muted);
 }
 
-/* The TaskNotes status chip in the list layout, sitting beside the priority
-   chip. Raw frontmatter values are usually lowercase ("open", "in-progress"),
-   so capitalize them to read like the priority label next to it. */
+/* The TaskNotes status chip in the list layout. Raw frontmatter values are
+   usually lowercase ("open", "in-progress"), so capitalize them to read like a
+   label rather than a field value. */
 .hearth-task-statuschip {
 	text-transform: capitalize;
+}
+
+/* The chip is left-aligned against the task title instead of drifting into the
+   right-hand chip cluster: the title stops filling the row, and the chip's auto
+   right margin pushes the priority and date chips to the far edge. The marker
+   class is set in renderTaskStatus() rather than matched with :has(), which is
+   avoided here for its broad selector-invalidation cost. */
+.hearth-task.has-statuschip .hearth-task-text {
+	flex: 0 1 auto;
+	min-width: 0;
+}
+
+.hearth-task.has-statuschip .hearth-task-statuschip {
+	margin-right: auto;
 }
 
 /* A completed task's status chip recedes with the rest of the row. */


### PR DESCRIPTION
## What does this PR do?

Two changes, both on the Tasks card.

**TaskNotes list layout shows the current status.** Replacing the status badge
with a completion checkbox (#111) left the list with no way to see a task's
actual status: the checkbox only says done or not-done, while the TaskNotes
status is free-form (`open`, `in-progress`, `waiting`, whatever the vault uses).
Each TaskNotes task now renders a small status pill directly after its title and
left-aligned against it — on a row that has a chip the title stops filling the
row and the chip takes `margin-right: auto`, so the priority and date chips still
hold the right edge. Rows with no status are untouched. The pill reuses the
existing `.hearth-task-status` styling that the Kanban column badge already uses,
capitalizes the raw frontmatter value for reading, keeps the verbatim value in
the tooltip, and fades with a completed row. Only TaskNotes hits carry a
`status`, so checkbox- and Kanban-source rows are unaffected.

The marker class is set in `renderTaskStatus()` rather than matched with
`:has()`, following this stylesheet's existing avoidance of it on
selector-invalidation grounds.

**Kanban boards are as translucent as task lists.** A list draws no surface of
its own, so a translucent or frosted card shows straight through it — but a
Kanban board covered that same card with an opaque `--background-secondary`
column plate and opaque `--background-primary` cards, reading as a solid slab on
an otherwise see-through board. Columns are now a 40% tint and cards a 55% fill,
both multiplied by `--card-opacity` so they fade in step with the card surface
they sit on, with the existing hairline border defining the card edge. Layout,
spacing, drag-and-drop, drop-target outlines, the done-column accent header and
the add-card control are unchanged — this is surface colour only.

Note that this also lightens fully opaque boards slightly, since the tints are
below 100% at `--card-opacity: 1`. That's deliberate — it's what makes a board
match the list's weight — but it is a visible change for opaque boards.

An earlier revision of this branch also softened the calendar agenda's
today-highlight; that has been reverted and the agenda is untouched.

## Related issue

None — UI follow-ups to the visuals introduced in #111.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (`npm run typecheck`, `npm run lint` — 0
      errors, only pre-existing warnings — and `npm test` — 169 passed, 1
      skipped — all pass too)
- [ ] I've tested this in an actual vault — not possible from this environment;
      the changes are CSS plus one render call and a marker class, so please
      spot-check on a real board

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mWauRwm3WcpRdu2RuMefw