### PR TITLE
chore: cut 1.18.0-beta.2

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "1.18.0-beta.1",
+	"version": "1.18.0-beta.2",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
## What does this PR do?

Opens the 1.18.0 soak build. One line: `manifest-beta.json` `1.18.0-beta.1` → `1.18.0-beta.2`.

`manifest.json` stays `1.17.0`, so the community store is untouched — this reaches BRAT testers only.

`1.18.0-beta.2` snapshots current `main`, which carries the work `CHANGELOG.md`'s `[1.18.0]` section already describes:

- Iconic/Iconize file icons (#132)
- exact-level priority sort (#145)
- checkbox writeback (#143)
- theme focus-ring suppression (#138)

`1.18.0-beta.1` was tagged at the 1.17.0 release commit, before any of that merged, so it holds no code changes over 1.17.0 — hence beta.2 rather than promoting beta.1 into an empty stable.

**This is a beta cut only.** Promotion to stable 1.18.0 is a separate job, after this has soaked and you've judged it good.

Once merged I'll dispatch `release.yml` from `main` with `version=1.18.0-beta.2` and confirm it publishes as `prerelease: true`.

## Related issue

None — release chore.

## Type of change

- [x] 📝 Docs <!-- release metadata only -->

## Checklist

- [x] `node scripts/verify-manifests.mjs` passes
- [x] Only `manifest-beta.json` changed — no `src/`, `styles.css`, `esbuild.config.mjs`, workflow or `manifest.json` changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQLmqfJmb6YSXJpbR5oJnt)_