### PR TITLE
fix(cards): stop clipping task checkboxes in embed and jot cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,15 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **Task checkboxes are no longer clipped in embed, daily and jot cards.** A
+  task list embedded in a card could have the left edge of its checkboxes cut
+  off. Obsidian pulls a checkbox back out of its list item by one and a half
+  checkbox widths, and when the embedded text renders smaller than the global
+  font size that pull-back is wider than the list's own indent. The card's side
+  padding sat on the card body, one level above the element that clips
+  horizontally, so it couldn't absorb the overhang. The gutter now sits on the
+  embed itself: text lands in exactly the same place, and the checkbox has room
+  (#137).
 - **Sorting tasks by priority puts Highest at the top.** The priority sort
   ranked tasks by the coarse colour bucket the priority dot uses, which lumps
   Highest in with High (and Lowest in with Low). Tasks one level apart therefore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,13 +73,14 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 - **Task checkboxes are no longer clipped in embed, daily and jot cards.** A
   task list embedded in a card could have the left edge of its checkboxes cut
-  off. Obsidian pulls a checkbox back out of its list item by one and a half
-  checkbox widths, and when the embedded text renders smaller than the global
-  font size that pull-back is wider than the list's own indent. The card's side
-  padding sat on the card body, one level above the element that clips
-  horizontally, so it couldn't absorb the overhang. The gutter now sits on the
-  embed itself: text lands in exactly the same place, and the checkbox has room
-  (#137).
+  off. Obsidian hangs a checkbox outside its list item by one and a half checkbox
+  widths, and sizes checkboxes from the global font-size setting — which card
+  text doesn't follow — so on a larger setting the checkbox outgrew the indent
+  it hangs out of and spilled past the card's edge. Checkboxes in a card now
+  scale with the card's own text, so they stay in their list item at any font
+  size (and no longer tower over the line they belong to). The card's side gutter
+  also moves onto the embed itself, where it can actually shield content from
+  being clipped; text lands in exactly the same place (#137).
 - **Sorting tasks by priority puts Highest at the top.** The priority sort
   ranked tasks by the coarse colour bucket the priority dot uses, which lumps
   Highest in with High (and Lowest in with Low). Tasks one level apart therefore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,11 +76,11 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   off. Obsidian hangs a checkbox outside its list item by one and a half checkbox
   widths, and sizes checkboxes from the global font-size setting — which card
   text doesn't follow — so on a larger setting the checkbox outgrew the indent
-  it hangs out of and spilled past the card's edge. Checkboxes in a card now
-  scale with the card's own text, so they stay in their list item at any font
-  size (and no longer tower over the line they belong to). The card's side gutter
-  also moves onto the embed itself, where it can actually shield content from
-  being clipped; text lands in exactly the same place (#137).
+  it hangs out of and spilled past the card's edge. The card's side gutter now
+  sits on the embed itself, where it can actually shield content from being
+  clipped, and widens to match the checkbox instead of being a fixed number, so
+  it holds at any font size. Checkboxes still scale with your font setting;
+  ordinary cards look exactly as before (#137).
 - **Sorting tasks by priority puts Highest at the top.** The priority sort
   ranked tasks by the coarse colour bucket the priority dot uses, which lumps
   Highest in with High (and Lowest in with Low). Tasks one level apart therefore

--- a/styles.css
+++ b/styles.css
@@ -633,8 +633,8 @@
  * than the list's own `3ch` indent. Padding on the body sits *outside* the clip
  * box and so can't absorb the overhang — the checkbox is simply cut off. Reading
  * view avoids this because its `--file-margins` gutter is interior. The rules
- * below zero the body's inline padding and re-apply the same value on the
- * scroll/clip elements themselves, so text lands in exactly the same place. */
+ * below zero the body's inline padding and re-apply it on the scroll/clip
+ * elements themselves, so text lands in exactly the same place. */
 .hearth-card-body.is-embed-host,
 .hearth-card-body.is-jot-host {
 	overflow: hidden;
@@ -648,18 +648,45 @@
 	padding-inline: 0;
 }
 
+/* Second half of the fix: tie the checkbox to the text beside it.
+ *
+ * Obsidian computes `--checkbox-size` once on `body` from `--font-text-size`,
+ * but card text is sized in `rem` and doesn't follow that slider. The hanging
+ * indent is `1.5 × --checkbox-size` against a list indent of `3ch` measured on
+ * the list item, so the two terms scale independently: raise the global font
+ * size and the checkbox keeps growing while the indent it hangs out of stays
+ * put. No fixed gutter survives that — the overhang has no upper bound.
+ *
+ * Scoping the variable to the host makes it resolve against the card's own text
+ * instead, so the hang is always ~1.5em against a ~1.6em indent and the checkbox
+ * stays inside its list item at any font-size setting. It also stops an embed
+ * from drawing a checkbox several times the height of the line it belongs to. */
+.hearth-embed,
+.hearth-jot-preview {
+	--checkbox-size: 1em;
+}
+
+/* `em` inside a custom property resolves where the value is *used*, not where
+ * it's declared — that's the checkbox input, whose font-size is a browser
+ * default (~13px) rather than the text it sits next to. Inheriting the font-size
+ * onto the input is what makes the `1em` above mean "one line of this card's
+ * text", which is also the em the hanging indent is computed in. */
+.hearth-embed .task-list-item-checkbox,
+.hearth-jot-preview .task-list-item-checkbox {
+	font-size: inherit;
+}
+
 /* Read-only embed hosts. `.hearth-embed-live` (canvas/Excalidraw) is excluded —
  * it's deliberately edge-to-edge and its body already zeroes all padding. */
-.hearth-card-body.is-embed-host > .hearth-embed:not(.hearth-embed-live) {
+.hearth-card-body.is-embed-host > .hearth-embed:not(.hearth-embed-live),
+.hearth-card-body.is-jot-host .hearth-jot-preview {
 	padding-inline: var(--hearth-card-pad-x);
 }
 
-/* Editable hosts: the preview and the raw textarea are siblings inside
- * `.hearth-jot`, so both need the gutter or the two views disagree on their
- * left edge as the card toggles between them. Covers the jot card
- * (`.hearth-jot-preview` alone) and the editable embed (which also carries
- * `.hearth-embed`). */
-.hearth-card-body.is-jot-host .hearth-jot-preview,
+/* The raw editor is a *sibling* of the preview inside `.hearth-jot`, not a
+ * descendant, so it needs the gutter too or the two views disagree on their
+ * left edge as the card toggles between them. Plain text, no checkbox to hang,
+ * so the flat gutter is enough. Covers the jot card and the editable embed. */
 .hearth-card-body.is-jot-host .hearth-jot-edit {
 	padding-inline: var(--hearth-card-pad-x);
 }

--- a/styles.css
+++ b/styles.css
@@ -616,17 +616,52 @@
 	flex: 1;
 	min-height: 0;
 	overflow: auto;
-	padding: 12px 14px;
+	--hearth-card-pad-x: 14px;
+	padding: 12px var(--hearth-card-pad-x);
 }
 
 /* When a card body holds a read-only embed/daily-note host directly, the host
  * is the scroll container (one vertical scrollbar) — the body itself doesn't
  * scroll, so it can't stack a second scrollbar next to the embed's. The same
  * applies to the editable embed wrapper (.hearth-jot), whose preview/textarea
- * handle their own scrolling. */
+ * handle their own scrolling.
+ *
+ * Those hosts also clip horizontally, so the side gutter has to move *inside*
+ * them (issue #137): Obsidian pulls a task-list checkbox back out of its list
+ * item (`margin-inline-start: calc(var(--checkbox-size) * -1.5)`), and when the
+ * embedded text renders smaller than `--font-text-size` that pull-back is wider
+ * than the list's own `3ch` indent. Padding on the body sits *outside* the clip
+ * box and so can't absorb the overhang — the checkbox is simply cut off. Reading
+ * view avoids this because its `--file-margins` gutter is interior. The rules
+ * below zero the body's inline padding and re-apply the same value on the
+ * scroll/clip elements themselves, so text lands in exactly the same place. */
 .hearth-card-body.is-embed-host,
 .hearth-card-body.is-jot-host {
 	overflow: hidden;
+}
+
+/* Scoped through `.hearth-card` purely for specificity: compact mode sets the
+ * body's `padding` shorthand later in this file, which would otherwise put the
+ * inline padding back and double it against the host's own. */
+.hearth-card > .hearth-card-body.is-embed-host,
+.hearth-card > .hearth-card-body.is-jot-host {
+	padding-inline: 0;
+}
+
+/* Read-only embed hosts. `.hearth-embed-live` (canvas/Excalidraw) is excluded —
+ * it's deliberately edge-to-edge and its body already zeroes all padding. */
+.hearth-card-body.is-embed-host > .hearth-embed:not(.hearth-embed-live) {
+	padding-inline: var(--hearth-card-pad-x);
+}
+
+/* Editable hosts: the preview and the raw textarea are siblings inside
+ * `.hearth-jot`, so both need the gutter or the two views disagree on their
+ * left edge as the card toggles between them. Covers the jot card
+ * (`.hearth-jot-preview` alone) and the editable embed (which also carries
+ * `.hearth-embed`). */
+.hearth-card-body.is-jot-host .hearth-jot-preview,
+.hearth-card-body.is-jot-host .hearth-jot-edit {
+	padding-inline: var(--hearth-card-pad-x);
 }
 
 /* Empty states */
@@ -3239,8 +3274,11 @@
 	padding: 6px 10px;
 }
 
+/* Sets the gutter through `--hearth-card-pad-x` so embed/jot hosts, which carry
+ * the inline padding themselves (see `.is-embed-host` above), follow suit. */
 .hearth-compact .hearth-card-body {
-	padding: 8px 10px;
+	--hearth-card-pad-x: 10px;
+	padding: 8px var(--hearth-card-pad-x);
 }
 
 /* ---- Calendar: week numbers & heatmap ------------------------------- */

--- a/styles.css
+++ b/styles.css
@@ -648,39 +648,30 @@
 	padding-inline: 0;
 }
 
-/* Second half of the fix: tie the checkbox to the text beside it.
+/* Read-only embed and jot hosts. `.hearth-embed-live` (canvas/Excalidraw) is
+ * excluded — it's deliberately edge-to-edge and its body already zeroes all
+ * padding.
  *
- * Obsidian computes `--checkbox-size` once on `body` from `--font-text-size`,
- * but card text is sized in `rem` and doesn't follow that slider. The hanging
- * indent is `1.5 × --checkbox-size` against a list indent of `3ch` measured on
- * the list item, so the two terms scale independently: raise the global font
- * size and the checkbox keeps growing while the indent it hangs out of stays
- * put. No fixed gutter survives that — the overhang has no upper bound.
+ * The start gutter is sized from the hang itself rather than being a flat
+ * number, because the hang has no upper bound. Obsidian computes
+ * `--checkbox-size` once on `body` from `--font-text-size`, while card text is
+ * sized in `rem` and doesn't follow that slider — so `1.5 × --checkbox-size`
+ * grows with the font setting while the `3ch` indent it hangs out of stays put,
+ * and any constant gutter is eventually outgrown (14px still clipped on a large
+ * setting). Both terms resolve here on the host, whose font size is the one the
+ * list items inherit, so the calc measures what the list actually does.
  *
- * Scoping the variable to the host makes it resolve against the card's own text
- * instead, so the hang is always ~1.5em against a ~1.6em indent and the checkbox
- * stays inside its list item at any font-size setting. It also stops an embed
- * from drawing a checkbox several times the height of the line it belongs to. */
-.hearth-embed,
-.hearth-jot-preview {
-	--checkbox-size: 1em;
-}
-
-/* `em` inside a custom property resolves where the value is *used*, not where
- * it's declared — that's the checkbox input, whose font-size is a browser
- * default (~13px) rather than the text it sits next to. Inheriting the font-size
- * onto the input is what makes the `1em` above mean "one line of this card's
- * text", which is also the em the hanging indent is computed in. */
-.hearth-embed .task-list-item-checkbox,
-.hearth-jot-preview .task-list-item-checkbox {
-	font-size: inherit;
-}
-
-/* Read-only embed hosts. `.hearth-embed-live` (canvas/Excalidraw) is excluded —
- * it's deliberately edge-to-edge and its body already zeroes all padding. */
+ * `max()` keeps every ordinary card pixel-identical to the flat gutter: the
+ * hang only widens it once it would otherwise eat in. The gutter is added on
+ * top of the hang, not compared against it, so the checkbox keeps a full
+ * gutter's clearance instead of landing flush against the clip edge. */
 .hearth-card-body.is-embed-host > .hearth-embed:not(.hearth-embed-live),
 .hearth-card-body.is-jot-host .hearth-jot-preview {
-	padding-inline: var(--hearth-card-pad-x);
+	padding-inline-start: max(
+		var(--hearth-card-pad-x),
+		calc(var(--checkbox-size, 1em) * 1.5 - 3ch + var(--hearth-card-pad-x))
+	);
+	padding-inline-end: var(--hearth-card-pad-x);
 }
 
 /* The raw editor is a *sibling* of the preview inside `.hearth-jot`, not a


### PR DESCRIPTION
## What does this PR do?

Fixes the left-side truncation of task-list checkboxes in embedded notes (issue #137). CSS only — no TypeScript touched.

**Root cause.** Obsidian hangs a task checkbox outside its list item by `1.5 × --checkbox-size`, against a list indent of `3ch`. `--checkbox-size` is computed once on `body` from `--font-text-size`, while card text is sized in `rem` and doesn't follow that slider — so the two terms scale independently. Raise the font-size setting and the checkbox keeps growing while the indent it hangs out of stays put: the overhang has **no upper bound**.

`.hearth-embed` / `.hearth-jot-preview` are the elements that clip horizontally (`overflow-x: hidden`), but the card's side padding lived on `.hearth-card-body`, one level above them — padding outside a clip box can't protect content inside it, so the overhang was cut off rather than absorbed. Reading view escapes this because its `--file-margins` gutter is interior.

**The fix.** Move the gutter inside the clip box, and size it from the hang instead of hardcoding it:

```css
padding-inline-start: max(
	var(--hearth-card-pad-x),
	calc(var(--checkbox-size, 1em) * 1.5 - 3ch + var(--hearth-card-pad-x))
);
```

`--hearth-card-pad-x` is introduced on `.hearth-card-body`; bodies hosting an embed or jot zero their own `padding-inline` and the hosts re-apply it. Both terms of the calc resolve on the host, whose font size the list items inherit, so it measures what the list actually does. `max()` leaves every ordinary card pixel-identical to a flat gutter — the hang only widens it once it would otherwise eat in — and the gutter is added on top of the hang so the checkbox keeps a full gutter's clearance rather than sitting flush on the clip edge.

Checkboxes still scale with the font-size setting. The visible consequence at large settings is that list text starts further in, which is the checkbox's real width being accounted for instead of clipped.

Details worth flagging for review:

- **Both hosts are zeroed together.** `.hearth-jot-preview` also carries `.hearth-embed`, so patching only `is-embed-host` would double-pad editable cards.
- **The textarea gets the flat gutter.** `.hearth-jot-edit` is a *sibling* of the preview, not a descendant, so without it the two views disagree on their left edge as the card toggles. Plain text, no checkbox to hang, so it doesn't need the calc. Covers both the jot card and the editable embed.
- **`.hearth-embed-live` is excluded.** Canvas/Excalidraw embeds are deliberately edge-to-edge.
- **The host rules are scoped through `.hearth-card` purely for specificity.** Compact mode sets the body's `padding` shorthand later in the file and would otherwise put the inline padding back and double it. Compact also sets `--hearth-card-pad-x: 10px` so its tighter gutter follows through.

**Considered and rejected:** scoping `--checkbox-size: 1em` to the hosts, so the checkbox is sized by the text beside it. It makes the geometry self-consistent at every font size and stops an embed drawing a checkbox several times the height of its line — but it does that by removing the growth, so checkboxes inside cards would stop honouring the font-size setting. That's a behaviour change dressed up as a fix. Mentioning it because it's a smaller diff if you'd rather cards had their own checkbox scale.

**Not included:** embeds containing Dataview blocks share the clip-box half of the root cause but need a separate fix — Dataview sets `overflow-x: auto` *inline* on `.block-language-dataview(js)`, creating a second clip box nested inside the gutter. That needs Dataview-specific selectors in core styles, so I left it out as a judgment call for you; happy to add it if you want it.

## Related issue

Closes #137. Root-cause analysis by @Darth-Ginger in [this comment](https://github.com/ondreu/Hearth/issues/137#issuecomment-5193742387). The gutter move follows their proposal, extended to cover the plain jot card (`.hearth-jot-preview` without `.hearth-embed`), compact mode, and the unbounded-hang case where a fixed 14px still clipped.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (`npm test` too: 269 passed, 1 skipped)
- [ ] I've tested this in an actual vault — no vault available here. Verified instead in headless Chromium, replicating the interacting Obsidian rules and sweeping `--font-text-size` from 12px to 80px with card text fixed at 15px. Checkbox clearance from the clip edge, normal mode, both columns measured:

  | `--font-text-size` | before | after |
  |---|---|---|
  | 12px | +7.02 | +21.02 |
  | 16px | +1.02 | +15.02 |
  | 20px | **−4.98 (clipped)** | +13.98 |
  | 28px | **−16.98** | +13.98 |
  | 40px | **−34.98** | +13.98 |
  | 60px | **−64.98** | +13.98 |
  | 80px | **−94.98** | +13.98 |

  Before, clearance falls linearly with the font setting and never recovers; after, it never drops below the gutter. Same in compact mode against its 10px gutter. Also confirmed the embed, jot preview and textarea share one gutter in both modes with no doubling, nested task items keep their deeper indent, and live canvas hosts stay at x=0. Worth a look in a real vault before merging.