### PR TITLE
perf(search): set the filter chip count from JS instead of :has()

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -184,6 +184,11 @@ export class SearchSection {
 		if (groups.length === 0) return;
 
 		const row = parent.createDiv("hearth-filters");
+		// The column-gap splits the row's leftover space between the chips, so
+		// the stylesheet needs the chip count. We know it exactly here, so set
+		// it directly: deriving it in CSS took a ladder of :has() rules, which
+		// carries a broad selector-invalidation cost and capped out at 14 chips.
+		row.style.setProperty("--n", String(groups.length));
 		for (const group of groups) {
 			const chip = row.createDiv("hearth-filter");
 			chip.toggleClass("is-active", this.activeFilter === group.id);

--- a/styles.css
+++ b/styles.css
@@ -350,11 +350,14 @@
  * function, so capping a track at 48px of slack also makes it wrap as soon as
  * 48px doesn't fit, far too early.
  *
- * So the count comes from :has() instead. --n resolves to the number of chips
- * (each rule below overrides the last, so the highest match wins) and the gap
- * is the exact leftover split between them, clamped to the 8-48px range. When
- * the clamp bottoms out at 8px the row no longer fits and flex wraps, which is
- * precisely the intended wrap point. */
+ * So the count comes from --n, which renderFilters() sets to the number of
+ * chips as it builds the row. The gap is the exact leftover split between
+ * them, clamped to the 8-48px range. When the clamp bottoms out at 8px the row
+ * no longer fits and flex wraps, which is precisely the intended wrap point.
+ *
+ * --n was previously derived here with a ladder of :has(.hearth-filter:
+ * nth-child(n)) rules. That is avoided for its broad selector-invalidation
+ * cost, and it also silently capped the count at 14 chips. */
 .hearth-filters {
 	display: flex;
 	flex-wrap: wrap;
@@ -367,20 +370,6 @@
 	row-gap: 8px;
 	width: 100%;
 }
-
-.hearth-filters:has(.hearth-filter:nth-child(2)) { --n: 2; }
-.hearth-filters:has(.hearth-filter:nth-child(3)) { --n: 3; }
-.hearth-filters:has(.hearth-filter:nth-child(4)) { --n: 4; }
-.hearth-filters:has(.hearth-filter:nth-child(5)) { --n: 5; }
-.hearth-filters:has(.hearth-filter:nth-child(6)) { --n: 6; }
-.hearth-filters:has(.hearth-filter:nth-child(7)) { --n: 7; }
-.hearth-filters:has(.hearth-filter:nth-child(8)) { --n: 8; }
-.hearth-filters:has(.hearth-filter:nth-child(9)) { --n: 9; }
-.hearth-filters:has(.hearth-filter:nth-child(10)) { --n: 10; }
-.hearth-filters:has(.hearth-filter:nth-child(11)) { --n: 11; }
-.hearth-filters:has(.hearth-filter:nth-child(12)) { --n: 12; }
-.hearth-filters:has(.hearth-filter:nth-child(13)) { --n: 13; }
-.hearth-filters:has(.hearth-filter:nth-child(14)) { --n: 14; }
 
 .hearth-filter {
 	display: flex;


### PR DESCRIPTION
## What does this PR do?

Removes all 13 `:has()` selectors from `styles.css` (the plugin-review warning: *"Avoid :has — it can cause significant performance issues due to broad selector invalidation"*, `styles.css:371–383`).

The filter row's `column-gap` divides the row's leftover space between the chips, so the stylesheet needs to know how many there are. That count was derived with a ladder of 13 rules:

```css
.hearth-filters:has(.hearth-filter:nth-child(2))  { --n: 2; }
…
.hearth-filters:has(.hearth-filter:nth-child(14)) { --n: 14; }
```

The whole ladder turned out to be avoidable: `renderFilters()` already knows `groups.length` at the moment it builds the row, so it now sets `--n` directly and the CSS rules are deleted.

**This also fixes a latent bug.** The ladder stopped at 14, so a 15th chip left `--n` pinned at 14 and the gap was computed against the wrong count. Reading the length has no such ceiling.

The `--n: 1` default stays as the fallback and the gap math is unchanged, so the layout behaviour is identical for every chip count the old ladder actually covered.

`styles.css` already documented this exact tradeoff for the task status chip — the marker class is set in `renderTaskStatus()` "rather than matched with `:has()`, which is avoided here for its broad selector-invalidation cost." This brings the filter row in line with that. Setting a dynamic custom property from JS is likewise the existing pattern (`cards/heatmap.ts`, `cards/links.ts`); it is a computed value, so it does not trip `obsidianmd/no-static-styles-assignment`.

`grep ":has(" styles.css` now matches only two comment lines, no selectors.

## Related issue

None — follows on from #140, which merged before this commit was pushed.

## Type of change

- [x] 🐛 Bug fix (off-by-one above 14 chips, plus the flagged `:has()` performance warning)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault — **not verified in a vault**; please sanity-check the filter row spacing. Verified via `npm run typecheck`, `npm test` (169 passed, 1 skipped), `npm run build`, and `npm run lint` (27 warnings, unchanged from main).

---
_Generated by [Claude Code](https://claude.ai/code/session_017wn6yTxCskhG8WhyBEQtwj)_