### PR TITLE
feat(icons): show Iconic and Iconize file icons across Hearth (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ## [1.18.0]
 
+### Added
+
+- **Your Iconic and Iconize icons now show up in Hearth.** A file that has a
+  custom icon set with either plugin keeps that icon everywhere Hearth draws
+  one — Recent files, Favorites, saved-search cards and the search bar — instead
+  of the generic file-type icon. Lucide icons and emoji are both shown; a file
+  using an icon from one of Iconize's downloaded icon packs keeps Hearth's own
+  icon, since those are SVG files rather than named icons. Neither plugin offers
+  an API, so Hearth reads their settings directly and quietly falls back to the
+  file-type icon if it can't. Turn it off, or point it at a renamed Iconize
+  frontmatter property, under Settings → Hearth → Integrations (#132).
+
 ### Fixed
 
 - **Sorting tasks by priority puts Highest at the top.** The priority sort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 - **Your Iconic and Iconize icons now show up in Hearth.** A file that has a
   custom icon set with either plugin keeps that icon everywhere Hearth draws
-  one — Recent files, Favorites, saved-search cards and the search bar — instead
-  of the generic file-type icon. Lucide icons and emoji are both shown; a file
+  one — Recent files, Favorites, Bookmarks, saved-search cards and the search
+  bar — instead of the generic file-type icon. Bookmarks pointing at a note or
+  folder now also follow the file's *type* icon rather than always showing the
+  same page glyph, so a bookmarked PDF or canvas looks like one. Lucide icons and emoji are both shown; a file
   using an icon from one of Iconize's downloaded icon packs keeps Hearth's own
   icon, since those are SVG files rather than named icons. Neither plugin offers
   an API, so Hearth reads their settings directly and quietly falls back to the

--- a/src/cards/bookmarks.ts
+++ b/src/cards/bookmarks.ts
@@ -1,5 +1,6 @@
 import { setIcon, TFile, TFolder } from "obsidian";
 import { emptyState } from "../cardbodies";
+import { applyFileIcon, fileIconOptions, resolveFileIcon } from "../fileicons";
 import { t } from "../i18n";
 import { type BookmarkItem } from "../obsidian-ext";
 import { makeClickable } from "../ui";
@@ -131,8 +132,19 @@ function renderBookmarkLeaf(
 		t().cards.bookmarks.untitled;
 	const row = container.createDiv("hearth-list-item");
 	const iconEl = row.createDiv("hearth-list-icon");
+	// A bookmark that points at a vault file or folder gets that target's icon —
+	// its Iconize/Iconic icon when one is set, otherwise its file-type icon — so
+	// the same note looks the same here as in Recent or Favorites (#132). Every
+	// other bookmark kind describes a destination rather than a file and keeps
+	// its own fixed icon.
+	const target =
+		(item.type === "file" || item.type === "folder") && item.path
+			? view.app.vault.getAbstractFileByPath(item.path)
+			: null;
 	if (item.type === "url" && item.url) {
 		renderFavicon(iconEl, item.url);
+	} else if (target) {
+		applyFileIcon(iconEl, resolveFileIcon(view.app, target, fileIconOptions(view.plugin.settings)));
 	} else {
 		const icon =
 			item.type === "folder" ? "folder" :

--- a/src/cards/favorites.ts
+++ b/src/cards/favorites.ts
@@ -1,7 +1,7 @@
 import { setIcon, Setting, TFile } from "obsidian";
 import { emptyState } from "../cardbodies";
 import { moveItem } from "../editors";
-import { iconForFile } from "../filetypes";
+import { applyFileIcon, fileIconOptions, resolveFileIcon } from "../fileicons";
 import { t } from "../i18n";
 import { FilePickerModal } from "../pickers";
 import { makeClickable } from "../ui";
@@ -19,11 +19,12 @@ export function renderFavorites(view: HomeView, body: HTMLElement): void {
 	}
 
 	const grid = body.createDiv("hearth-favorites");
+	const icons = fileIconOptions(view.plugin.settings);
 	for (const path of paths) {
 		const file = view.app.vault.getAbstractFileByPath(path);
 		const card = grid.createDiv("hearth-fav-card");
 		if (file instanceof TFile) {
-			setIcon(card.createDiv("hearth-fav-icon"), iconForFile(file));
+			applyFileIcon(card.createDiv("hearth-fav-icon"), resolveFileIcon(view.app, file, icons));
 			card.createDiv({ cls: "hearth-fav-name", text: file.basename });
 			const open = () => void view.app.workspace.getLeaf(true).openFile(file);
 			card.addEventListener("click", open);

--- a/src/cards/recent.ts
+++ b/src/cards/recent.ts
@@ -1,7 +1,8 @@
 import { setIcon, Setting, TFile } from "obsidian";
 import { emptyState } from "../cardbodies";
 import { addResetButton } from "../editors";
-import { FILE_TYPE_GROUPS, fileTypeLabel, FOLDERS_GROUP_ID, groupForFile, iconForFile } from "../filetypes";
+import { applyFileIcon, fileIconOptions, resolveFileIcon } from "../fileicons";
+import { FILE_TYPE_GROUPS, fileTypeLabel, FOLDERS_GROUP_ID, groupForFile } from "../filetypes";
 import { t } from "../i18n";
 import { type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
@@ -35,9 +36,10 @@ export function renderRecent(view: HomeView, card: DashboardCard, body: HTMLElem
 	}
 
 	const list = body.createDiv("hearth-list");
+	const icons = fileIconOptions(view.plugin.settings);
 	for (const file of files) {
 		const row = list.createDiv("hearth-list-item");
-		setIcon(row.createDiv("hearth-list-icon"), iconForFile(file));
+		applyFileIcon(row.createDiv("hearth-list-icon"), resolveFileIcon(view.app, file, icons));
 		row.createDiv({ cls: "hearth-list-label", text: file.basename });
 		const open = () => void view.app.workspace.getLeaf(true).openFile(file);
 		row.addEventListener("click", open);

--- a/src/cards/search.ts
+++ b/src/cards/search.ts
@@ -1,7 +1,7 @@
-import { setIcon, Setting, TFile } from "obsidian";
+import { Setting, TFile } from "obsidian";
 import { emptyState } from "../cardbodies";
 import { addResetButton } from "../editors";
-import { iconForFile } from "../filetypes";
+import { applyFileIcon, fileIconOptions, resolveFileIcon } from "../fileicons";
 import { t } from "../i18n";
 import { runQuery, searchFileContents, type QueryHit } from "../query";
 import { type DashboardCard } from "../types";
@@ -53,9 +53,15 @@ export function renderSavedSearch(view: HomeView, card: DashboardCard, body: HTM
 
 function renderQueryList(view: HomeView, body: HTMLElement, list: QueryHit[]): void {
 	const el = body.createDiv("hearth-list");
+	const icons = fileIconOptions(view.plugin.settings);
 	for (const hit of list) {
 		const row = el.createDiv("hearth-list-item");
-		setIcon(row.createDiv("hearth-list-icon"), hit.badge?.icon ?? iconForFile(hit.file));
+		// A badge icon describes *why* the file matched (tag, property, body), so
+		// it outranks the file's own icon.
+		applyFileIcon(
+			row.createDiv("hearth-list-icon"),
+			hit.badge?.icon ?? resolveFileIcon(view.app, hit.file, icons),
+		);
 		const name = hit.file instanceof TFile ? hit.file.basename : hit.file.name;
 		row.createDiv({ cls: "hearth-list-label", text: name });
 		if (hit.badge) row.createDiv({ cls: "hearth-task-status", text: hit.badge.label });
@@ -72,9 +78,13 @@ function renderQueryTiles(view: HomeView, body: HTMLElement, list: QueryHit[]): 
 	const grid = body.createDiv("hearth-links hearth-tiles-sized");
 	const baseTile = 90;
 	grid.style.setProperty("--hearth-tile", `${baseTile}px`);
+	const icons = fileIconOptions(view.plugin.settings);
 	for (const hit of list) {
 		const tile = grid.createDiv("hearth-link-tile");
-		setIcon(tile.createDiv("hearth-link-icon"), hit.badge?.icon ?? iconForFile(hit.file));
+		applyFileIcon(
+			tile.createDiv("hearth-link-icon"),
+			hit.badge?.icon ?? resolveFileIcon(view.app, hit.file, icons),
+		);
 		const name = hit.file instanceof TFile ? hit.file.basename : hit.file.name;
 		tile.createDiv({ cls: "hearth-link-label", text: name });
 		const open = () => {

--- a/src/fileicons.ts
+++ b/src/fileicons.ts
@@ -1,0 +1,298 @@
+import { getIconIds, setIcon, TFile, type App, type TAbstractFile } from "obsidian";
+import { iconForFile } from "./filetypes";
+import { type HomeSettings } from "./types";
+
+/**
+ * Per-file icons from the Iconic and Iconize community plugins (#132).
+ *
+ * Neither plugin exposes an API for other plugins, so — exactly as with
+ * TaskNotes in `cards/tasks.ts` — Hearth reads their stored state directly.
+ * That state is private and can change shape in any release of theirs, so every
+ * read here is wrapped and every failure degrades silently to Hearth's own
+ * file-type icon. A broken read must never surface as a broken card.
+ *
+ * Two plugins, because the two are mid-handover: Iconize
+ * (`obsidian-icon-folder`) is deprecated but still widely installed, and Iconic
+ * is its spiritual successor. A vault can have either, both, or neither.
+ *
+ * Scope: Lucide icons and emoji. Iconize can also draw icons from downloaded
+ * icon packs (Font Awesome, Remix, …), which are SVG blobs on disk — rendering
+ * those means injecting third-party markup, so those files keep Hearth's
+ * built-in icon instead.
+ */
+
+/** The community-plugin id Iconic registers itself under. */
+export const ICONIC_PLUGIN_ID = "iconic";
+/** The community-plugin id Iconize registers itself under. Its original name
+ * was "Obsidian Icon Folder", which is what the id still reflects. */
+export const ICONIZE_PLUGIN_ID = "obsidian-icon-folder";
+
+/** Iconize's prefix for icons drawn from the Lucide pack. Icons from any other
+ * pack carry that pack's own prefix and aren't renderable via `setIcon`. */
+const ICONIZE_LUCIDE_PREFIX = "Li";
+
+/** Keys Iconize stores alongside the path→icon entries in its data file. They
+ * are not file paths and must never be treated as one. */
+const ICONIZE_RESERVED_KEYS = new Set(["settings", "migrated"]);
+
+/**
+ * An icon resolved for a file: either a Lucide id renderable with Obsidian's
+ * `setIcon`, or a literal emoji that has to be rendered as text.
+ */
+export type ResolvedIcon =
+	| { kind: "lucide"; id: string }
+	| { kind: "emoji"; char: string };
+
+/** What {@link resolveFileIcon} needs from the user's settings. */
+export interface FileIconOptions {
+	/** Master switch for the whole integration. */
+	enabled: boolean;
+	/** The frontmatter property Iconize reads a note's icon from. Iconize lets
+	 * the user rename it, so it mirrors Iconize's default rather than assuming
+	 * it (same reasoning as the TaskNotes field names). */
+	frontmatterProperty: string;
+}
+
+// ---- Pure helpers (unit-tested) -----------------------------------------
+
+/**
+ * Whether a stored icon value is an emoji rather than an icon name.
+ *
+ * Both plugins store emoji as the literal character. Icon names from every pack
+ * are ASCII, so a leading non-ASCII codepoint is the distinguishing signal. The
+ * length cap keeps a stray sentence out of an icon slot while leaving room for
+ * the longest ZWJ sequences (family emoji run to 7 codepoints with joiners).
+ */
+export function isEmojiIcon(value: string): boolean {
+	const trimmed = value.trim();
+	if (!trimmed) return false;
+	const first = trimmed.codePointAt(0);
+	if (first === undefined || first <= 0x7f) return false;
+	return Array.from(trimmed).length <= 8;
+}
+
+/**
+ * Convert Iconize's stored icon name into a plain Lucide id, or null when the
+ * icon comes from a downloaded pack Hearth can't render.
+ *
+ * Iconize stores `<PackPrefix><NormalizedName>` — the Lucide id `file-text`
+ * becomes `LiFileText`. Undoing the normalization means splitting the
+ * PascalCase back apart: `LiFileText` → `file-text`, `LiSquare1` → `square-1`.
+ * The result is only a candidate; the caller checks it against the icons
+ * Obsidian actually has registered.
+ */
+export function iconizeNameToLucide(name: string): string | null {
+	if (!name.startsWith(ICONIZE_LUCIDE_PREFIX)) return null;
+	const body = name.slice(ICONIZE_LUCIDE_PREFIX.length);
+	// A bare "Li" carries no icon, and a lowercase next character means the
+	// prefix match was a coincidence inside some other pack's name.
+	if (!body || body[0] !== body[0].toUpperCase()) return null;
+	return body
+		.replace(/([a-z])([A-Z0-9])/g, "$1-$2")
+		.replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
+		.toLowerCase();
+}
+
+/**
+ * Turn a raw stored icon value from either plugin into something renderable,
+ * or null when it names an icon Obsidian doesn't have.
+ *
+ * `isKnown` reports whether an id is registered with Obsidian; it is injected
+ * so this stays pure (and so the icon list is looked up once per render rather
+ * than once per file). Handles all three shapes seen in the wild: a literal
+ * emoji, a Lucide id with or without Obsidian's `lucide-` prefix (Iconic stores
+ * the prefixed form), and Iconize's PascalCase pack name.
+ */
+export function normalizeStoredIcon(
+	raw: string,
+	isKnown: (id: string) => boolean,
+): ResolvedIcon | null {
+	const value = raw.trim();
+	if (!value) return null;
+	if (isEmojiIcon(value)) return { kind: "emoji", char: value };
+
+	for (const candidate of [value, `lucide-${value}`]) {
+		if (isKnown(candidate)) return { kind: "lucide", id: candidate };
+	}
+
+	const fromIconize = iconizeNameToLucide(value);
+	if (fromIconize) {
+		for (const candidate of [fromIconize, `lucide-${fromIconize}`]) {
+			if (isKnown(candidate)) return { kind: "lucide", id: candidate };
+		}
+	}
+	return null;
+}
+
+/**
+ * Pull the icon name for `path` out of an Iconize data blob.
+ *
+ * Iconize keys its data file by vault path, storing either the icon name
+ * directly or a `{ iconName }` object (folders, which also carry a colour).
+ * Its own custom *rules* (glob/regex matchers) are deliberately not evaluated
+ * here — replicating its matching order would be guesswork against private
+ * behaviour, and getting it wrong shows the user the wrong icon rather than
+ * none.
+ */
+export function iconizeIconForPath(data: unknown, path: string): string | null {
+	if (!data || typeof data !== "object") return null;
+	if (ICONIZE_RESERVED_KEYS.has(path)) return null;
+	const entry = (data as Record<string, unknown>)[path];
+	if (typeof entry === "string") return entry || null;
+	if (entry && typeof entry === "object") {
+		const named = (entry as { iconName?: unknown }).iconName;
+		if (typeof named === "string" && named) return named;
+	}
+	return null;
+}
+
+/** Pull the icon name for `path` out of an Iconic `fileIcons` map, which stores
+ * `{ icon, color }` per vault path. The colour is read but not applied —
+ * Hearth's icons take their colour from the theme. */
+export function iconicIconForPath(fileIcons: unknown, path: string): string | null {
+	if (!fileIcons || typeof fileIcons !== "object") return null;
+	const entry = (fileIcons as Record<string, unknown>)[path];
+	if (!entry || typeof entry !== "object") return null;
+	const icon = (entry as { icon?: unknown }).icon;
+	return typeof icon === "string" && icon ? icon : null;
+}
+
+// ---- Reading the plugins ------------------------------------------------
+
+/**
+ * The set of icon ids Obsidian has registered, memoized by list length.
+ *
+ * `getIconIds()` allocates a fresh array of ~1,700 entries, which is too much
+ * to redo for every file in a card. Length is a good enough cache key: the list
+ * only grows, and only when a plugin calls `addIcon`.
+ */
+let knownIconIds: { size: number; ids: Set<string> } | null = null;
+
+function knownIcons(): Set<string> {
+	try {
+		const ids = getIconIds();
+		if (!knownIconIds || knownIconIds.size !== ids.length) {
+			knownIconIds = { size: ids.length, ids: new Set(ids) };
+		}
+		return knownIconIds.ids;
+	} catch {
+		return new Set();
+	}
+}
+
+/** Iconic's plugin instance keeps its settings — including the path→icon map —
+ * on the instance itself. */
+function iconicIcon(app: App, path: string): string | null {
+	const plugin = app.plugins.plugins[ICONIC_PLUGIN_ID] as
+		| { settings?: { fileIcons?: unknown } }
+		| undefined;
+	return iconicIconForPath(plugin?.settings?.fileIcons, path);
+}
+
+/** Iconize exposes its data blob through `getData()`; older builds only had the
+ * `data` field, so fall back to it. */
+function iconizeIcon(app: App, path: string): string | null {
+	const plugin = app.plugins.plugins[ICONIZE_PLUGIN_ID] as
+		| { getData?: () => unknown; data?: unknown }
+		| undefined;
+	if (!plugin) return null;
+	const data = typeof plugin.getData === "function" ? plugin.getData() : plugin.data;
+	return iconizeIconForPath(data, path);
+}
+
+/**
+ * Iconize's other storage location: a frontmatter property on the note itself.
+ * Read through Obsidian's metadata cache, so this one costs nothing and keeps
+ * working regardless of what Iconize does to its internals.
+ *
+ * Gated on Iconize being enabled, deliberately. `icon` is a common enough
+ * property name that a vault using it for its own purposes — a template field,
+ * a Dataview column — would otherwise find those values turning into icons in
+ * Hearth without ever having installed an icon plugin.
+ */
+function frontmatterIcon(app: App, file: TAbstractFile, property: string): string | null {
+	const key = property.trim();
+	if (!key) return null;
+	if (!app.plugins.enabledPlugins.has(ICONIZE_PLUGIN_ID)) return null;
+	// getFileCache takes a TFile; folders have no frontmatter to read.
+	if (!(file instanceof TFile)) return null;
+	// FrontMatterCache is indexed as `any`; widening it to unknown keeps the
+	// value check below honest.
+	const frontmatter: Record<string, unknown> | undefined =
+		app.metadataCache.getFileCache(file)?.frontmatter;
+	const value = frontmatter?.[key];
+	return typeof value === "string" && value.trim() ? value : null;
+}
+
+/** Whether either icon plugin is currently enabled. Used to decide whether the
+ * settings row is worth explaining, not to gate resolution — resolution already
+ * falls back on its own. */
+export function hasFileIconPlugin(app: App): boolean {
+	try {
+		const enabled = app.plugins.enabledPlugins;
+		return enabled.has(ICONIC_PLUGIN_ID) || enabled.has(ICONIZE_PLUGIN_ID);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * The icon to draw for `file`: a custom one from Iconic or Iconize when the
+ * user has set one, otherwise Hearth's own file-type icon.
+ *
+ * Iconic is consulted first — it is the maintained plugin, so in a vault
+ * migrating from Iconize its choice is the more recent one. Within Iconize, the
+ * data file wins over frontmatter, matching Iconize's own precedence.
+ *
+ * Never throws: any failure reading plugin internals falls through to
+ * {@link iconForFile}.
+ */
+export function resolveFileIcon(
+	app: App,
+	file: TAbstractFile,
+	opts: FileIconOptions,
+): ResolvedIcon {
+	const fallback: ResolvedIcon = { kind: "lucide", id: iconForFile(file) };
+	if (!opts.enabled) return fallback;
+	try {
+		const path = file.path;
+		const raw =
+			iconicIcon(app, path) ??
+			iconizeIcon(app, path) ??
+			frontmatterIcon(app, file, opts.frontmatterProperty);
+		if (!raw) return fallback;
+		const ids = knownIcons();
+		return normalizeStoredIcon(raw, (id) => ids.has(id)) ?? fallback;
+	} catch {
+		// Both plugins' internals are private; a shape change must cost the user
+		// their custom icon, not the card it was on.
+		return fallback;
+	}
+}
+
+/** The resolver options carried by the user's settings. A one-liner, but it
+ * keeps every call site from having to remember which two fields matter. */
+export function fileIconOptions(settings: HomeSettings): FileIconOptions {
+	return {
+		enabled: settings.customFileIcons,
+		frontmatterProperty: settings.iconizeIconProperty,
+	};
+}
+
+/**
+ * Draw an icon into `el`. Accepts a plain Lucide id for the call sites that
+ * already have one (search badges), so those keep reading as a single
+ * expression.
+ */
+export function applyFileIcon(el: HTMLElement, icon: ResolvedIcon | string): void {
+	if (typeof icon === "string") {
+		setIcon(el, icon);
+		return;
+	}
+	if (icon.kind === "emoji") {
+		el.empty();
+		el.createSpan({ cls: "hearth-emoji-icon", text: icon.char });
+		return;
+	}
+	setIcon(el, icon.id);
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -423,6 +423,27 @@ export const en = {
 			doneValue: "“Done” status value",
 			doneValueDesc: "The status value that marks a TaskNotes task complete.",
 		},
+		fileIcons: {
+			heading: "File icons / Iconic / Iconize",
+			headingDesc:
+				"Use the per-file icons you've set with the Iconic or Iconize " +
+				"plugins wherever Hearth shows a file — Recent, Favorites, saved " +
+				"searches and the search bar. Lucide icons and emoji are shown; " +
+				"files using an icon from a downloaded icon pack keep Hearth's own " +
+				"file-type icon.",
+			enable: "Use icons from Iconic / Iconize",
+			enableDesc:
+				"Off shows Hearth's file-type icon for every file, ignoring both plugins.",
+			enableDescNoPlugin:
+				"Neither Iconic nor Iconize is enabled right now, so every file " +
+				"shows Hearth's file-type icon. This can stay on — it takes effect " +
+				"as soon as one of them is installed.",
+			property: "Iconize frontmatter property",
+			propertyDesc:
+				"Property Iconize stores a note's icon in, for icons set through " +
+				"frontmatter rather than its menu. Match this to Iconize's own " +
+				"setting if you renamed it (its default is “icon”).",
+		},
 		filters: {
 			heading: "Search filters",
 			headingDesc:

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,6 +1,7 @@
 import { Command, Component, debounce, Platform, setIcon, TAbstractFile, TFile, TFolder } from "obsidian";
 import type { HomeView } from "./view";
-import { FILE_TYPE_GROUPS, FileTypeGroup, fileTypeLabel, groupForFile, iconForFile, OTHER_GROUP_ID } from "./filetypes";
+import { applyFileIcon, fileIconOptions, resolveFileIcon, type ResolvedIcon } from "./fileicons";
+import { FILE_TYPE_GROUPS, FileTypeGroup, fileTypeLabel, groupForFile, OTHER_GROUP_ID } from "./filetypes";
 import { QueryFilter, QueryHit, runQuery, searchFileContents } from "./query";
 import { isOmnisearchAvailable, searchWithOmnisearch } from "./omnisearch";
 import { t } from "./i18n";
@@ -337,8 +338,10 @@ export class SearchSection {
 			this.showEmpty();
 			return;
 		}
+		const icons = fileIconOptions(this.view.plugin.settings);
 		hits.forEach((hit, i) => {
-			const row = this.newRow(i, hit.badge?.icon ?? iconForFile(hit.file));
+			// A badge icon says why the file matched, so it outranks the file's own.
+			const row = this.newRow(i, hit.badge?.icon ?? resolveFileIcon(this.view.app, hit.file, icons));
 			const text = row.createDiv("hearth-result-text");
 			const name = hit.file instanceof TFile ? hit.file.basename : hit.file.name;
 			this.renderName(text.createDiv("hearth-result-name"), name || "/", hit.matches);
@@ -374,12 +377,12 @@ export class SearchSection {
 		this.finishResults();
 	}
 
-	private newRow(index: number, icon: string): HTMLElement {
+	private newRow(index: number, icon: ResolvedIcon | string): HTMLElement {
 		const row = this.resultsEl.createDiv("hearth-result");
 		row.id = `${this.resultsId}-opt-${index}`;
 		row.setAttribute("role", "option");
 		row.setAttribute("aria-selected", "false");
-		setIcon(row.createDiv("hearth-result-icon"), icon);
+		applyFileIcon(row.createDiv("hearth-result-icon"), icon);
 		return row;
 	}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import { type App, type ButtonComponent, Notice, Platform, PluginSettingTab, setIcon, Setting, type SettingDefinitionItem, type SliderComponent, type TextComponent, TFile } from "obsidian";
 import type HearthPlugin from "./main";
+import { hasFileIconPlugin } from "./fileicons";
 import { FILE_TYPE_GROUPS, fileTypeLabel } from "./filetypes";
 import { CommandPickerModal } from "./pickers";
 import { type BackgroundKind, CARD_BORDER_WIDTH_MAX, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, type MobileActionButton } from "./types";
@@ -32,7 +33,8 @@ type StringSettingKey =
 	| "taskNotesStatusField"
 	| "taskNotesDueField"
 	| "taskNotesPriorityField"
-	| "taskNotesDoneValue";
+	| "taskNotesDoneValue"
+	| "iconizeIconProperty";
 
 /** The GitHub repository and support links surfaced in the About tab. */
 const GITHUB_URL = "https://github.com/ondreu/hearth";
@@ -343,6 +345,9 @@ export class HomeSettingTab extends PluginSettingTab {
 				break;
 			case "integrations":
 				this.section(body, s.tasks.heading, s.tasks.headingDesc, (b) => this.tasksSection(b));
+				this.section(body, s.fileIcons.heading, s.fileIcons.headingDesc, (b) =>
+					this.fileIconsSection(b),
+				);
 				break;
 			case "backup":
 				this.section(body, s.layout.heading, s.layout.headingDesc, (b) => this.layoutSection(b));
@@ -968,6 +973,37 @@ export class HomeSettingTab extends PluginSettingTab {
 				await this.save();
 			});
 			this.addTextReset(doneValue, txt, "taskNotesDoneValue");
+		});
+	}
+
+	// ---- File icons (Iconic / Iconize) ----------------------------------
+
+	private fileIconsSection(containerEl: HTMLElement): void {
+		const s = this.plugin.settings;
+
+		new Setting(containerEl)
+			.setName(t().settings.fileIcons.enable)
+			.setDesc(
+				hasFileIconPlugin(this.plugin.app)
+					? t().settings.fileIcons.enableDesc
+					: t().settings.fileIcons.enableDescNoPlugin,
+			)
+			.addToggle((tog) =>
+				tog.setValue(s.customFileIcons).onChange(async (v) => {
+					s.customFileIcons = v;
+					await this.save();
+				}),
+			);
+
+		const property = new Setting(containerEl)
+			.setName(t().settings.fileIcons.property)
+			.setDesc(t().settings.fileIcons.propertyDesc);
+		property.addText((txt) => {
+			txt.setValue(s.iconizeIconProperty).onChange(async (v) => {
+				s.iconizeIconProperty = v;
+				await this.save();
+			});
+			this.addTextReset(property, txt, "iconizeIconProperty");
 		});
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -849,6 +849,17 @@ export interface HomeSettings {
 	/** The status value that counts as "done". */
 	taskNotesDoneValue: string;
 
+	// ---- File icons / Iconic / Iconize ----
+	/** Show the per-file icons set with the Iconic or Iconize community plugins
+	 * wherever Hearth draws a file icon, instead of Hearth's file-type icon.
+	 * Harmless with neither plugin installed — there is simply nothing to read,
+	 * and every file keeps its type icon. */
+	customFileIcons: boolean;
+	/** Frontmatter property Iconize stores a note's icon in. Iconize lets the
+	 * user rename it, so — as with the TaskNotes fields above — this mirrors its
+	 * default rather than assuming nobody changed it. */
+	iconizeIconProperty: string;
+
 	// ---- Layout ----
 	maxWidth: number;
 
@@ -919,6 +930,12 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	taskNotesDueField: "due",
 	taskNotesPriorityField: "priority",
 	taskNotesDoneValue: "done",
+
+	// On by default: with neither icon plugin installed this changes nothing,
+	// and with one installed the icons the user already set are what they expect
+	// to see. "icon" is Iconize's own default property name.
+	customFileIcons: true,
+	iconizeIconProperty: "icon",
 
 	maxWidth: 1600,
 

--- a/styles.css
+++ b/styles.css
@@ -1228,6 +1228,28 @@
 	border-radius: 3px;
 }
 
+/* An emoji icon from Iconic/Iconize stands in for the Lucide glyph setIcon
+ * would have drawn, so it has to occupy the same box — otherwise rows with an
+ * emoji sit a pixel or two off from rows without one. Sized off --icon-size so
+ * it tracks Obsidian's own icon scaling. */
+.hearth-emoji-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--icon-size, 16px);
+	height: var(--icon-size, 16px);
+	font-size: calc(var(--icon-size, 16px) * 0.85);
+	line-height: 1;
+}
+
+/* Tile icons are drawn at a fixed 24px rather than --icon-size (see
+ * .hearth-link-icon .svg-icon), so the emoji has to match that explicitly. */
+.hearth-link-icon .hearth-emoji-icon {
+	width: 24px;
+	height: 24px;
+	font-size: 20px;
+}
+
 .hearth-list-label {
 	font-size: 0.9rem;
 	color: var(--text-normal);

--- a/test/fileicons.test.ts
+++ b/test/fileicons.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+	iconicIconForPath,
+	iconizeIconForPath,
+	iconizeNameToLucide,
+	isEmojiIcon,
+	normalizeStoredIcon,
+} from "../src/fileicons";
+
+/**
+ * Per-file icons from Iconic and Iconize (#132). Neither plugin has an API, so
+ * Hearth reads their stored state — these cover the parsing of that state and
+ * the name translation between their formats and Obsidian's icon ids. The
+ * reads themselves (plugin instances, metadata cache) are Obsidian API and stay
+ * untested, per the no-mocks rule.
+ */
+
+/** Stand-in for Obsidian's icon registry. Real ids carry the `lucide-` prefix,
+ * which is what `getIconIds()` returns. */
+const REGISTERED = new Set([
+	"lucide-file-text",
+	"lucide-square-1",
+	"lucide-book-open-check",
+	"lucide-globe-2",
+]);
+const isKnown = (id: string) => REGISTERED.has(id);
+
+describe("isEmojiIcon", () => {
+	it("accepts the literal emoji both plugins store", () => {
+		expect(isEmojiIcon("📕")).toBe(true);
+		expect(isEmojiIcon("🌵")).toBe(true);
+	});
+
+	it("accepts multi-codepoint sequences", () => {
+		// Skin-tone modifier and a ZWJ family sequence.
+		expect(isEmojiIcon("👍🏽")).toBe(true);
+		expect(isEmojiIcon("👩‍👩‍👧‍👦")).toBe(true);
+	});
+
+	it("rejects icon names, which are always ASCII", () => {
+		expect(isEmojiIcon("lucide-file-text")).toBe(false);
+		expect(isEmojiIcon("LiFileText")).toBe(false);
+		expect(isEmojiIcon("")).toBe(false);
+		expect(isEmojiIcon("   ")).toBe(false);
+	});
+
+	it("rejects prose that landed in an icon field", () => {
+		expect(isEmojiIcon("— a stray sentence that is not an icon at all")).toBe(false);
+	});
+});
+
+describe("iconizeNameToLucide", () => {
+	it("undoes Iconize's PascalCase normalization", () => {
+		expect(iconizeNameToLucide("LiFileText")).toBe("file-text");
+		expect(iconizeNameToLucide("LiBookOpenCheck")).toBe("book-open-check");
+	});
+
+	it("splits trailing digits back out", () => {
+		expect(iconizeNameToLucide("LiSquare1")).toBe("square-1");
+		expect(iconizeNameToLucide("LiGlobe2")).toBe("globe-2");
+	});
+
+	it("ignores icons from other packs, which are SVG blobs Hearth can't draw", () => {
+		expect(iconizeNameToLucide("FaBook")).toBeNull();
+		expect(iconizeNameToLucide("RiHome")).toBeNull();
+	});
+
+	it("ignores a bare prefix and a coincidental lowercase match", () => {
+		expect(iconizeNameToLucide("Li")).toBeNull();
+		expect(iconizeNameToLucide("Library")).toBeNull();
+	});
+});
+
+describe("normalizeStoredIcon", () => {
+	it("passes through Iconic's prefixed lucide ids", () => {
+		expect(normalizeStoredIcon("lucide-file-text", isKnown)).toEqual({
+			kind: "lucide",
+			id: "lucide-file-text",
+		});
+	});
+
+	it("resolves an unprefixed lucide id", () => {
+		expect(normalizeStoredIcon("file-text", isKnown)).toEqual({
+			kind: "lucide",
+			id: "lucide-file-text",
+		});
+	});
+
+	it("resolves Iconize's pack name", () => {
+		expect(normalizeStoredIcon("LiBookOpenCheck", isKnown)).toEqual({
+			kind: "lucide",
+			id: "lucide-book-open-check",
+		});
+	});
+
+	it("returns emoji as emoji", () => {
+		expect(normalizeStoredIcon("📕", isKnown)).toEqual({ kind: "emoji", char: "📕" });
+	});
+
+	it("rejects an icon Obsidian doesn't have, so the caller can fall back", () => {
+		// setIcon draws nothing for an unknown id, which would leave a blank slot
+		// where the file-type icon should be.
+		expect(normalizeStoredIcon("FaBook", isKnown)).toBeNull();
+		expect(normalizeStoredIcon("lucide-not-a-real-icon", isKnown)).toBeNull();
+		expect(normalizeStoredIcon("   ", isKnown)).toBeNull();
+	});
+});
+
+describe("iconizeIconForPath", () => {
+	const data = {
+		"Notes/Recipe.md": "LiChefHat",
+		"Notes/Empty.md": "",
+		Projects: { iconName: "LiFolderGit", iconColor: "#ff0000" },
+		"Notes/Nulled.md": { iconName: null },
+		settings: { iconInFrontmatterEnabled: true },
+		migrated: 3,
+	};
+
+	it("reads a plain icon-name entry", () => {
+		expect(iconizeIconForPath(data, "Notes/Recipe.md")).toBe("LiChefHat");
+	});
+
+	it("reads the object form used for folders", () => {
+		expect(iconizeIconForPath(data, "Projects")).toBe("LiFolderGit");
+	});
+
+	it("ignores the reserved keys that share the data file with paths", () => {
+		expect(iconizeIconForPath(data, "settings")).toBeNull();
+		expect(iconizeIconForPath(data, "migrated")).toBeNull();
+	});
+
+	it("treats empty and nulled entries as no icon", () => {
+		expect(iconizeIconForPath(data, "Notes/Empty.md")).toBeNull();
+		expect(iconizeIconForPath(data, "Notes/Nulled.md")).toBeNull();
+	});
+
+	it("survives a missing path or a data blob that isn't one", () => {
+		expect(iconizeIconForPath(data, "Notes/Absent.md")).toBeNull();
+		expect(iconizeIconForPath(undefined, "Notes/Recipe.md")).toBeNull();
+		expect(iconizeIconForPath("not an object", "Notes/Recipe.md")).toBeNull();
+	});
+});
+
+describe("iconicIconForPath", () => {
+	const fileIcons = {
+		"Notes/Recipe.md": { icon: "lucide-chef-hat", color: "red" },
+		"Notes/ColorOnly.md": { color: "blue" },
+		"Notes/Emoji.md": { icon: "📕" },
+	};
+
+	it("reads the icon out of an entry", () => {
+		expect(iconicIconForPath(fileIcons, "Notes/Recipe.md")).toBe("lucide-chef-hat");
+		expect(iconicIconForPath(fileIcons, "Notes/Emoji.md")).toBe("📕");
+	});
+
+	it("returns null for an entry that only sets a colour", () => {
+		expect(iconicIconForPath(fileIcons, "Notes/ColorOnly.md")).toBeNull();
+	});
+
+	it("survives a missing path or a map that isn't one", () => {
+		expect(iconicIconForPath(fileIcons, "Notes/Absent.md")).toBeNull();
+		expect(iconicIconForPath(undefined, "Notes/Recipe.md")).toBeNull();
+		expect(iconicIconForPath(42, "Notes/Recipe.md")).toBeNull();
+	});
+});

--- a/test/support/obsidian-shim.ts
+++ b/test/support/obsidian-shim.ts
@@ -63,6 +63,12 @@ export class TextComponent {}
 
 export function setIcon(): void {}
 export function addIcon(): void {}
+// fileicons.ts imports this for its icon-registry lookup. The pure helpers
+// under test take the "is this icon registered?" check as a parameter, so the
+// real registry is never consulted.
+export function getIconIds(): string[] {
+	throw new Error("getIconIds is not implemented in tests (Obsidian API)");
+}
 export function parseYaml(): unknown {
 	throw new Error("parseYaml is not implemented in tests (Obsidian API)");
 }


### PR DESCRIPTION
## What does this PR do?

Files with a custom icon set through **Iconic** or **Iconize** now keep that icon everywhere Hearth draws a file icon, instead of falling back to the generic file-type icon.

**Applied everywhere, not just Recent.** All file-icon call sites route through one new seam, `src/fileicons.ts`:

- `src/cards/recent.ts` — Recent files
- `src/cards/favorites.ts` — Favorites
- `src/cards/search.ts` — saved-search lists and tiles
- `src/search.ts` — the search bar results

Showing a custom icon in Recent and the generic one in Favorites for the same note would read as a bug, so this had to be one seam rather than a change to the Recent card.

**Both plugins, because the two are mid-handover.** Iconize (`obsidian-icon-folder`) is deprecated but still widely installed; Iconic (`iconic`) is its successor. A vault can have either, both, or neither.

**Defensively, because neither has an API.** Both store per-file icons in private plugin state, so Hearth reads it directly — the same approach already taken for TaskNotes in `cards/tasks.ts`. Every read is wrapped, and every failure falls through to the existing `iconForFile()` result. A shape change in either plugin costs a custom icon, never the card it sat on.

Resolution order per file: Iconic's `fileIcons` map → Iconize's data file → Iconize's frontmatter property → Hearth's file-type icon.

### Scope and deliberate limits

- **Lucide icons and emoji are rendered.** Iconic stores `lucide-*` ids; Iconize stores its own PascalCase pack names (`LiFileText`), which are translated back and then validated against `getIconIds()` — an unvalidated name would make `setIcon` draw nothing and leave a blank slot, which is worse than the fallback.
- **Iconize icons from downloaded icon packs** (Font Awesome, Remix, …) are SVG files on disk. Rendering them means injecting third-party markup, so those files keep Hearth's own icon.
- **Iconic's per-icon colour is not applied** — Hearth's icons take their colour from the theme.
- **Iconize's frontmatter property is read only when Iconize is enabled.** `icon` is a common enough property name that a vault using it for a template field or Dataview column would otherwise find those values turning into icons without ever having installed an icon plugin.
- **Iconize's custom rules** (glob/regex matchers) are not evaluated. Replicating its matching order would be guesswork against private behaviour, and getting it wrong shows the *wrong* icon rather than none.

### Settings

Under **Settings → Hearth → Integrations**, a new "File icons" section:

- A master toggle, on by default — a no-op with neither plugin installed, and with one installed it shows the icons the user already set.
- The Iconize frontmatter property name, which Iconize lets users rename (same reasoning as the existing TaskNotes field settings). Defaults to Iconize's own default, `icon`.

Both settings land through the existing `Object.assign(DEFAULT_SETTINGS, raw)` load path, so no migration is needed.

### Known limitation

Recent and Favorites are `liveness: "static"`, so changing a note's icon in Iconic or Iconize won't refresh an already-open board — it picks up on the next render. Worth a follow-up if it bothers anyone; it didn't seem worth adding a watcher for.

## Related issue

Closes #132

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault

On the last box, to be straightforward: this was developed in a container with no Obsidian instance, so it has **not** been exercised against a real vault with either plugin installed. `npm run build`, `npm run lint` (0 errors) and `npm test` (222 tests) all pass, and the pure logic is covered by 21 new tests in `test/fileicons.test.ts` — icon-name translation and the parsing of both plugins' stored shapes. The plugin-instance and metadata-cache reads are Obsidian API and stay untested per the repo's no-mocks rule, so **the reads against real Iconic and Iconize data are the part that wants a manual check** before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_0125b7rg5sdafVWGo3u7j6Ja)_