### PR TITLE
chore: clear the lint warnings that are safe to clear

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,31 @@ export default tseslint.config(
 			// Vyžaduje Obsidian API 1.13.0+; minAppVersion je 1.8.7.
 			// Zapnout zpět, až se minAppVersion zvedne.
 			"obsidianmd/settings-tab/prefer-setting-definitions": "off",
+			// Sentence case is for prose. Some UI strings are literal property
+			// keys instead — e.g. the `event_uid` placeholder in the calendar
+			// event-note settings, which is the actual frontmatter key written
+			// by eventnote.ts. Sentence-casing those to `Event_uid` would show
+			// users a key that does not match the one the plugin writes, so
+			// exempt snake_case identifiers. `enforceCamelCaseLower` is
+			// repeated from the preset because options replace, not merge.
+			"obsidianmd/ui/sentence-case": [
+				"warn",
+				{
+					enforceCamelCaseLower: true,
+					ignoreRegex: ["^[a-z0-9]+(?:_[a-z0-9]+)+$"],
+				},
+			],
+		},
+	},
+	// The test suite is not part of the shipped plugin bundle, so the rules
+	// about what a plugin may import do not apply to it. In particular,
+	// test/support/obsidian-shim.ts is what *provides* the `moment` export that
+	// the "import moment from 'obsidian' instead" rule points at — following
+	// that advice here would be circular, and the shim documents the choice.
+	{
+		files: ["test/**"],
+		rules: {
+			"@typescript-eslint/no-restricted-imports": "off",
 		},
 	},
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
 	"name": "hearth",
-	"version": "1.15.0",
+	"version": "1.17.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hearth",
-			"version": "1.15.0",
+			"version": "1.17.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^20.11.0",
 				"esbuild": "^0.28.1",
 				"eslint": "^9.39.5",
 				"eslint-plugin-obsidianmd": "^0.4.1",
+				"moment": "2.29.4",
 				"obsidian": "latest",
 				"tslib": "^2.6.2",
 				"typescript": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"esbuild": "^0.28.1",
 		"eslint": "^9.39.5",
 		"eslint-plugin-obsidianmd": "^0.4.1",
+		"moment": "2.29.4",
 		"obsidian": "latest",
 		"tslib": "^2.6.2",
 		"typescript": "^5.4.0",


### PR DESCRIPTION
## What does this PR do?

`npm run lint` reported **31 warnings** (0 errors). Four had real fixes; the other 27 are load-bearing and are left in place deliberately. Now at **27 warnings, all `no-deprecated`**.

**Fixed:**

- **Declare `moment` as a devDependency.** The test suite imports it directly (`test/ics.test.ts`, `test/support/obsidian-shim.ts`) but it only resolved transitively through `obsidian`, so the version was whatever that dependency happened to pin. Pinned exactly to `2.29.4` — the version `obsidian` already resolves — so nothing changes at runtime.
- **Turn off `@typescript-eslint/no-restricted-imports` for `test/**`.** The rule says to import `moment` from `obsidian` instead, but `obsidian-shim.ts` is what *provides* that export — following the advice there is circular, and the shim already documents the choice. Test code isn't part of the shipped bundle, so import rules aimed at plugin source don't apply.
- **Exempt snake_case identifiers from `obsidianmd/ui/sentence-case`.** The `event_uid` placeholder in the calendar event-note settings is the literal frontmatter key `eventnote.ts` writes (`frontmatter[linkKey] = ev.uid`). The rule's suggested `Event_uid` would have shown users a key the plugin never writes — so this one was a lint autofix waiting to become a bug. `enforceCamelCaseLower` is restated because rule options replace rather than merge.

**Left alone (the remaining 27 `no-deprecated` warnings):**

- `setDynamicTooltip()` (22 call sites) and `setWarning()` (`ui.ts`). Their replacements — the always-inline slider value, and `setDestructive()` — are both `@since 1.13.0`, while `minAppVersion` is **1.8.7**. Removing the calls would silently drop the slider tooltip, and swapping in `setDestructive()` would throw, for anyone below 1.13.0. This is the same reasoning as the existing `prefer-setting-definitions` exception in `eslint.config.mjs`, and `ui.ts` already carries a comment saying so.
- Reads of our own deprecated `use24Hour` and `commandId` fields. These are the settings-migration fallbacks, and `mobileactions.ts` explicitly states the warning is the intentional marker for them, to be removed together with the fields.

No `eslint-disable` comments were added — the repo has none, and `mobileactions.ts` records that silencing `no-deprecated` isn't wanted. Both fixes are scoped in config rather than suppressed at the call site.

## Related issue

None — lint-only cleanup, no behaviour change.

## Type of change

- [x] 📝 Docs / chore (tooling config + dependency declaration; no runtime code touched)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault — n/a, no runtime code changed; verified via `npm run typecheck`, `npm test` (169 passed, 1 skipped), `npm run build`, and `npm run verify:manifests`, all passing

---
_Generated by [Claude Code](https://claude.ai/code/session_017wn6yTxCskhG8WhyBEQtwj)_