### PR TITLE
fix(tasks): keep a task list to one task per line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,15 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **A task list keeps one task per line.** A task whose title didn't fit
+  alongside its chips broke across two or three lines — the checkbox alone on
+  one, the title on the next, its status, priority and dates on a third — so a
+  list of tasks with mixed title lengths read as a ragged block rather than a
+  list. A row now holds the checkbox and title (with the status chip beside it)
+  on the left and gathers every other chip at the right edge, and the title is
+  the only part that gives way: it ellipsizes instead of wrapping the row. This
+  is how the list already behaved with **Customize task fields** on; both modes
+  now match (#156).
 - **Task checkboxes are no longer clipped in embed, daily and jot cards.** A
   task list embedded in a card could have the left edge of its checkboxes cut
   off. Obsidian hangs a checkbox outside its list item by one and a half checkbox

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -376,28 +376,23 @@ function renderPriorityChip(
 
 /** A pill showing a TaskNotes task's raw status value. The list layout's
  * completion checkbox only says done/not-done, so the actual status (open,
- * in-progress, waiting, …) needs a chip of its own. With `alignToTitle` it is
- * left-aligned against the task title (see the `has-statuschip` rules in
- * styles.css) so it reads as part of the task rather than floating among the
- * right-hand chips — which is how the fixed layout has always drawn it.
+ * in-progress, waiting, …) needs a chip of its own. Where it lands is the
+ * caller's choice of host: the fixed layout puts it beside the title, so it
+ * reads as part of the task rather than floating among the right-hand chips.
  *
  * Callers only reach here with a value in hand, so there is no empty case. */
 function renderStatusChip(
-	row: HTMLElement,
+	parent: HTMLElement,
 	status: string,
 	style: TaskFieldStyle,
 	color: string | null,
-	alignToTitle: boolean,
 	label = status.trim(),
 ): HTMLElement {
-	const chip = row.createDiv(`hearth-task-status hearth-task-statuschip is-${style}`);
+	const chip = parent.createDiv(`hearth-task-status hearth-task-statuschip is-${style}`);
 	if (style === "dot") chip.createDiv("hearth-task-chip-dot");
 	else chip.setText(label);
 	applyChipColor(chip, color);
 	chip.setAttribute("title", `Status: ${label}`);
-	// Set here rather than matched with :has(), which is avoided in this
-	// stylesheet for its broad selector-invalidation cost.
-	if (alignToTitle) row.addClass("has-statuschip");
 	return chip;
 }
 
@@ -897,7 +892,7 @@ function renderLegacyTaskFields(
 	if (layout === "list") {
 		// TaskNotes tasks: the status is free-form (open / in-progress / waiting /
 		// …) and the checkbox can't express it, so show it right after the title.
-		if (hit.status) renderStatusChip(hosts.inline, hit.status, "pill", null, true);
+		if (hit.status) renderStatusChip(hosts.inline, hit.status, "pill", null);
 		// Kanban cards show the board column they belong to as a small badge.
 		if (hit.boardColumn) {
 			hosts.inline.createDiv({
@@ -1060,7 +1055,7 @@ function renderCustomTaskFields(
 				if (builtin === "priority") {
 					el = renderPriorityChip(host, raw, style, shown.color, shown.label);
 				} else if (builtin === "status") {
-					el = renderStatusChip(host, raw, style, shown.color, false, shown.label);
+					el = renderStatusChip(host, raw, style, shown.color, shown.label);
 				} else {
 					el = renderValueChip(host, {
 						text: shown.label,
@@ -1877,12 +1872,19 @@ function renderTaskRow(
 		renderTaskNotesCheckbox(view, cfg, hit, row, refresh, openStatus);
 	}
 
-	const label = row.createDiv({ cls: "hearth-list-label hearth-task-text" });
+	// Two groups on the one row: the title (with whatever sits beside it) holds
+	// the left and is the only part allowed to shrink, and every other chip
+	// gathers at the right edge. Grouping them is what keeps a task to a single
+	// line — a long title ellipsizes instead of pushing the chips onto a line of
+	// their own (#156). The card's configured field order still reads
+	// left-to-right, since a list draws all its chips into the one meta group.
+	const main = row.createDiv("hearth-task-main");
+	const meta = row.createDiv("hearth-task-metas");
+	const label = main.createDiv({ cls: "hearth-list-label hearth-task-text" });
 	fillTaskText(view, label, hit.text || hit.file.basename, hit.file.path);
-	// One row, so every field lands in it and the card's configured field order
-	// is exactly the left-to-right order: status/column beside the title, then
-	// priority, dates and any frontmatter chips.
-	renderTaskFields(view, cfg, hit, { inline: row, meta: row, block: row, root: row }, today, "list", refresh);
+	// The description is the one field that gets its own line, so it goes to the
+	// row itself rather than into either group.
+	renderTaskFields(view, cfg, hit, { inline: main, meta, block: row, root: row }, today, "list", refresh);
 
 	const open = () => void openTask(view, cfg, hit, refresh);
 	row.addEventListener("click", open);

--- a/styles.css
+++ b/styles.css
@@ -1345,8 +1345,48 @@
 }
 
 /* Tasks card */
+
+/* A task list row is one line per task: the checkbox and title on the left, the
+   chips gathered at the right edge, and only the title yielding when there
+   isn't room for everything — it ellipsizes rather than wrapping the row (see
+   the `is-done` rule below for what a completed one looks like). */
+.hearth-task-main {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	/* Zero basis: a flex item is broken onto the next line by its *content*
+	   width, so a long title would wrap the row however freely it can shrink
+	   afterwards. With no basis to overflow it stays put and shrinks instead. */
+	flex: 1 1 0;
+	min-width: 0;
+}
+
+/* The chips, held against the right edge. They keep their size until they alone
+   outgrow the row, at which point they wrap among themselves — the title is
+   already down to an ellipsis by then, and chips spilling past the card's edge
+   would be worse than a second line of them. */
+.hearth-task-metas {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	flex-wrap: wrap;
+	gap: 8px;
+	flex: 0 1 auto;
+	min-width: 0;
+	margin-left: auto;
+}
+
+/* A task with no chips at all shouldn't pay for the row's gap. */
+.hearth-task-metas:empty {
+	display: none;
+}
+
+/* The title takes only the width it needs, so anything drawn beside it (the
+   TaskNotes status chip, a Kanban card's column badge) sits against it rather
+   than being pushed to the far edge. */
 .hearth-task-text {
-	flex: 1;
+	flex: 0 1 auto;
+	min-width: 0;
 }
 
 .hearth-task.is-done .hearth-task-text {
@@ -3497,20 +3537,6 @@
    label rather than a field value. */
 .hearth-task-statuschip {
 	text-transform: capitalize;
-}
-
-/* The chip is left-aligned against the task title instead of drifting into the
-   right-hand chip cluster: the title stops filling the row, and the chip's auto
-   right margin pushes the priority and date chips to the far edge. The marker
-   class is set in renderTaskStatus() rather than matched with :has(), which is
-   avoided here for its broad selector-invalidation cost. */
-.hearth-task.has-statuschip .hearth-task-text {
-	flex: 0 1 auto;
-	min-width: 0;
-}
-
-.hearth-task.has-statuschip .hearth-task-statuschip {
-	margin-right: auto;
 }
 
 /* A completed task's status chip recedes with the rest of the row. */


### PR DESCRIPTION
## What does this PR do?

A task list row broke across two or three lines whenever the title didn't fit alongside its chips — the checkbox alone on one line, the title on the next, the status/priority/date chips on a third.

A row laid its checkbox, title and every chip out as siblings of one `flex-wrap: wrap` row. Flex breaks a line on an item's *content* width, before any shrinking happens, so `.hearth-task-text { flex: 1 }` (basis 0) never wrapped the row — but the legacy field path's `has-statuschip` rule overrode it with `flex: 0 1 auto` (basis = content width). A long title then didn't fit the first line and was pushed onto its own, taking the chips with it. **Customize task fields** never set `has-statuschip`, which is why only the standard mode was affected.

The row is now grouped: the checkbox, a `.hearth-task-main` group holding the title plus whatever sits beside it (the TaskNotes status chip, a Kanban column badge), and a `.hearth-task-metas` group gathering every other chip at the right edge. The title group has a zero flex basis so it never breaks the line, and the title is the only part that gives way — it ellipsizes. A description still gets its own line below the row. `has-statuschip` and `renderStatusChip()`'s `alignToTitle` parameter are removed: aligning the status chip to the title is what the title group now does structurally.

Verified by rendering the real `styles.css` against the old and new row DOM in a 355px-wide card in Chromium — row heights went from `[54, 77, 30, 30]` (the reported layout) to `[30, 30, 30, 30]`, with titles ellipsized and chips right-aligned.

## Related issue

Closes #156

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (lint clean — 27 pre-existing warnings, 0 errors; 269 tests pass)
- [x] I've tested this in an actual vault — not possible from this environment; layout was verified by rendering the shipped stylesheet against the real row markup in a headless browser

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pEKcvihmsRqpX5UcySZdK

---
_Generated by [Claude Code](https://claude.ai/code/session_019pEKcvihmsRqpX5UcySZdK)_