### PR TITLE
fix(tasks): stop the filter modal crushing the Status label (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,17 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **The task filter's Status row is readable again.** With more than a handful
+  of statuses — TaskNotes states, Kanban columns, your own checkbox statuses —
+  the chips took the whole row and squeezed the label down to *Sta…*, then
+  wrapped into a staggered, right-aligned block. Status and Priority now stack
+  their chips under the label and lay them out left to right, so the label stays
+  whole and the chips read as one strip however many there are. Two things that
+  went with it: a preset chip (**Overdue**, **High priority**, …) now shows when
+  it's on and a second click takes it back off, instead of only ever applying;
+  and a status your filter still selects but that no tasks use any more keeps
+  its chip, so you can switch it off rather than having to clear the whole
+  filter. Chips also report their on/off state to screen readers (#164).
 - **A task list keeps one task per line.** A task whose title didn't fit
   alongside its chips broke across two or three lines — the checkbox alone on
   one, the title on the next, its status, priority and dates on a third — so a

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -1594,12 +1594,23 @@ function renderTaskFilterControl(
 const TASK_PRIORITY_LEVELS: TaskPriorityLevel[] = ["high", "medium", "low", "none"];
 
 
+/** Paint a filter chip as on or off, and say so for screen readers — the
+ * accent fill is the only other cue that a chip is selected. */
+function setChipState(chip: HTMLElement, on: boolean): void {
+	chip.toggleClass("is-on", on);
+	chip.setAttribute("aria-pressed", String(on));
+}
+
+
 /** The filter modal: quick presets across the top, then editable criteria
  * (due, priority, status, text). Edits are applied on "Apply"; "Cancel"
  * discards them and "Clear" empties every field. */
 class TaskFilterModal extends Modal {
 	private working: TaskFilterConfig;
 	private body: HTMLElement | null = null;
+	/** Re-reads each preset chip's on/off state from `working`. Kept so a chip
+	 * or dropdown below can leave the presets showing the truth. */
+	private presetSyncs: (() => void)[] = [];
 
 	constructor(
 		app: App,
@@ -1627,22 +1638,47 @@ class TaskFilterModal extends Modal {
 		this.renderFooter(contentEl);
 	}
 
-	/** Preset chips that fill in the criteria below, then re-render the body. */
+	/** Preset chips that fill in the criteria below, then re-render the body.
+	 * Each one reads as on while the criteria below still match it, and a
+	 * second click takes it back off — a preset you can only apply, never
+	 * undo, reads as broken. */
 	private renderPresets(parent: HTMLElement): void {
 		const labels = t().cards.tasks.filterPresets;
 		const row = parent.createDiv("hearth-taskfilter-presets");
-		const preset = (label: string, apply: () => void) => {
-			const chip = row.createEl("button", { cls: "hearth-taskfilter-chip", text: label });
+		this.presetSyncs = [];
+		const preset = (label: string, isOn: () => boolean, apply: (on: boolean) => void) => {
+			const chip = row.createEl("button", { cls: "hearth-taskfilter-chip", attr: { type: "button" }, text: label });
+			const sync = () => setChipState(chip, isOn());
+			sync();
+			this.presetSyncs.push(sync);
 			chip.addEventListener("click", () => {
-				apply();
+				apply(!isOn());
 				this.renderBody();
+				this.syncPresets();
 			});
 		};
-		preset(labels.overdue, () => (this.working.due = "overdue"));
-		preset(labels.today, () => (this.working.due = "today"));
-		preset(labels.week, () => (this.working.due = "week"));
-		preset(labels.highPriority, () => (this.working.priorities = ["high"]));
-		preset(labels.noDate, () => (this.working.due = "noDate"));
+		const duePreset = (label: string, value: TaskDueFilter) =>
+			preset(label, () => this.working.due === value, (on) => {
+				this.working.due = on ? value : undefined;
+			});
+		duePreset(labels.overdue, "overdue");
+		duePreset(labels.today, "today");
+		duePreset(labels.week, "week");
+		preset(
+			labels.highPriority,
+			() => {
+				const levels = this.working.priorities ?? [];
+				return levels.length === 1 && levels[0] === "high";
+			},
+			(on) => {
+				this.working.priorities = on ? ["high"] : undefined;
+			},
+		);
+		duePreset(labels.noDate, "noDate");
+	}
+
+	private syncPresets(): void {
+		for (const sync of this.presetSyncs) sync();
 	}
 
 	/** The editable criteria; rebuilt whenever a preset or toggle changes them. */
@@ -1663,11 +1699,12 @@ class TaskFilterModal extends Modal {
 			d.setValue(this.working.due ?? "");
 			d.onChange((v) => {
 				this.working.due = v ? (v as TaskDueFilter) : undefined;
+				this.syncPresets();
 			});
 		});
 
 		// Priority buckets (multi-select chips).
-		const prioRow = new Setting(body).setName(labels.filterPriority);
+		const prioRow = new Setting(body).setName(labels.filterPriority).setClass("hearth-taskfilter-row");
 		const prioHost = prioRow.controlEl.createDiv("hearth-taskfilter-chips");
 		for (const level of TASK_PRIORITY_LEVELS) {
 			this.toggleChip(prioHost, labels.filterPriorityLevels[level], () => (this.working.priorities ?? []).includes(level), () => {
@@ -1679,10 +1716,11 @@ class TaskFilterModal extends Modal {
 		}
 
 		// Status/column chips (only when the source exposes statuses).
-		if (this.availableStatuses.length) {
-			const statusRow = new Setting(body).setName(labels.filterStatus);
+		const statuses = this.statusOptions();
+		if (statuses.length) {
+			const statusRow = new Setting(body).setName(labels.filterStatus).setClass("hearth-taskfilter-row");
 			const statusHost = statusRow.controlEl.createDiv("hearth-taskfilter-chips");
-			for (const status of this.availableStatuses) {
+			for (const status of statuses) {
 				this.toggleChip(statusHost, status, () => (this.working.statuses ?? []).some((s) => s.toLowerCase() === status.toLowerCase()), () => {
 					const cur = this.working.statuses ?? [];
 					const has = cur.some((s) => s.toLowerCase() === status.toLowerCase());
@@ -1699,13 +1737,32 @@ class TaskFilterModal extends Modal {
 		});
 	}
 
-	/** A single multi-select chip: reflects `isOn()` and flips it on click. */
+	/** The statuses to offer as chips: those the card's tasks actually use,
+	 * plus any the working filter still selects that no longer appear. Without
+	 * the second group a filter kept from an earlier state (a status renamed,
+	 * or its last task deleted) would go on hiding tasks with no chip left to
+	 * switch it off. */
+	private statusOptions(): string[] {
+		const out = [...this.availableStatuses];
+		const seen = new Set(out.map((s) => s.toLowerCase()));
+		for (const status of this.working.statuses ?? []) {
+			if (seen.has(status.toLowerCase())) continue;
+			seen.add(status.toLowerCase());
+			out.push(status);
+		}
+		return out;
+	}
+
+	/** A single multi-select chip: reflects `isOn()` and flips it on click.
+	 * Updated in place rather than by re-rendering the row, so the chip you
+	 * just clicked keeps keyboard focus. */
 	private toggleChip(host: HTMLElement, label: string, isOn: () => boolean, flip: () => void): void {
-		const chip = host.createEl("button", { cls: "hearth-taskfilter-chip", text: label });
-		chip.toggleClass("is-on", isOn());
+		const chip = host.createEl("button", { cls: "hearth-taskfilter-chip", attr: { type: "button" }, text: label });
+		setChipState(chip, isOn());
 		chip.addEventListener("click", () => {
 			flip();
-			chip.toggleClass("is-on", isOn());
+			setChipState(chip, isOn());
+			this.syncPresets();
 		});
 	}
 
@@ -1724,6 +1781,7 @@ class TaskFilterModal extends Modal {
 				b.setButtonText(t().cards.tasks.filterClear).onClick(() => {
 					this.working = {};
 					this.renderBody();
+					this.syncPresets();
 				}),
 			)
 			.addButton((b) => b.setButtonText(t().cards.tasks.cancel).onClick(() => this.close()));

--- a/styles.css
+++ b/styles.css
@@ -3979,6 +3979,22 @@ body.hearth-dv-resizing {
 	border-bottom: 1px solid var(--background-modifier-border);
 }
 
+/* Priority and status rows: a strip of chips, and status can carry a dozen
+   custom values (TaskNotes statuses, Kanban columns). Obsidian's side-by-side
+   .setting-item gives the control the room and squeezes the name into a sliver
+   — "Status" arrives as "Sta…" — then right-aligns the wrapped chips into a
+   staggered block (#164). Stack the chips under the label instead and run them
+   left-to-right, the way the other crowded settings in Hearth do. */
+.hearth-taskfilter-row {
+	display: block;
+}
+
+.hearth-taskfilter-row .setting-item-control {
+	margin-top: 8px;
+	justify-content: flex-start;
+	flex-wrap: wrap;
+}
+
 .hearth-taskfilter-chips {
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
## What does this PR do?

Obsidian's `.setting-item` puts a control to the right of its name, and the control takes the room it needs. The task filter modal's **Status** row hands it a strip of chips — one per status the card's tasks use, which with TaskNotes states or Kanban columns is easily a dozen — so the name collapsed to "Sta…" and the chips wrapped into a staggered, right-aligned block. Priority looked fine only because four chips happen to fit.

Both chip rows now carry `.hearth-taskfilter-row`, which stacks the control under the name and runs it left-to-right — the treatment `.hearth-setting-stacked` and `.hearth-rss-github` already give crowded settings for the same reason.

Reviewing the rest of the modal turned up two more things, fixed here:

- **Preset chips only ever applied.** Clicking **Overdue** set the due filter with no acknowledgement, and clicking it again did nothing to undo it. Presets now read as on while the criteria below still match them, and a second click clears them; the chips and dropdown below keep them in sync.
- **Status chips came only from the tasks currently loaded**, so a filter selecting a status nothing uses any more — renamed, or its last task gone — kept filtering with no chip left to switch it off, and only **Clear** got you out. The offered statuses are now those in use plus any the working filter still holds.

Chips also carry `aria-pressed`, matching the chips in `search.ts`, `recent.ts` and `stats.ts` — the accent fill was the only cue that one was selected.

## Related issue

Closes #164

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (`eslint src test` too: 27 pre-existing warnings, unchanged; 269 tests pass)
- [ ] I've tested this in an actual vault — **not done.** The layout was verified by reading the CSS against Hearth's existing stacked-setting patterns, not in a running Obsidian. Worth a look on the reporter's setup before release.

No test added: the modal lives in `src/cards/tasks.ts`, which the test shim can't import — that module's filter logic (`taskMatchesFilter`, `isTaskFilterActive`) is untested for the same reason, and extracting this into a tested module would be a larger refactor than the bug warrants.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhYd2Fdxow8GiTvxchYy6L)_