### PR TITLE
fix(cards): write checkbox ticks back to their source (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **Checkboxes now stay checked.** Ticking a task in an embedded note, a daily
+  note or a jot card looked like it worked and was lost on the next render:
+  Obsidian only writes a checkbox click back to the file inside a real preview
+  view, and the boxes Hearth renders into a card were live but inert. They now
+  edit their source — the note for embed and daily cards, the card's own text
+  for jots — so the state sticks, whether or not the card is set to editable.
+  A tick is reverted if the write can't land, and a click on a checkbox no
+  longer opens the raw editor when it lands as part of a double-click (#143).
 - **Theme focus rings no longer break the search bar.** Under Catppuccin (and
   any theme that styles input focus with a body-class-prefixed selector), the
   home-screen search input picked up the theme's own focus ring, so a blue

--- a/src/cardbodies.ts
+++ b/src/cardbodies.ts
@@ -1,4 +1,5 @@
 import { Component, debounce, MarkdownRenderer, moment as createMoment, setIcon, TFile } from "obsidian";
+import { type CheckboxScanOptions, countCheckboxes, toggleCheckboxAt } from "./checkboxes";
 import { localDayKey } from "./dates";
 import { t } from "./i18n";
 import { type DashboardCard, type EmbedView } from "./types";
@@ -146,6 +147,96 @@ export function wireMarkdownLinks(view: HomeView, host: HTMLElement, sourcePath:
 }
 
 
+/** The task checkboxes a rendered host owns, in document order. Checkboxes
+ * inside a transclusion belong to another file, so they're left out: they would
+ * shift the ordinals the source mapping counts on (and clicking one should edit
+ * that other note, which this wiring can't do). */
+function checkboxInputs(host: HTMLElement): HTMLInputElement[] {
+	const all = host.querySelectorAll<HTMLInputElement>(
+		"input.task-list-item-checkbox, li.task-list-item > input[type='checkbox']",
+	);
+	return Array.from(all).filter((el) => !el.closest(".internal-embed, .markdown-embed"));
+}
+
+
+/**
+ * Make task checkboxes inside rendered Markdown write back to their source
+ * (issue #143). Obsidian only persists a checkbox click inside a real preview
+ * view; the inputs `MarkdownRenderer.render` emits into a custom container are
+ * live but inert, so a tick looked like it stuck and was lost on the next
+ * render. Like `wireMarkdownLinks`, this delegates from the stable host so it
+ * keeps working as the content node is re-rendered underneath it.
+ *
+ * `process` applies an edit to the source text (a vault read-modify-write for
+ * note-backed cards). The click is reverted in the DOM when the edit doesn't
+ * land, so the checkbox never shows a state the source doesn't have.
+ */
+export function wireMarkdownCheckboxes(
+	host: HTMLElement,
+	process: (fn: (data: string) => string) => Promise<unknown>,
+	opts: CheckboxScanOptions = {},
+): void {
+	const isCheckbox = (evt: Event): HTMLInputElement | null => {
+		const target = evt.target;
+		if (!(target instanceof HTMLInputElement) || target.type !== "checkbox") return null;
+		return target;
+	};
+
+	// A card whose preview opens a raw editor on double-click shouldn't do that
+	// when the user ticks two boxes quickly. Registered before that handler, so
+	// stopping the event here keeps it from running.
+	host.addEventListener("dblclick", (evt) => {
+		if (isCheckbox(evt)) evt.stopImmediatePropagation();
+	});
+
+	host.addEventListener("click", (evt) => {
+		const input = isCheckbox(evt);
+		if (!input) return;
+		const inputs = checkboxInputs(host);
+		const ordinal = inputs.indexOf(input);
+		if (ordinal < 0) return;
+		// The browser has already flipped the input; that's the state to write.
+		const checked = input.checked;
+		const count = inputs.length;
+		evt.stopPropagation();
+		const revert = () => {
+			if (input.isConnected) input.checked = !checked;
+		};
+		let applied = false;
+		void process((data) => {
+			// The render we counted no longer matches the source (an edit landed
+			// in between, or the note renders checkboxes we can't account for) —
+			// writing by ordinal could tick the wrong line, so write nothing.
+			if (countCheckboxes(data, opts) !== count) return data;
+			const next = toggleCheckboxAt(data, ordinal, checked, opts);
+			if (next === null) return data;
+			applied = true;
+			return next;
+		})
+			.then(() => {
+				if (!applied) revert();
+			})
+			.catch(() => {
+				revert();
+			});
+	});
+}
+
+
+/** Apply an edit to a note, atomically re-reading it first so a checkbox click
+ * can't clobber a concurrent edit. */
+function processFile(
+	view: HomeView,
+	file: TFile,
+): (fn: (data: string) => string) => Promise<unknown> {
+	return (fn) => {
+		const current = view.app.vault.getAbstractFileByPath(file.path);
+		if (!(current instanceof TFile)) return Promise.reject(new Error(`Missing: ${file.path}`));
+		return view.app.vault.process(current, fn);
+	};
+}
+
+
 /** Render a Markdown file's real content (not a transclusion placeholder). */
 export async function renderMarkdownFile(
 	view: HomeView,
@@ -156,6 +247,7 @@ export async function renderMarkdownFile(
 	const raw = await view.app.vault.cachedRead(file);
 	await MarkdownRenderer.render(view.app, stripFrontmatter(raw), host, file.path, component);
 	wireMarkdownLinks(view, host, file.path);
+	wireMarkdownCheckboxes(host, processFile(view, file));
 }
 
 
@@ -176,6 +268,9 @@ export function renderEditableEmbed(
 	const preview = wrap.createDiv("hearth-embed markdown-rendered hearth-jot-preview");
 	preview.setAttribute("title", t().cards.embed.editHint);
 	wireMarkdownLinks(view, preview, file.path);
+	// Registered before the dblclick-to-edit handler below, so ticking two boxes
+	// in quick succession doesn't drop the card into the raw editor.
+	wireMarkdownCheckboxes(preview, processFile(view, file));
 	const area = wrap.createEl("textarea", {
 		cls: "hearth-text hearth-embed-edit hearth-jot-edit",
 		attr: { placeholder: t().cards.embed.emptyNotePlaceholder },

--- a/src/cards/text.ts
+++ b/src/cards/text.ts
@@ -1,5 +1,5 @@
 import { Component, debounce, MarkdownRenderer } from "obsidian";
-import { wireMarkdownLinks } from "../cardbodies";
+import { wireMarkdownCheckboxes, wireMarkdownLinks } from "../cardbodies";
 import { t } from "../i18n";
 import { type DashboardCard } from "../types";
 import { type HomeView } from "../view";
@@ -19,6 +19,22 @@ export function renderText(
 	const preview = wrap.createDiv("hearth-jot-preview markdown-rendered");
 	preview.setAttribute("title", t().cards.embed.editHint);
 	wireMarkdownLinks(view, preview, "");
+	// Ticking a checkbox edits the card's own text (issue #143). The jot isn't a
+	// note, so its leading `---` is content, not frontmatter. Registered before
+	// the dblclick-to-edit handler below so a quick double-tick doesn't open the
+	// raw editor.
+	wireMarkdownCheckboxes(
+		preview,
+		(fn) => {
+			const next = fn(card.text ?? "");
+			if (next !== (card.text ?? "")) {
+				card.text = next;
+				void view.plugin.saveData(view.plugin.settings);
+			}
+			return Promise.resolve();
+		},
+		{ skipFrontmatter: false },
+	);
 	const area = wrap.createEl("textarea", {
 		cls: "hearth-text hearth-jot-edit",
 		attr: { placeholder: t().cards.text.placeholder },

--- a/src/checkboxes.ts
+++ b/src/checkboxes.ts
@@ -1,0 +1,117 @@
+/**
+ * Toggling Markdown task checkboxes from rendered output (issue #143).
+ *
+ * `MarkdownRenderer.render` emits reading-view markup, checkbox `<input>`s
+ * included, but it isn't backed by a preview view — so nothing writes a click
+ * back to the note and the tick vanishes on the next render. The DOM half of
+ * the fix lives in `cardbodies.ts`; this module is the pure half: find the
+ * checkbox lines in a Markdown source and rewrite one of them.
+ *
+ * The rendered `<input>`s carry no line information (there's no
+ * `MarkdownPostProcessorContext` for a standalone render, so `getSectionInfo`
+ * isn't available), so the mapping is by ordinal: the Nth checkbox in the
+ * output is the Nth checkbox line in the source. The caller compares
+ * `countCheckboxes` against the number of inputs it found and does nothing when
+ * they disagree, which keeps a desync from writing to the wrong line.
+ */
+
+/** A list item that is a task: `- [ ] text`, `1. [x] text`, `> - [ ] text`.
+ * The status character is captured; a space means open, anything else done-ish.
+ * `]` must be followed by whitespace or end of line, matching Obsidian. */
+const CHECKBOX_RE = /^([\s>]*(?:[-*+]|\d+[.)])\s+\[)(.)(\](?=\s|$))/;
+
+/** Opening/closing fence of a code block, with the indent and fence captured. */
+const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})/;
+
+/** A leading YAML frontmatter block. */
+const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+
+
+export interface CheckboxScanOptions {
+	/** Skip a leading YAML frontmatter block, matching what the card renders.
+	 * Defaults to true; the text card (whose content is a jotted snippet, not a
+	 * note) passes false. */
+	skipFrontmatter?: boolean;
+}
+
+
+/** How many lines a leading frontmatter block occupies (0 when there is none). */
+function frontmatterLines(text: string): number {
+	const match = FRONTMATTER_RE.exec(text);
+	if (!match) return 0;
+	// The block's own trailing newline ends its last line; count the breaks.
+	return match[0].split("\n").length - 1;
+}
+
+
+/**
+ * The line indices of every task checkbox in `text`, in document order — the
+ * same order the renderer emits the inputs in. Lines inside fenced code blocks
+ * are skipped: they render as text, not as checkboxes, so counting them would
+ * shift every ordinal after them.
+ */
+export function checkboxLines(text: string, opts: CheckboxScanOptions = {}): number[] {
+	const lines = text.split("\n");
+	const start = opts.skipFrontmatter === false ? 0 : frontmatterLines(text);
+	const found: number[] = [];
+	let fence: string | null = null;
+	for (let i = start; i < lines.length; i++) {
+		const line = lines[i];
+		const fenceMatch = FENCE_RE.exec(line);
+		if (fenceMatch) {
+			// A fence closes only on the same character, and only when at least
+			// as long as the one that opened the block.
+			if (fence === null) fence = fenceMatch[1];
+			else if (fenceMatch[1][0] === fence[0] && fenceMatch[1].length >= fence.length)
+				fence = null;
+			continue;
+		}
+		if (fence !== null) continue;
+		if (CHECKBOX_RE.test(line)) found.push(i);
+	}
+	return found;
+}
+
+
+/** How many task checkboxes `text` renders. */
+export function countCheckboxes(text: string, opts: CheckboxScanOptions = {}): number {
+	return checkboxLines(text, opts).length;
+}
+
+
+/** Rewrite one checkbox line's status character. Returns the line unchanged
+ * when it is already in the wanted state, or null when it isn't a checkbox. */
+export function toggleCheckboxLine(line: string, checked: boolean): string | null {
+	const match = CHECKBOX_RE.exec(line);
+	if (!match) return null;
+	const status = checked ? "x" : " ";
+	// A custom status (`[/]`, `[-]`, …) renders as a ticked box, so "check it"
+	// is already true of it — leave the symbol alone rather than flattening it
+	// to `x`. Unchecking one resets it to open, the only other state the
+	// rendered input can express.
+	if (match[2] === status || (checked && match[2] !== " ")) return line;
+	return line.replace(CHECKBOX_RE, `$1${status}$3`);
+}
+
+
+/**
+ * Set the `ordinal`-th checkbox (0-based, document order) in `text` to
+ * `checked`. Returns the new text, or null when the ordinal is out of range or
+ * the line turns out not to be a checkbox — the caller treats null as "don't
+ * write", leaving the note untouched.
+ */
+export function toggleCheckboxAt(
+	text: string,
+	ordinal: number,
+	checked: boolean,
+	opts: CheckboxScanOptions = {},
+): string | null {
+	const indices = checkboxLines(text, opts);
+	const lineIndex = indices[ordinal];
+	if (lineIndex === undefined) return null;
+	const lines = text.split("\n");
+	const next = toggleCheckboxLine(lines[lineIndex], checked);
+	if (next === null) return null;
+	lines[lineIndex] = next;
+	return lines.join("\n");
+}

--- a/test/checkboxes.test.ts
+++ b/test/checkboxes.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+	checkboxLines,
+	countCheckboxes,
+	toggleCheckboxAt,
+	toggleCheckboxLine,
+} from "../src/checkboxes";
+
+describe("checkboxLines", () => {
+	it("finds bullet, ordered and quoted task lines", () => {
+		const md = ["- [ ] one", "* [x] two", "+ [ ] three", "1. [ ] four", "2) [x] five", "> - [ ] six"].join("\n");
+		expect(checkboxLines(md)).toEqual([0, 1, 2, 3, 4, 5]);
+	});
+
+	it("keeps indented (nested) tasks", () => {
+		const md = ["- [ ] parent", "\t- [ ] child", "    - [x] grandchild"].join("\n");
+		expect(checkboxLines(md)).toEqual([0, 1, 2]);
+	});
+
+	it("ignores plain list items and prose brackets", () => {
+		const md = ["- plain", "- [ ]no space after", "text [ ] mid-line", "- [ ] real"].join("\n");
+		expect(checkboxLines(md)).toEqual([3]);
+	});
+
+	it("accepts a task whose text is empty", () => {
+		expect(checkboxLines("- [ ]")).toEqual([0]);
+	});
+
+	it("skips fenced code blocks, which render as text", () => {
+		const md = ["- [ ] before", "```md", "- [ ] not a checkbox", "```", "- [x] after"].join("\n");
+		expect(checkboxLines(md)).toEqual([0, 4]);
+	});
+
+	it("handles tilde fences and longer closing fences", () => {
+		const md = ["~~~", "- [ ] hidden", "~~~", "````", "- [ ] also hidden", "````", "- [ ] shown"].join("\n");
+		expect(checkboxLines(md)).toEqual([6]);
+	});
+
+	it("does not close a backtick fence with a tilde one", () => {
+		const md = ["```", "- [ ] hidden", "~~~", "- [ ] still hidden"].join("\n");
+		expect(checkboxLines(md)).toEqual([]);
+	});
+
+	it("skips frontmatter by default and counts it when asked not to", () => {
+		const md = ["---", "tags:", "  - [ ] odd", "---", "- [ ] body"].join("\n");
+		expect(checkboxLines(md)).toEqual([4]);
+		expect(checkboxLines(md, { skipFrontmatter: false })).toEqual([2, 4]);
+	});
+
+	it("only treats a leading block as frontmatter", () => {
+		const md = ["- [ ] first", "---", "a: 1", "---", "- [ ] second"].join("\n");
+		expect(checkboxLines(md)).toEqual([0, 4]);
+	});
+
+	it("tolerates CRLF line endings", () => {
+		expect(checkboxLines("- [ ] one\r\n- [x] two\r\n")).toEqual([0, 1]);
+	});
+});
+
+
+describe("countCheckboxes", () => {
+	it("counts what the renderer would emit", () => {
+		expect(countCheckboxes("- [ ] a\n- [x] b\n- plain")).toBe(2);
+		expect(countCheckboxes("no tasks here")).toBe(0);
+	});
+});
+
+
+describe("toggleCheckboxLine", () => {
+	it("checks and unchecks", () => {
+		expect(toggleCheckboxLine("- [ ] milk", true)).toBe("- [x] milk");
+		expect(toggleCheckboxLine("- [x] milk", false)).toBe("- [ ] milk");
+	});
+
+	it("resets a custom status when unchecked", () => {
+		expect(toggleCheckboxLine("- [/] in progress", false)).toBe("- [ ] in progress");
+	});
+
+	it("treats a custom status as already checked", () => {
+		expect(toggleCheckboxLine("- [/] in progress", true)).toBe("- [/] in progress");
+	});
+
+	it("leaves an already-correct line untouched", () => {
+		expect(toggleCheckboxLine("- [x] done", true)).toBe("- [x] done");
+	});
+
+	it("preserves indentation, markers and trailing text", () => {
+		expect(toggleCheckboxLine("  \t2) [ ] buy #tag [link]", true)).toBe("  \t2) [x] buy #tag [link]");
+		expect(toggleCheckboxLine("> - [ ] quoted", true)).toBe("> - [x] quoted");
+	});
+
+	it("only rewrites the first bracket pair", () => {
+		expect(toggleCheckboxLine("- [ ] see [ ] example", true)).toBe("- [x] see [ ] example");
+	});
+
+	it("returns null for a non-task line", () => {
+		expect(toggleCheckboxLine("- plain", true)).toBeNull();
+		expect(toggleCheckboxLine("", true)).toBeNull();
+	});
+});
+
+
+describe("toggleCheckboxAt", () => {
+	const md = ["# List", "- [ ] one", "- [x] two", "- [ ] three"].join("\n");
+
+	it("toggles by ordinal, not by line", () => {
+		expect(toggleCheckboxAt(md, 0, true)).toBe("# List\n- [x] one\n- [x] two\n- [ ] three");
+		expect(toggleCheckboxAt(md, 1, false)).toBe("# List\n- [ ] one\n- [ ] two\n- [ ] three");
+		expect(toggleCheckboxAt(md, 2, true)).toBe("# List\n- [ ] one\n- [x] two\n- [x] three");
+	});
+
+	it("counts past frontmatter so ordinals match the rendered output", () => {
+		const withFm = ["---", "title: Shopping", "---", "- [ ] one", "- [ ] two"].join("\n");
+		expect(toggleCheckboxAt(withFm, 1, true)).toBe(
+			"---\ntitle: Shopping\n---\n- [ ] one\n- [x] two",
+		);
+	});
+
+	it("skips code fences when resolving the ordinal", () => {
+		const withCode = ["- [ ] one", "```", "- [ ] fake", "```", "- [ ] two"].join("\n");
+		expect(toggleCheckboxAt(withCode, 1, true)).toBe(
+			"- [ ] one\n```\n- [ ] fake\n```\n- [x] two",
+		);
+	});
+
+	it("returns null when the ordinal is out of range", () => {
+		expect(toggleCheckboxAt(md, 3, true)).toBeNull();
+		expect(toggleCheckboxAt(md, -1, true)).toBeNull();
+		expect(toggleCheckboxAt("no tasks", 0, true)).toBeNull();
+	});
+
+	it("leaves the rest of the note byte-identical", () => {
+		const note = "---\na: 1\n---\n\ntext\n\n- [ ] task\n\n> quote\n";
+		expect(toggleCheckboxAt(note, 0, true)).toBe("---\na: 1\n---\n\ntext\n\n- [x] task\n\n> quote\n");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Makes task checkboxes in rendered Markdown actually edit their source, so a tick survives the next render.

**Root cause.** Every Markdown surface in Hearth renders through the static `MarkdownRenderer.render`. That emits reading-view markup — live `<input type="checkbox">` elements included — but it isn't attached to a preview view, and the preview view is what owns the click-to-rewrite-the-`- [ ]`-line behaviour. So the box toggled visually and the state lived only in that DOM node until something re-rendered. It's the same gap `wireMarkdownLinks` already fills for links ("Obsidian only resolves link clicks inside a real Markdown view"). The `editable` toggle didn't help, because it only swaps the preview for a raw `<textarea>` on double-click; the preview half was still inert.

Affected, and all fixed here: embed card (read-only *and* editable), daily-note card (both modes), and the text/jot card.

**How it works.** A new `wireMarkdownCheckboxes` delegates a click listener from the stable render host, like the link wiring, so it survives the content node being re-rendered underneath it. The rendered inputs carry no line information — there's no `MarkdownPostProcessorContext` for a standalone render, so `getSectionInfo` isn't available — so the mapping is **by ordinal**: the Nth input is the Nth checkbox line in the source.

Guards against that mapping going wrong:

- Checkboxes inside a transclusion (`.internal-embed` / `.markdown-embed`) are excluded from the count — they belong to another file and would shift every ordinal after them.
- The write is skipped entirely if the source's checkbox count no longer matches the render it was counted against, so a desync writes nothing rather than ticking the wrong line.
- The source scan skips fenced code blocks and frontmatter, which the cards don't render as checkboxes.
- A failed or skipped write reverts the input, so the DOM never shows a state the source doesn't have.

Notes are edited through `vault.process` (atomic read-modify-write, so a tick can't clobber a concurrent edit). The jot card writes to the card's own text instead, where a leading `---` is content rather than frontmatter. Custom statuses (`[/]`, `[-]`, …) render as ticked, so "check" leaves the symbol alone rather than flattening it to `x`; unchecking resets to `[ ]`.

The handler is registered before each preview's dblclick-to-edit handler, so ticking two boxes in quick succession no longer drops the card into the raw editor.

The source-side logic is a new pure `src/checkboxes.ts` with 23 tests, per the repo's convention of keeping parsing out of the rendering files.

## Related issue

Closes #143

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (`npm test` 192 passed, `npm run lint` 0 errors — warning count unchanged from `main`)
- [x] I've tested this in an actual vault — **not done**: this was written in a container with no Obsidian. The pure line-rewriting half is covered by unit tests; the DOM half (selector match against Obsidian's rendered checkbox markup, and the dblclick ordering) needs a real vault before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrhyeMcKVn47radpG3hdbM)_