### PR TITLE
chore: cut 1.17.0-beta.2

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "1.17.0-beta.1",
+	"version": "1.17.0-beta.2",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
## What does this PR do?

Bumps `manifest-beta.json` from `1.17.0-beta.1` to `1.17.0-beta.2`, landing the
beta-cut commit on `main` so the open beta line on the default branch matches the
published pre-release.

The [`1.17.0-beta.2`](https://github.com/ondreu/Hearth/releases/tag/1.17.0-beta.2)
pre-release is already out (tag points at `6772f14`, which is `main` + this
manifest bump). Over `beta.1` the snapshot carries the Tasks card status chip and
Kanban translucency (#135) and the `default-bg` asset rename (#133, #134).

`manifest.json` is untouched at stable `1.16.0`; `node scripts/verify-manifests.mjs`
passes on this branch.

## Related issue

n/a — release chore.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

Release chore — none of the above; no `src/`, `styles.css` or build-config changes.

## Checklist

- [x] `npm run build` passes locally — the release workflow built this exact commit successfully
- [x] I've tested this in an actual vault — n/a for a version-only manifest bump; the built artifacts are attached to the pre-release for BRAT testing

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrhrnroXYnSs1LLPbbJAxd)_