### PR TITLE
fix(styles): hold our focus suppression against theme focus rings (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ preceding beta series.
 History begins at 1.5.0. For releases before 1.5.0, see the
 [GitHub Releases](https://github.com/ondreu/Hearth/releases) page.
 
+## [1.18.0]
+
+### Fixed
+
+- **Theme focus rings no longer break the search bar.** Under Catppuccin (and
+  any theme that styles input focus with a body-class-prefixed selector), the
+  home-screen search input picked up the theme's own focus ring, so a blue
+  outline hugged the text field instead of the search bar lighting up as a
+  whole. Those themes' selectors outrank the plain class selectors Hearth used
+  to suppress the ring. The controls that draw their own focus affordance — the
+  search input, the jot/embed editors, the calculator, the card-title field and
+  the task-detail title editor — now hold that suppression against any theme.
+  Inputs with an ordinary border, such as the Kanban editors and the task-detail
+  description field, keep the theme's ring, since for them it is the focus
+  affordance (#138).
+
 ## [1.17.0]
 
 ### Added

--- a/styles.css
+++ b/styles.css
@@ -4589,3 +4589,43 @@ body.hearth-dv-resizing {
 		max-width: none;
 	}
 }
+
+/* ---- Theme focus-ring guard ------------------------------------------
+   Some themes restyle input focus with a body-class-prefixed selector.
+   Catppuccin, for one, ships
+
+     .theme-dark:not(.css-settings-manager) input[type=text]:focus-visible {
+       box-shadow: 0 0 0 2px rgb(var(--ctp-blue), 70%);
+     }
+
+   at specificity (0,4,1), which outranks the plain class selectors used
+   above — the search input's `.hearth-view .hearth-search-bar
+   .hearth-search-input` is only (0,3,0). The theme's ring then lands on the
+   controls that deliberately suppress it: the search bar draws its focus
+   state on the bar via :focus-within, and the inline editors highlight their
+   own border. The visible result is a ring hugging the input instead of the
+   affordance the control was built with (#138).
+
+   Out-specifying that per control would mean leaning on each one's ancestors
+   — awkward, since the task-detail editor lives in a modal rather than in
+   .hearth-view — and would still only hold against this one theme's exact
+   selector. !important states the rule these controls actually follow: they
+   own their focus affordance, whatever a theme writes.
+
+   Deliberately limited to the controls that already set `outline: none`.
+   Inputs drawn with an ordinary border (the Kanban editors, the task-detail
+   description and interval fields, the Jira filter search) keep the theme's
+   focus ring, because for them it is the affordance. */
+.hearth-search-input:focus,
+.hearth-search-input:focus-visible,
+.hearth-text:focus,
+.hearth-text:focus-visible,
+.hearth-calc-input:focus,
+.hearth-calc-input:focus-visible,
+.hearth-card-title-input:focus,
+.hearth-card-title-input:focus-visible,
+.hearth-taskdetail-title-edit:focus,
+.hearth-taskdetail-title-edit:focus-visible {
+	outline: none !important;
+	box-shadow: none !important;
+}


### PR DESCRIPTION
## What does this PR do?

Under Catppuccin, focusing the home-screen search input draws a blue ring around the text field instead of letting the bar light up as a whole.

The cause is CSS specificity, not a script bug. Catppuccin ships this in `theme.css`:

```css
.theme-dark:not(.css-settings-manager) input[type=text]:focus-visible {
  box-shadow: 0 0 0 2px rgb(var(--ctp-blue), 70%);
}
```

at specificity **(0,4,1)**. The rule suppressing the ring is `.hearth-view .hearth-search-bar .hearth-search-input { box-shadow: none }` at **(0,3,0)** — and its comment says the `.hearth-view` prefix exists to win over Obsidian's defaults without `!important`, which it does against core's `input[type=text]:focus-visible` at (0,2,0). A theme that prefixes the same selector with a body class outranks it. Catppuccin also ships an unprefixed copy at (0,2,0) which loses, so the prefixed one is the one that bites.

Two details worth noting against the issue text: the ring is a **`box-shadow`**, not the native outline — `outline: none` was already holding — so only the `box-shadow` line of the reported workaround was doing any work.

The search bar is just where it's most visible. Every control that suppresses its own ring loses the same way. Verified in Chromium against the real `theme.css`: before this change, all of search, calculator, jot/embed, card title and task-detail title take the ring; after, none do, while the deliberately-bordered controls keep theirs.

**On the `!important`:** out-specifying per control would mean leaning on each one's ancestors, and the task-detail title editor lives in a modal rather than under `.hearth-view`, so there's no shared prefix available. It would also only hold against this one theme's exact selector. `!important` states the rule these controls actually follow — they own their focus affordance, whatever a theme writes.

**Scope is deliberately narrow.** Only controls that already set `outline: none` *and* provide their own affordance are covered: the bar's `:focus-within` state, and the accent border on the calculator, card-title and task-detail-title fields. Inputs drawn with an ordinary border — the Kanban editors, the task-detail description and interval fields, the Jira filter search — keep the theme's ring, since for them it *is* the focus affordance and removing it would cost keyboard users a cue with nothing put back.

Changes are `styles.css` (one commented guard block appended) and a `CHANGELOG.md` entry under `## [1.18.0]`, the current beta line.

## Related issue

Closes #138

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault

On that last box — I don't have Obsidian here, so instead of a vault check I verified the cascade in headless Chromium, loading the repo's `styles.css` alongside the actual rule fetched from `catppuccin/obsidian@main`, and read back `getComputedStyle().boxShadow` on each control at `:focus-visible`. That confirms the specificity analysis and the before/after in both directions, but it does **not** cover how this looks in a real vault, so a visual pass under Catppuccin before merge is worth doing.

`npm run lint` (0 errors, 27 pre-existing deprecation warnings), `npm test` (169 passed) and `npm run verify:manifests` are also clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Pn4cSMVvJdcj39WNnAjfW)_