### PR TITLE
docs(releasing): make cut-and-promote-in-one-pass impossible to read as valid

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -35,6 +35,16 @@ main ──●──●──●───────●──●──●──
 - So at promotion time `main` will *always* be ahead of the beta. That is
   normal and correct — it does **not** block promotion (see "drift" below).
 
+**The two rules, and the one thing they forbid:**
+
+1. A beta is cut from current `main`. Always.
+2. A stable is promoted from a beta that soaked, unchanged. Always.
+
+⛔ **Therefore a beta cut today can never be promoted today.** Cutting and
+promoting are separated by the soak — they are never two halves of one job. If
+the beta you would promote does not already exist and has not already soaked,
+you are not doing a promotion: cut the beta, stop, and hand back.
+
 Always read `RELEASING.md` first; this skill is the operational runbook for it.
 
 ## Preflight (do this every time, before deciding anything)
@@ -47,13 +57,30 @@ git tag -l "*-beta.*" --sort=-v:refname | head      # existing beta snapshots
 git log --oneline "$(git describe --tags --abbrev=0 --match '*-beta.*')"..origin/main -- src styles.css esbuild.config.mjs
 ```
 
-Then classify the drift you see on `main` since the newest beta:
+Drift on `main` since the newest beta is **not** something to classify or fix.
+It is next-cycle work by definition: it ships in the beta you cut from `main` in
+this same pass and reaches stable one cycle later. Promote the soaked snapshot
+as-is.
 
-- Commits are **next-version** work → normal train movement. Promote the beta
-  as-is; those commits become the next beta line.
-- Commits are **this-version** work (a fix/feature you intend to ship in the
-  stable you're about to cut) → they were never soaked. Do **not** fold them in
-  silently: cut a fresh `beta.N` from `main`, let it soak, and promote *that*.
+The one question preflight actually has to answer is:
+
+> **Does a soaked `X.Y.Z-beta.N` already exist?**
+
+- **Yes** → Operation B. Promote it unchanged, whatever `main` looks like now.
+- **No** (the line was opened but never soaked, or soak found a bug) → this is
+  **not a promotion**. Do Operation A only — cut `X.Y.Z-beta.N` from `main` —
+  then **stop and hand back**. Do not continue into Operation B in the same
+  pass, and do not treat silence as permission to. Promotion is a later job,
+  after someone has decided the build is good.
+
+⛔ Cutting a beta and promoting it minutes later ships un-soaked code to every
+user, and **the beta-parity guard will not catch it** — that guard resolves the
+newest `X.Y.Z-beta.*` tag, and a beta you just cut is always the newest. Nothing
+downstream will stop you. This rule is the only thing that does.
+
+If the changelog files work under `[X.Y.Z]` that is not in the soaked beta, the
+**changelog** is wrong, not the beta: move those entries to the next version's
+section in B2 and promote as planned.
 
 ## Operation A — Cut a beta from `main`
 
@@ -66,6 +93,10 @@ Then classify the drift you see on `main` since the newest beta:
    version, no `v` prefix). The workflow publishes it as a **pre-release**.
 
 ## Operation B — Promote a beta to stable (+ open the next beta line)
+
+**Precondition:** the `X.Y.Z-beta.N` you are promoting already existed and had
+already soaked when this job started. If you cut it yourself in this pass,
+Operation B does not apply — you are done after Operation A.
 
 This is two commits on **two different bases** — do not try to do it as one
 commit on `main`, or the beta-parity guard will reject the stable tag.
@@ -158,6 +189,14 @@ rejected — land it via a PR and merge once the check is green.
 
 ## Never
 
+- **Never promote a beta you cut in this same pass.** No soak, no promotion —
+  cut it, stop, hand back. The beta-parity guard does not catch this.
+- **Never merge the B2 store-manifest PR yourself**, and never dispatch
+  `release.yml` for a plain `x.y.z`, unless the user asked for that in this
+  session. Those two steps are what reach every user. Open the PR, report the
+  green check, hand over the link.
+- **Never treat an unanswered question as approval.** If you asked whether to
+  proceed and got no reply, the answer is no — stop with what you have.
 - Never create a release by hand through the GitHub UI.
 - Never put a `-beta` version in `manifest.json`.
 - Never carry `src/` / `styles.css` / `esbuild.config.mjs` changes into a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,6 +44,18 @@ Hearth releases run as a **train**. `main` never freezes:
 4. While the beta soaks, the *next* version's features keep merging into `main`;
    they become the next beta line. Go to 2.
 
+Two rules define the train. Everything else in this document follows from them:
+
+> 1. **A beta is cut from current `main`.** Always — that is the only thing a
+>    beta ever is.
+> 2. **A stable is promoted from a beta that soaked**, unchanged. Always.
+>
+> Together they mean: **a beta cut today can never be promoted today.** Cutting
+> and promoting are two operations separated by the soak, never two halves of
+> one job. If the beta you would promote does not already exist and has not
+> already soaked, you are not doing a promotion — see
+> ["No soaked beta to promote?"](#no-soaked-beta-to-promote).
+
 Two consequences fall out of this and drive the rules below:
 
 - **At promotion time `main` is always ahead of the beta you're promoting.**
@@ -142,20 +154,39 @@ convention — which can be deleted once the tag exists.
 > such beta exists). This is what stops a beta's un-tested code — a new feature,
 > a refactor — from riding a stable tag straight into the store.
 
-**First, check what has drifted onto `main` since the beta.** Because the train
-never freezes (see "Release cadence"), `main` is normally ahead of the beta
-you're promoting — and that's fine when the drift is **next-version** work: it
-stays on `main` and becomes the next beta line, while you promote the soaked
-snapshot as-is.
+**`main` being ahead of the beta is not a problem to solve.** Because the train
+never freezes (see "Release cadence"), `main` is *always* ahead of the beta you
+promote. Everything that landed after the snapshot belongs to the **next**
+carriage — it ships in the beta you cut from `main` in this same pass, and
+reaches stable one cycle later. Nothing is stranded and nothing needs folding
+in. Promote the soaked snapshot as-is.
 
-The drift only blocks promotion when it's **this-version** work: a fix or change
-you intend to ship *in the stable you're about to cut* that landed after the
-`x.y.z-beta.N` you soaked. Those changes were **never beta-tested**, so do
-**not** fold them into the promotion. Cut a fresh beta from current `main`
-(bump `manifest-beta.json` to the next `-beta.N`, tag it), let it soak, and
-promote _that_. The beta-parity guard enforces this either way — it will reject
-a stable tag whose build inputs differ from the beta, so this-version work
-cannot ride a promotion without its own beta.
+> **Don't let the changelog talk you out of this.** If `CHANGELOG.md` files work
+> under `[x.y.z]` that is not in the `x.y.z-beta.N` you soaked, the *changelog*
+> is wrong, not the beta. Move those entries to the next version's section
+> (step 5 below) and promote as planned. A mismatch between prose and the
+> snapshot is never a reason to build a new stable out of `main`.
+
+<a id="no-soaked-beta-to-promote"></a>
+
+### No soaked beta to promote?
+
+Then this is not a promotion, and no amount of preparation makes it one. Cutting
+a beta and promoting it in the same pass ships un-soaked code to every user
+while looking like a correct release — the beta-parity guard **passes**, because
+it resolves the newest `x.y.z-beta.*` tag and a beta you just cut is always
+newest.
+
+There are two ways to arrive here, and both end the same way:
+
+- **The line was opened but never soaked** — `manifest-beta.json` holds
+  `x.y.z-beta.1` and no meaningful build was ever cut from it.
+- **Soak found a bug** — the beta you meant to promote is no good.
+
+In both cases: **cut `x.y.z-beta.N` from current `main`, and stop there.** Let
+it soak. Promoting it is a separate, later job — a different day and a different
+run of this document, once someone has decided the build is good. A stable
+release is never the second half of the job that created its beta.
 
 To promote:
 


### PR DESCRIPTION
## What does this PR do?

Docs only — closes the reading of RELEASING.md that led to 1.18.0 shipping to the store with no soak earlier today.

Both RELEASING.md and the release skill described, *inside the promotion procedure*, "cut a fresh beta from `main`, let it soak, and promote that". That reads as one continuous operation. It isn't — the soak separates two jobs.

**`RELEASING.md`**
- States the two rules up front in "Release cadence": a beta is cut from current `main`; a stable is promoted from a beta that soaked, unchanged. Plus the consequence: **a beta cut today can never be promoted today.**
- Replaces the "drift only blocks promotion when it's this-version work" passage. Drift on `main` never blocks promotion — it's next-cycle work by definition and ships in the beta cut in the same pass.
- New **"No soaked beta to promote?"** section: cut the beta, stop there, promotion is a separate later job.
- Notes that a changelog filing work under `[x.y.z]` that isn't in the soaked beta means the *changelog* is wrong, not the beta — the fix is moving the entries, which step 5 already describes.

**`.claude/skills/release/SKILL.md`**
- Same two rules and consequence near the top.
- Preflight no longer asks to classify drift; it asks the one question that matters — does a soaked `X.Y.Z-beta.N` already exist? No → Operation A only, then stop and hand back.
- Operation B gains an explicit precondition.
- Three additions to **Never**: never promote a beta cut in the same pass; never merge the B2 store-manifest PR or dispatch a stable release unless asked; never treat an unanswered question as approval.

Records the reason the existing guard can't catch this: beta-parity resolves the newest `x.y.z-beta.*` tag, so a beta you just cut always satisfies it.

No workflow, script or source changes. The soak guard discussed separately is deliberately **not** included here.

## Related issue

None — follows the 1.18.0 rollback (#152).

## Type of change

- [x] 📝 Docs

## Checklist

- [x] `node scripts/verify-manifests.mjs` passes
- [x] No `src/`, `styles.css`, `esbuild.config.mjs`, workflow or script changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQLmqfJmb6YSXJpbR5oJnt)_