### PR TITLE
feat(behaviour): choose where Hearth opens notes (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,15 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   land somewhere different — a search hit taking over the Hearth tab while a
   link from a card opens beside it. Ctrl/Cmd-click still opens a new tab
   whatever the setting says, and the modifier combinations Obsidian understands
-  for a split or a window work here too (#106).
+  for a split or a window work here too.
+
+  A last row covers what Hearth doesn't control: **Notes opened from outside
+  Hearth** — the file explorer, the quick switcher, the graph — which Obsidian
+  hands to whichever tab is focused, taking a Hearth tab over. It still does by
+  default (the dashboard acts like an ordinary tab, and the explorer's selection
+  follows what you open), but set it to **A new tab** and the Hearth tab is left
+  alone. Links inside an embedded Bases table now follow the **Links** rule too,
+  instead of always replacing the dashboard (#106).
 - **An embedded note can be opened in its own tab.** Note embed cards have a new
   **Open button** toggle in their card settings; turned on, a button on the card
   opens the embedded file properly — following the open-behaviour setting above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
+- **Choose where Hearth opens notes.** Settings → Hearth → Behaviour → **Opening
+  notes** has a single **Open notes in** choice that governs every note Hearth
+  opens: **a new tab** (what it has always done), **the current tab**, which
+  replaces the home view so Hearth behaves like any other tab and the back
+  arrow brings it straight back, **a split pane**, or **a new window**. Four
+  optional rows under it take exceptions, each starting on *Same as above*, so
+  links, search results, notes listed in cards and notes Hearth creates can each
+  land somewhere different — a search hit taking over the Hearth tab while a
+  link from a card opens beside it. Ctrl/Cmd-click still opens a new tab
+  whatever the setting says, and the modifier combinations Obsidian understands
+  for a split or a window work here too (#106).
+- **An embedded note can be opened in its own tab.** Note embed cards have a new
+  **Open button** toggle in their card settings; turned on, a button on the card
+  opens the embedded file properly — following the open-behaviour setting above.
+  Off by default, so no existing board changes (#144).
+
 - **Build your own task fields.** Turn on **Customize task fields** under
   Settings → Hearth → Integrations and the fixed metadata Tasks cards show is
   replaced by fields you define yourself. You start from a blank slate — a task
@@ -145,6 +161,15 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   Inputs with an ordinary border, such as the Kanban editors and the task-detail
   description field, keep the theme's ring, since for them it is the focus
   affordance (#138).
+
+### Changed
+
+- **Links inside tasks now open where every other link does.** A `[[wikilink]]`
+  in a task's text took over the current tab, which in a Hearth tab meant
+  replacing the home view — while the same link on a card opened a new tab. Both
+  now follow **Open notes in** (a new tab by default). To keep tasks behaving as
+  they did, set **Links** under Settings → Hearth → Behaviour → Opening notes to
+  *The current tab* (#106).
 
 ## [1.17.0]
 

--- a/README.md
+++ b/README.md
@@ -436,9 +436,11 @@ many fields have a reset (↺) button back to their default.
   engine (built-in / Omnisearch), file-type filters.
 - **Dashboard** — fit to page, columns, row height, max width, card opacity,
   **card blur** (frosted glass).
-- **Behaviour** — open on startup, replace empty new tabs, mobile search-only,
-  mobile action bar, and a **Privacy & network** toggle to disable external
-  calls (Jira, calendars, RSS, and currency rates).
+- **Behaviour** — open on startup, replace empty new tabs, **where notes open**
+  (a new tab, the current tab replacing Hearth, a split, or a new window — with
+  per-source exceptions for links, search results, cards and new notes),
+  mobile search-only, mobile action bar, and a **Privacy & network** toggle to
+  disable external calls (Jira, calendars, RSS, and currency rates).
 - **Integrations** — Tasks / TaskNotes frontmatter field names and the status
   value(s) that count as "done".
 - **Backup** — import / export the current dashboard's layout as JSON.

--- a/README.md
+++ b/README.md
@@ -438,9 +438,10 @@ many fields have a reset (↺) button back to their default.
   **card blur** (frosted glass).
 - **Behaviour** — open on startup, replace empty new tabs, **where notes open**
   (a new tab, the current tab replacing Hearth, a split, or a new window — with
-  per-source exceptions for links, search results, cards and new notes),
-  mobile search-only, mobile action bar, and a **Privacy & network** toggle to
-  disable external calls (Jira, calendars, RSS, and currency rates).
+  per-source exceptions for links, search results, cards, new notes, and notes
+  opened from outside Hearth such as the file explorer), mobile search-only,
+  mobile action bar, and a **Privacy & network** toggle to disable external
+  calls (Jira, calendars, RSS, and currency rates).
 - **Integrations** — Tasks / TaskNotes frontmatter field names and the status
   value(s) that count as "done".
 - **Backup** — import / export the current dashboard's layout as JSON.

--- a/src/cardbodies.ts
+++ b/src/cardbodies.ts
@@ -4,6 +4,7 @@ import { type CheckboxScanOptions, countCheckboxes, toggleCheckboxAt } from "./c
 import { localDayKey } from "./dates";
 import { t } from "./i18n";
 import { mountMarkdownEditor } from "./leafview";
+import { openLink } from "./opener";
 import { type DashboardCard, type EmbedView } from "./types";
 import { type HomeView } from "./view";
 
@@ -169,7 +170,7 @@ export function wireMarkdownLinks(view: HomeView, host: HTMLElement, sourcePath:
 			const linktext = anchor.getAttribute("data-href") || anchor.getAttribute("href");
 			if (linktext) {
 				evt.preventDefault();
-				void view.app.workspace.openLinkText(linktext, sourcePath, true);
+				void openLink(view, linktext, sourcePath, "link", evt);
 			}
 		}
 	});

--- a/src/cardbodies.ts
+++ b/src/cardbodies.ts
@@ -4,7 +4,7 @@ import { type CheckboxScanOptions, countCheckboxes, toggleCheckboxAt } from "./c
 import { localDayKey } from "./dates";
 import { t } from "./i18n";
 import { mountMarkdownEditor } from "./leafview";
-import { openLink } from "./opener";
+import { internalLinkText, openLink } from "./opener";
 import { type DashboardCard, type EmbedView } from "./types";
 import { type HomeView } from "./view";
 
@@ -166,12 +166,17 @@ export function wireMarkdownLinks(view: HomeView, host: HTMLElement, sourcePath:
 			return;
 		}
 
-		if (anchor.classList.contains("internal-link")) {
-			const linktext = anchor.getAttribute("data-href") || anchor.getAttribute("href");
-			if (linktext) {
-				evt.preventDefault();
-				void openLink(view, linktext, sourcePath, "link", evt);
-			}
+		// Not gated on the `internal-link` class: an embedded Bases view (and
+		// other plugin-rendered content) draws note links without it, and those
+		// clicks would otherwise fall through to Obsidian's own handler, which
+		// always takes over the tab the click came from — the Hearth tab (#106).
+		const linktext = internalLinkText(
+			anchor.getAttribute("data-href"),
+			anchor.getAttribute("href"),
+		);
+		if (linktext) {
+			evt.preventDefault();
+			void openLink(view, linktext, sourcePath, "link", evt);
 		}
 	});
 }

--- a/src/cards/bookmarks.ts
+++ b/src/cards/bookmarks.ts
@@ -3,6 +3,7 @@ import { emptyState } from "../cardbodies";
 import { applyFileIcon, fileIconOptions, resolveFileIcon } from "../fileicons";
 import { t } from "../i18n";
 import { type BookmarkItem } from "../obsidian-ext";
+import { openFile } from "../opener";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
 import { type CardDefinition } from "./definition";
@@ -187,7 +188,7 @@ function openBookmark(view: HomeView, item: BookmarkItem): void {
 	}
 	if (item.path) {
 		const file = view.app.vault.getAbstractFileByPath(item.path);
-		if (file instanceof TFile) void view.app.workspace.getLeaf(true).openFile(file);
+		if (file instanceof TFile) void openFile(view, file, "card");
 	}
 }
 

--- a/src/cards/calendar.ts
+++ b/src/cards/calendar.ts
@@ -34,6 +34,7 @@ import {
 } from "../eventnote";
 import { t } from "../i18n";
 import { cachedCalendar, eventsByDay, expandEvents, loadCalendar, type IcsOccurrence } from "../ics";
+import { openFile } from "../opener";
 import { FilePickerModal } from "../pickers";
 import { type CalendarConfig, type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
@@ -241,7 +242,7 @@ function openDailyNote(
 	isToday: boolean,
 ): void {
 	if (file instanceof TFile) {
-		void view.app.workspace.getLeaf(true).openFile(file);
+		void openFile(view, file, "card");
 	} else if (!options) {
 		// Calendar-only card: nothing to open or create.
 	} else if (isToday) {
@@ -250,7 +251,7 @@ function openDailyNote(
 		}
 	} else {
 		void createDailyNoteAt(view, day, options).then((created) => {
-			if (created) void view.app.workspace.getLeaf(true).openFile(created);
+			if (created) void openFile(view, created, "newNote");
 			else new Notice(t().notices.couldNotCreateNoteForDay(day.format("MMM D, YYYY")));
 		});
 	}
@@ -269,7 +270,7 @@ function eventTimeLabel(ev: IcsOccurrence): string {
 /** Open the full event-details modal — the "view this event" action from the
  * day picker and the agenda. */
 function showEventDetail(view: HomeView, ev: IcsOccurrence, ics: IcsContext): void {
-	new EventDetailModal(view.app, ev, ics).open();
+	new EventDetailModal(view, ev, ics).open();
 }
 
 
@@ -298,11 +299,11 @@ function eventDateLabel(ev: IcsOccurrence): string {
  * simply skipped, so a bare event shows just its name and when. */
 class EventDetailModal extends Modal {
 	constructor(
-		app: App,
+		private readonly view: HomeView,
 		private readonly ev: IcsOccurrence,
 		private readonly ics: IcsContext,
 	) {
-		super(app);
+		super(view.app);
 	}
 
 	onOpen(): void {
@@ -365,13 +366,13 @@ class EventDetailModal extends Modal {
 		});
 		btn.addEventListener("click", () => {
 			if (existing instanceof TFile) {
-				void this.app.workspace.getLeaf(true).openFile(existing);
+				void openFile(this.view, existing, "card");
 				this.close();
 				return;
 			}
 			void createEventNote(this.app, this.ev, this.ics).then((file) => {
 				if (file) {
-					void this.app.workspace.getLeaf(true).openFile(file);
+					void openFile(this.view, file, "newNote");
 					this.close();
 				} else {
 					new Notice(t().notices.couldNotCreateEventNote);

--- a/src/cards/daily.ts
+++ b/src/cards/daily.ts
@@ -10,6 +10,7 @@ import {
 	watchedCardPath,
 } from "../cardbodies";
 import { t } from "../i18n";
+import { openFile } from "../opener";
 import { type DashboardCard } from "../types";
 import { type HomeView } from "../view";
 import { type CardDefinition, type CardEditorContext } from "./definition";
@@ -65,7 +66,7 @@ export function renderDaily(
 		});
 		setIcon(open, "square-pen");
 		open.addEventListener("click", () => {
-			void view.app.workspace.getLeaf(true).openFile(file);
+			void openFile(view, file, "card");
 		});
 	}
 

--- a/src/cards/embed.ts
+++ b/src/cards/embed.ts
@@ -1,4 +1,4 @@
-import { Component, MarkdownRenderer, Setting, TFile } from "obsidian";
+import { Component, MarkdownRenderer, setIcon, Setting, TFile } from "obsidian";
 import { isBaseTarget, isEmbeddableBaseViewName, listBaseViews } from "../bases";
 import {
 	activeEmbedIndex,
@@ -14,6 +14,7 @@ import {
 } from "../cardbodies";
 import { EXCALIDRAW_PLUGIN_ID, isExcalidraw } from "../filetypes";
 import { t } from "../i18n";
+import { openFile } from "../opener";
 import { FilePickerModal } from "../pickers";
 import { type DashboardCard, type EmbedView } from "../types";
 import { type HomeView } from "../view";
@@ -70,6 +71,13 @@ export function renderEmbed(
 			return;
 		}
 	}
+
+	// An embedded note is read (and often edited) right here on the board, so
+	// there was no way to get to it in its own tab (#144). This optional overlay
+	// button is that way. Off unless asked for — unlike the Daily card's button,
+	// which predates the setting and stays on by default — so no existing board
+	// grows a control it never had.
+	if (card.showOpenButton === true) renderEmbedOpenButton(view, file, body);
 
 	const ext = file.extension.toLowerCase();
 	const isMarkdown = ext === "md" || ext === "markdown";
@@ -188,6 +196,24 @@ export function mountEmbedViewSwitcher(
 // can be owned by its module. Each takes a CardEditorContext instead of the
 // modal's `this`. Phase B relocates these into src/cards/<kind>/.
 
+/** The "open this file in a tab" button, floated over the card like the Daily
+ * card's. It lives on the card element rather than the body so it doesn't take
+ * part in the body's scroll or flow. Where the file lands follows the global
+ * open-behaviour setting (#106). */
+function renderEmbedOpenButton(view: HomeView, file: TFile, body: HTMLElement): void {
+	const cardEl = body.closest(".hearth-card");
+	const overlay = (cardEl ?? body).createDiv("hearth-card-actions-overlay");
+	const open = overlay.createEl("button", {
+		cls: "hearth-open-btn",
+		attr: { "aria-label": t().cards.embed.openFile },
+	});
+	setIcon(open, "square-arrow-out-up-right");
+	open.addEventListener("click", (evt) => {
+		void openFile(view, file, "card", evt);
+	});
+}
+
+
 export function embedEditor(ctx: CardEditorContext, containerEl: HTMLElement): void {
 	const card = ctx.card;
 	const setting = new Setting(containerEl)
@@ -255,6 +281,16 @@ export function embedEditor(ctx: CardEditorContext, containerEl: HTMLElement): v
 			}),
 		);
 	if (card.editable) livePreviewSetting(ctx, containerEl, card);
+	new Setting(containerEl)
+		.setName(t().editors.embed.openButton)
+		.setDesc(t().editors.embed.openButtonDesc)
+		.addToggle((tg) =>
+			tg.setValue(card.showOpenButton === true).onChange((v) => {
+				card.showOpenButton = v || undefined;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			}),
+		);
 	// Hide-base-header is only relevant to .base embeds; shown when either
 	// view targets one.
 	if (isBaseTarget(card.target) || isBaseTarget(card.secondView?.target)) {

--- a/src/cards/embed.ts
+++ b/src/cards/embed.ts
@@ -11,6 +11,7 @@ import {
 	renderLivePreviewEmbed,
 	renderMarkdownFile,
 	watchedCardPath,
+	wireMarkdownLinks,
 } from "../cardbodies";
 import { EXCALIDRAW_PLUGIN_ID, isExcalidraw } from "../filetypes";
 import { t } from "../i18n";
@@ -119,6 +120,12 @@ export function renderEmbed(
 		const embedTarget =
 			ext === "base" && isEmbeddableBaseViewName(baseView) ? `${target}#${baseView}` : target;
 		void MarkdownRenderer.render(view.app, `![[${embedTarget}]]`, host, target, component);
+		// A transclusion renders content that resolves its own links — a Bases
+		// table's note column, most of all. Left alone, those clicks go to
+		// Obsidian's default handler, which opens into the tab the click came
+		// from, i.e. this Hearth tab, whatever the open-behaviour setting says
+		// (#106). Delegated from the host, so it survives the async render above.
+		wireMarkdownLinks(view, host, target);
 
 		// Canvas and Excalidraw embeds are natively interactive (pan/zoom, and
 		// their own in-place edit toggle) — let them fill the card edge-to-edge

--- a/src/cards/favorites.ts
+++ b/src/cards/favorites.ts
@@ -3,6 +3,7 @@ import { emptyState } from "../cardbodies";
 import { moveItem } from "../editors";
 import { applyFileIcon, fileIconOptions, resolveFileIcon } from "../fileicons";
 import { t } from "../i18n";
+import { openFile } from "../opener";
 import { FilePickerModal } from "../pickers";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -26,7 +27,7 @@ export function renderFavorites(view: HomeView, body: HTMLElement): void {
 		if (file instanceof TFile) {
 			applyFileIcon(card.createDiv("hearth-fav-icon"), resolveFileIcon(view.app, file, icons));
 			card.createDiv({ cls: "hearth-fav-name", text: file.basename });
-			const open = () => void view.app.workspace.getLeaf(true).openFile(file);
+			const open = () => void openFile(view, file, "card");
 			card.addEventListener("click", open);
 			makeClickable(card, open, file.basename);
 		} else {

--- a/src/cards/heatmap.ts
+++ b/src/cards/heatmap.ts
@@ -1,6 +1,7 @@
 import { Setting } from "obsidian";
 import { activityByDay, createDailyNoteAt, dailyNotesOptions, heatLevel, moment } from "../cardbodies";
 import { t } from "../i18n";
+import { openFile } from "../opener";
 import { type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -54,7 +55,7 @@ export function renderHeatmap(view: HomeView, card: DashboardCard, body: HTMLEle
 			if (options) {
 				const activate = () => {
 					void createDailyNoteAt(view, day, options).then((f) => {
-						if (f) void view.app.workspace.getLeaf(true).openFile(f);
+						if (f) void openFile(view, f, "card");
 					});
 				};
 				cellEl.addEventListener("click", activate);

--- a/src/cards/links.ts
+++ b/src/cards/links.ts
@@ -2,6 +2,7 @@ import { setTooltip, Setting, TFile } from "obsidian";
 import { applyTileSize, emptyState, makeTileDraggable, makeTileResizable, markOverlappingTiles } from "../cardbodies";
 import { moveItem } from "../editors";
 import { t } from "../i18n";
+import { openFile, openLink as openLinkTarget } from "../opener";
 import { CommandPickerModal } from "../pickers";
 import { addIconHelp, applyTileVisual } from "../widgeticon";
 import { type DashboardCard, type LinkItem } from "../types";
@@ -68,8 +69,8 @@ function openLink(view: HomeView, link: LinkItem): void {
 			break;
 		case "note": {
 			const file = view.app.vault.getAbstractFileByPath(link.target);
-			if (file instanceof TFile) void view.app.workspace.getLeaf(true).openFile(file);
-			else if (link.target) void view.app.workspace.openLinkText(link.target, "", true);
+			if (file instanceof TFile) void openFile(view, file, "link");
+			else if (link.target) void openLinkTarget(view, link.target, "", "link");
 			break;
 		}
 	}

--- a/src/cards/recent.ts
+++ b/src/cards/recent.ts
@@ -4,6 +4,7 @@ import { addResetButton } from "../editors";
 import { applyFileIcon, fileIconOptions, resolveFileIcon } from "../fileicons";
 import { FILE_TYPE_GROUPS, fileTypeLabel, FOLDERS_GROUP_ID, groupForFile } from "../filetypes";
 import { t } from "../i18n";
+import { openFile } from "../opener";
 import { type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -41,7 +42,7 @@ export function renderRecent(view: HomeView, card: DashboardCard, body: HTMLElem
 		const row = list.createDiv("hearth-list-item");
 		applyFileIcon(row.createDiv("hearth-list-icon"), resolveFileIcon(view.app, file, icons));
 		row.createDiv({ cls: "hearth-list-label", text: file.basename });
-		const open = () => void view.app.workspace.getLeaf(true).openFile(file);
+		const open = () => void openFile(view, file, "card");
 		row.addEventListener("click", open);
 		makeClickable(row, open, file.basename);
 	}

--- a/src/cards/search.ts
+++ b/src/cards/search.ts
@@ -3,6 +3,7 @@ import { emptyState } from "../cardbodies";
 import { addResetButton } from "../editors";
 import { applyFileIcon, fileIconOptions, resolveFileIcon } from "../fileicons";
 import { t } from "../i18n";
+import { openFile } from "../opener";
 import { runQuery, searchFileContents, type QueryHit } from "../query";
 import { type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
@@ -66,7 +67,7 @@ function renderQueryList(view: HomeView, body: HTMLElement, list: QueryHit[]): v
 		row.createDiv({ cls: "hearth-list-label", text: name });
 		if (hit.badge) row.createDiv({ cls: "hearth-task-status", text: hit.badge.label });
 		const open = () => {
-			if (hit.file instanceof TFile) void view.app.workspace.getLeaf(true).openFile(hit.file);
+			if (hit.file instanceof TFile) void openFile(view, hit.file, "search");
 		};
 		row.addEventListener("click", open);
 		makeClickable(row, open, name);
@@ -88,7 +89,7 @@ function renderQueryTiles(view: HomeView, body: HTMLElement, list: QueryHit[]): 
 		const name = hit.file instanceof TFile ? hit.file.basename : hit.file.name;
 		tile.createDiv({ cls: "hearth-link-label", text: name });
 		const open = () => {
-			if (hit.file instanceof TFile) void view.app.workspace.getLeaf(true).openFile(hit.file);
+			if (hit.file instanceof TFile) void openFile(view, hit.file, "search");
 		};
 		tile.addEventListener("click", open);
 		makeClickable(tile, open, name);

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -16,6 +16,7 @@ import { emptyState, moment } from "../cardbodies";
 import { formatRelativeDate, parseNaturalDate } from "../dates";
 import { addResetButton } from "../editors";
 import { t } from "../i18n";
+import { openFile, openLink, targetLeaf } from "../opener";
 import { FilePickerModal } from "../pickers";
 import {
 	PRIORITY_EMOJI,
@@ -3733,7 +3734,7 @@ function fillTaskText(view: HomeView, el: HTMLElement, text: string, sourcePath:
 			link.addEventListener("click", (ev) => {
 				ev.stopPropagation();
 				ev.preventDefault();
-				void view.app.workspace.openLinkText(target.trim(), sourcePath, false);
+				void openLink(view, target.trim(), sourcePath, "link", ev);
 			});
 		} else {
 			const link = el.createSpan({ cls: "hearth-task-link", text: m[2] });
@@ -3742,7 +3743,7 @@ function fillTaskText(view: HomeView, el: HTMLElement, text: string, sourcePath:
 				ev.stopPropagation();
 				ev.preventDefault();
 				if (/^https?:\/\//i.test(url)) window.open(url, "_blank");
-				else void view.app.workspace.openLinkText(url, sourcePath, false);
+				else void openLink(view, url, sourcePath, "link", ev);
 			});
 		}
 		last = re.lastIndex;
@@ -4605,13 +4606,13 @@ async function openTask(view: HomeView, cfg: TasksConfig, hit: TaskHit, refresh:
 async function openTaskFile(view: HomeView, hit: TaskHit): Promise<void> {
 	// A card that links to a note opens that note directly (not the board line).
 	if (hit.linkedFile) {
-		await view.app.workspace.getLeaf(true).openFile(hit.linkedFile);
+		await openFile(view, hit.linkedFile, "card");
 		return;
 	}
 	// TaskNotes tasks (no line) open in TaskNotes' own editor when possible.
 	if (hit.line < 0 && (await openInTaskNotes(view, hit.file))) return;
 
-	const leaf = view.app.workspace.getLeaf(true);
+	const leaf = targetLeaf(view, "card");
 	// Scroll to the task's line via ephemeral state rather than a setCursor call
 	// right after openFile: in a freshly created leaf the editor isn't laid out
 	// yet, so an immediate scroll is discarded and the note opens at the top

--- a/src/header.ts
+++ b/src/header.ts
@@ -120,7 +120,7 @@ function createNewNoteButton(view: HomeView): HTMLElement {
 	setIcon(btn.createSpan("hearth-newnote-icon"), "plus");
 	btn.createSpan({ cls: "hearth-newnote-label", text: t().header.newNote });
 	btn.addEventListener("click", () => {
-		void view.plugin.createNewNote();
+		void view.plugin.createNewNote(view);
 	});
 	return btn;
 }

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -18,9 +18,11 @@ import {
 	type JiraControl,
 	newDashboardId,
 	OPEN_IN_MODES,
+	OPEN_OUTSIDE_RULES,
 	OPEN_SOURCES,
 	type OpenIn,
 	type OpenInRule,
+	type OpenOutsideRule,
 	type RssConfig,
 	type RssSource,
 	type SavedSearchConfig,
@@ -141,6 +143,7 @@ export function exportSettings(s: HomeSettings): string {
 		disableExternalCalls: s.disableExternalCalls,
 		openIn: s.openIn,
 		openInOverrides: s.openInOverrides,
+		openFromOutside: s.openFromOutside,
 
 		// Appearance
 		compact: s.compact,
@@ -1085,6 +1088,9 @@ function sanitizeMobileActionButton(raw: unknown): MobileActionButton | null {
  * into a partial map — imports what it can and leaves the rest alone. */
 function applyOpenIn(s: HomeSettings, data: Record<string, unknown>): void {
 	if (OPEN_IN_MODES.includes(data.openIn as OpenIn)) s.openIn = data.openIn as OpenIn;
+	if (OPEN_OUTSIDE_RULES.includes(data.openFromOutside as OpenOutsideRule)) {
+		s.openFromOutside = data.openFromOutside as OpenOutsideRule;
+	}
 	const raw = data.openInOverrides;
 	if (!raw || typeof raw !== "object") return;
 	const map = raw as Record<string, unknown>;

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -17,6 +17,10 @@ import {
 	type JiraConfig,
 	type JiraControl,
 	newDashboardId,
+	OPEN_IN_MODES,
+	OPEN_SOURCES,
+	type OpenIn,
+	type OpenInRule,
 	type RssConfig,
 	type RssSource,
 	type SavedSearchConfig,
@@ -135,6 +139,8 @@ export function exportSettings(s: HomeSettings): string {
 		showMobileActionBar: s.showMobileActionBar,
 		mobileActionButtons: s.mobileActionButtons,
 		disableExternalCalls: s.disableExternalCalls,
+		openIn: s.openIn,
+		openInOverrides: s.openInOverrides,
 
 		// Appearance
 		compact: s.compact,
@@ -1074,6 +1080,25 @@ function sanitizeMobileActionButton(raw: unknown): MobileActionButton | null {
 
 /** Apply the non-layout settings carried by a full settings export, each field
  * validated/clamped so an untrusted backup can only set values the UI could. */
+/** Where notes open (#106). The global choice and each per-source rule are
+ * validated on their own, so a file from another version — or one hand-edited
+ * into a partial map — imports what it can and leaves the rest alone. */
+function applyOpenIn(s: HomeSettings, data: Record<string, unknown>): void {
+	if (OPEN_IN_MODES.includes(data.openIn as OpenIn)) s.openIn = data.openIn as OpenIn;
+	const raw = data.openInOverrides;
+	if (!raw || typeof raw !== "object") return;
+	const map = raw as Record<string, unknown>;
+	const overrides = { ...s.openInOverrides };
+	for (const source of OPEN_SOURCES) {
+		const rule = map[source];
+		if (rule === "default" || OPEN_IN_MODES.includes(rule as OpenIn)) {
+			overrides[source] = rule as OpenInRule;
+		}
+	}
+	s.openInOverrides = overrides;
+}
+
+
 function applySettings(s: HomeSettings, data: Record<string, unknown>): void {
 	// Header
 	const title = str(data.title);
@@ -1133,6 +1158,7 @@ function applySettings(s: HomeSettings, data: Record<string, unknown>): void {
 	}
 	if (typeof data.disableExternalCalls === "boolean")
 		s.disableExternalCalls = data.disableExternalCalls;
+	applyOpenIn(s, data);
 
 	// Appearance
 	if (typeof data.compact === "boolean") s.compact = data.compact;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -267,6 +267,8 @@ export const en = {
 				"Transparency and frosted-glass blur applied to every card.",
 			startup: "Startup & tabs",
 			startupDesc: "When and where the home view opens.",
+			opening: "Opening notes",
+			openingDesc: "Where a note opens when you click it in Hearth.",
 			mobileMode: "Mobile mode",
 			mobileModeDesc: "How Hearth behaves on phones and tablets.",
 			privacy: "Privacy & network",
@@ -385,6 +387,32 @@ export const en = {
 			disableExternalCallsDesc:
 				"Block all outbound network requests Hearth makes, including Jira, " +
 				"external calendars, RSS feeds, and the calculator's currency-rate lookup.",
+			openIn: "Open notes in",
+			openInDesc:
+				"Where a note goes when you open one from Hearth. \"Current tab\" replaces " +
+				"the home view, so Hearth behaves like any other tab. Ctrl/Cmd-click always " +
+				"opens a new tab regardless.",
+			openInModes: {
+				tab: "A new tab",
+				same: "The current tab (replace Hearth)",
+				split: "A split pane",
+				window: "A new window",
+			},
+			/** The extra choice each per-source dropdown offers on top of the four
+			 * destinations: follow whatever "Open notes in" is set to. */
+			openInFollow: "Same as above",
+			openInSources: {
+				link: "Links",
+				linkDesc: "Links inside notes, tasks and the Links card.",
+				search: "Search results",
+				searchDesc: "Hits from the search bar and the Search card.",
+				card: "Notes in cards",
+				cardDesc:
+					"Notes listed by Recent, Bookmarks, Favourites, Calendar, Heatmap and " +
+					"Tasks cards, and by mobile action buttons.",
+				newNote: "Notes Hearth creates",
+				newNoteDesc: "New notes, daily notes and event notes, opened as they're made.",
+			},
 		},
 		mobileActions: {
 			heading: "Mobile action bar",
@@ -614,6 +642,9 @@ export const en = {
 			secondViewFileDesc:
 				"Optional. When set, the card shows a switcher between the two views — in the header when the card has a title, or floating (on hover) when it doesn't.",
 			secondViewClear: "Remove second view",
+			openButton: "Open button",
+			openButtonDesc:
+				"Show a button that opens the embedded file in its own tab (#144). Off by default.",
 		},
 		daily: {
 			editable: "Editable",
@@ -1211,6 +1242,7 @@ export const en = {
 				"This view isn't available — enable the plugin that provides it",
 		},
 		embed: {
+			openFile: "Open this file",
 			editHint: "Double-click to edit",
 			emptyNotePlaceholder: "Empty note…",
 			emptyNoteHint: "Empty note — double-click to edit",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -413,6 +413,16 @@ export const en = {
 				newNote: "Notes Hearth creates",
 				newNoteDesc: "New notes, daily notes and event notes, opened as they're made.",
 			},
+			openFromOutside: "Notes opened from outside Hearth",
+			openFromOutsideDesc:
+				"The file explorer, the quick switcher, the graph — and anything a card " +
+				"embeds that opens links itself. Obsidian hands those to whichever tab " +
+				"is focused, so a Hearth tab gets taken over. Choose \"a new tab\" to keep " +
+				"the Hearth tab; the file explorer then stops following what you open.",
+			openFromOutsideModes: {
+				same: "The current tab (replace Hearth)",
+				tab: "A new tab (keep Hearth open)",
+			},
 		},
 		mobileActions: {
 			heading: "Mobile action bar",

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
 	hearthIconIdFor,
 } from "./icon";
 import type { WorkspacesInstance } from "./obsidian-ext";
+import { openFile } from "./opener";
 import { EXCALIDRAW_PLUGIN_ID } from "./filetypes";
 import { setLanguage, t } from "./i18n";
 import { maybeShowWhatsNew } from "./whatsnew";
@@ -252,16 +253,22 @@ export default class HearthPlugin extends Plugin {
 		await workspace.revealLeaf(leaf);
 	}
 
-	/** Create a new note in the user's configured default location and open it. */
-	async createNewNote() {
+	/** Create a new note in the user's configured default location and open it.
+	 * `from` is the view the "New note" button was pressed in, so the note can
+	 * replace that Hearth tab when the user asked for "same tab" (#106); the
+	 * command palette has no view and falls back to the active leaf. */
+	async createNewNote(from?: HomeView) {
 		try {
 			const parent = this.app.fileManager.getNewFileParent("");
 			const file = await this.app.fileManager.createNewMarkdownFile(
 				parent instanceof TFolder ? parent : this.app.vault.getRoot(),
 				"Untitled",
 			);
-			const leaf = this.app.workspace.getLeaf(true);
-			await leaf.openFile(file);
+			await openFile(
+				from ?? { app: this.app, settings: this.settings },
+				file,
+				"newNote",
+			);
 		} catch (err) {
 			// Fall back to the core command if the internal API shape changes.
 			if (!this.app.commands.executeCommandById("file-explorer:new-file")) {

--- a/src/mobileactions.ts
+++ b/src/mobileactions.ts
@@ -1,4 +1,5 @@
 import { setIcon, TFile } from "obsidian";
+import { openFile, openLink } from "./opener";
 import type { HomeView } from "./view";
 import type { MobileActionButton } from "./types";
 
@@ -48,8 +49,8 @@ function runMobileAction(view: HomeView, btn: MobileActionButton): void {
 			break;
 		case "note": {
 			const file = view.app.vault.getAbstractFileByPath(target);
-			if (file instanceof TFile) void view.app.workspace.getLeaf(true).openFile(file);
-			else void view.app.workspace.openLinkText(target, "", true);
+			if (file instanceof TFile) void openFile(view, file, "card");
+			else void openLink(view, target, "", "card");
 			break;
 		}
 		case "command":

--- a/src/opener.ts
+++ b/src/opener.ts
@@ -77,6 +77,47 @@ export function resolveOpenIn(settings: HomeSettings, source: OpenSource): OpenI
 	return OPEN_IN_MODES.includes(mode) ? mode : "tab";
 }
 
+/**
+ * Whether the Hearth view should report itself as navigable.
+ *
+ * Obsidian reuses the focused leaf for a file opened from the file explorer,
+ * the quick switcher or the graph — but only when the view in it says it is
+ * navigable. That is the only lever Hearth has over those opens, since the
+ * click never reaches Hearth's own code (the same goes for a view embedded in a
+ * card that resolves links itself, such as an embedded Bases table).
+ *
+ * Defaults to navigable, which is the behaviour since #84: the dashboard acts
+ * like an ordinary tab, so the explorer's selection follows what you open
+ * instead of getting stuck on a note in a tab you can't see.
+ */
+export function hearthLeafIsNavigable(settings: HomeSettings): boolean {
+	const rule = settings.openFromOutside;
+	if (rule === "same") return true;
+	if (rule === "tab") return false;
+	// "default" (and any unknown value) follows the global choice — not a
+	// per-source rule, since Hearth never sees which kind of click this was.
+	// Only "the current tab" means Hearth is there to be taken over.
+	return settings.openIn === "same";
+}
+
+/**
+ * The vault link an anchor points at, or null when it isn't one.
+ *
+ * `data-href` is what Obsidian's Markdown renderer emits, but content rendered
+ * by other things inside a card — an embedded Bases view, a plugin's own
+ * output — doesn't always carry it, or the `internal-link` class, so a plain
+ * relative `href` counts too. Anything with a URL scheme (`https:`, `mailto:`,
+ * `obsidian:`) belongs to the external-link path, and a fragment-only href is a
+ * footnote or heading jump within the rendered content rather than a link to a
+ * note.
+ */
+export function internalLinkText(dataHref: string | null, href: string | null): string | null {
+	if (dataHref) return dataHref;
+	if (!href || href.startsWith("#")) return null;
+	if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return null;
+	return href;
+}
+
 /** Resolve the modifier state for an open: the triggering event when the caller
  * has one, otherwise the last user interaction Obsidian recorded — which is how
  * commands see modifier keys they were never handed. */

--- a/src/opener.ts
+++ b/src/opener.ts
@@ -1,0 +1,133 @@
+import { Keymap, type App, type OpenViewState, type PaneType, type TFile, type UserEvent, type WorkspaceLeaf } from "obsidian";
+import {
+	OPEN_IN_MODES,
+	type HomeSettings,
+	type OpenIn,
+	type OpenSource,
+} from "./types";
+
+/**
+ * One place that decides *where* a note Hearth opens ends up (#106).
+ *
+ * Every "open this note" path in the plugin used to hard-code
+ * `workspace.getLeaf(true)` — always a new tab. They all route through here
+ * instead, so a single Behaviour setting (plus optional per-source exceptions)
+ * governs the lot, and a Mod-click still wins over any of it exactly like it
+ * does everywhere else in Obsidian.
+ */
+
+/** What Hearth needs to know to open something: the app, the settings, and the
+ * leaf the click came from (so "same tab" replaces *that* view rather than
+ * whichever tab happens to be focused). */
+export interface OpenHost {
+	app: App;
+	settings: HomeSettings;
+	/** The leaf hosting the view that was clicked, when the caller knows it. */
+	leaf?: WorkspaceLeaf | null;
+}
+
+/** Structural shape of a Hearth view — matched by `HomeView` without importing
+ * it, which would make this module part of the view's import cycle. */
+interface HearthViewLike {
+	app: App;
+	leaf: WorkspaceLeaf;
+	plugin: { settings: HomeSettings };
+}
+
+/** Anything the open helpers accept: a Hearth view, or a hand-built host for
+ * the few callers (modals, the plugin itself) that have no view. */
+export type OpenFrom = OpenHost | HearthViewLike;
+
+function host(from: OpenFrom): OpenHost {
+	return "plugin" in from
+		? { app: from.app, settings: from.plugin.settings, leaf: from.leaf }
+		: from;
+}
+
+/**
+ * The destination for one open: either reuse the leaf Hearth is in, or hand a
+ * pane type to `getLeaf`/`openLinkText`. Kept separate from the workspace calls
+ * so the decision itself is pure and testable.
+ */
+export type OpenTarget = { kind: "reuse" } | { kind: "pane"; pane: PaneType };
+
+/**
+ * Which destination a mode implies, given the modifier keys held at the time.
+ *
+ * `mod` is whatever {@link Keymap.isModEvent} reported: `false` for a plain
+ * click, a {@link PaneType} when the modifier combination names one, or `true`
+ * for a bare Mod-click. A modifier always overrides the setting — Mod-click
+ * means "new tab" throughout Obsidian, and Hearth must not be the exception.
+ */
+export function openTarget(mode: OpenIn, mod: PaneType | boolean = false): OpenTarget {
+	if (mod) return { kind: "pane", pane: mod === true ? "tab" : mod };
+	if (mode === "same") return { kind: "reuse" };
+	if (mode === "split" || mode === "window") return { kind: "pane", pane: mode };
+	return { kind: "pane", pane: "tab" };
+}
+
+/**
+ * The mode that applies to one kind of click: the source's own rule when it has
+ * one, otherwise the global choice. Falls back to `"tab"` — Hearth's historical
+ * behaviour — for any value a hand-edited or future settings file might hold.
+ */
+export function resolveOpenIn(settings: HomeSettings, source: OpenSource): OpenIn {
+	const rule = settings.openInOverrides?.[source];
+	const mode = rule && rule !== "default" ? rule : settings.openIn;
+	return OPEN_IN_MODES.includes(mode) ? mode : "tab";
+}
+
+/** Resolve the modifier state for an open: the triggering event when the caller
+ * has one, otherwise the last user interaction Obsidian recorded — which is how
+ * commands see modifier keys they were never handed. */
+function modifiers(h: OpenHost, evt?: UserEvent | null): PaneType | boolean {
+	return Keymap.isModEvent(evt ?? h.app.lastEvent);
+}
+
+/** The leaf a note should open in. Exported for callers that need the leaf
+ * itself (to scroll it, or to read its view back). */
+export function targetLeaf(from: OpenFrom, source: OpenSource, evt?: UserEvent | null): WorkspaceLeaf {
+	const h = host(from);
+	const target = openTarget(resolveOpenIn(h.settings, source), modifiers(h, evt));
+	if (target.kind === "pane") return h.app.workspace.getLeaf(target.pane);
+	// "Same tab": replace the Hearth view in its own leaf. Without a known leaf
+	// (a modal, a command) fall back to the active one, which is what Obsidian
+	// itself does for `getLeaf(false)`.
+	return h.leaf ?? h.app.workspace.getLeaf(false);
+}
+
+/** Open a file the way the user asked Hearth to open notes. */
+export async function openFile(
+	from: OpenFrom,
+	file: TFile,
+	source: OpenSource,
+	evt?: UserEvent | null,
+	state?: OpenViewState,
+): Promise<void> {
+	await targetLeaf(from, source, evt).openFile(file, state);
+}
+
+/**
+ * Open a link the way the user asked Hearth to open notes.
+ *
+ * Link text is left to `openLinkText`, which resolves aliases, headings, block
+ * references and missing notes — none of which a raw path lookup here would get
+ * right. For "same tab" that means focusing the Hearth leaf first, since
+ * `openLinkText` can only be told *which kind* of pane to use, not which leaf.
+ */
+export async function openLink(
+	from: OpenFrom,
+	linktext: string,
+	sourcePath: string,
+	source: OpenSource,
+	evt?: UserEvent | null,
+): Promise<void> {
+	const h = host(from);
+	const target = openTarget(resolveOpenIn(h.settings, source), modifiers(h, evt));
+	if (target.kind === "pane") {
+		await h.app.workspace.openLinkText(linktext, sourcePath, target.pane);
+		return;
+	}
+	if (h.leaf) h.app.workspace.setActiveLeaf(h.leaf, { focus: true });
+	await h.app.workspace.openLinkText(linktext, sourcePath, false);
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -4,6 +4,7 @@ import { applyFileIcon, fileIconOptions, resolveFileIcon, type ResolvedIcon } fr
 import { FILE_TYPE_GROUPS, FileTypeGroup, fileTypeLabel, groupForFile, OTHER_GROUP_ID } from "./filetypes";
 import { QueryFilter, QueryHit, runQuery, searchFileContents } from "./query";
 import { isOmnisearchAvailable, searchWithOmnisearch } from "./omnisearch";
+import { openFile as openInLeaf } from "./opener";
 import { t } from "./i18n";
 
 /** Recently opened-via-search files, kept in the vault's local storage (never
@@ -480,7 +481,7 @@ export class SearchSection {
 	private openFile(file: TAbstractFile): void {
 		if (file instanceof TFile) {
 			this.pushHistory(file.path);
-			void this.view.app.workspace.getLeaf(true).openFile(file);
+			void openInLeaf(this.view, file, "search");
 			this.hide();
 		} else if (file instanceof TFolder) {
 			// Reveal the folder in the file explorer.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,7 @@ import { TaskFieldsModal } from "./cards/tasks";
 import { hasFileIconPlugin } from "./fileicons";
 import { FILE_TYPE_GROUPS, fileTypeLabel } from "./filetypes";
 import { CommandPickerModal } from "./pickers";
-import { type BackgroundKind, CARD_BORDER_WIDTH_MAX, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, type MobileActionButton, OPEN_IN_MODES, OPEN_SOURCES, type OpenIn, type OpenInRule } from "./types";
+import { type BackgroundKind, CARD_BORDER_WIDTH_MAX, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, type MobileActionButton, OPEN_IN_MODES, OPEN_SOURCES, type OpenIn, type OpenInRule, type OpenOutsideRule } from "./types";
 import { exportLayout, exportSettings, importLayout, importSettings } from "./layout";
 import { confirmAction, downloadTextFile, pickTextFile } from "./ui";
 import { isOmnisearchAvailable, OMNISEARCH_PLUGIN_ID } from "./omnisearch";
@@ -796,6 +796,25 @@ export class HomeSettingTab extends PluginSettingTab {
 					});
 				});
 		}
+
+		// Not one of the four sources above: Obsidian, not Hearth, decides where
+		// these land, and the only say Hearth has is whether its tab may be taken
+		// over — so the choice is two-way, and it defaults to being taken over
+		// (what Hearth has done since #84) rather than following the global
+		// dropdown, which would change that for everyone on upgrade.
+		const outside = t().settings.behaviour.openFromOutsideModes;
+		new Setting(containerEl)
+			.setName(t().settings.behaviour.openFromOutside)
+			.setDesc(t().settings.behaviour.openFromOutsideDesc)
+			.addDropdown((d) => {
+				d.addOption("default", t().settings.behaviour.openInFollow);
+				d.addOption("same", outside.same);
+				d.addOption("tab", outside.tab);
+				d.setValue(s.openFromOutside ?? "same").onChange(async (v) => {
+					s.openFromOutside = v as OpenOutsideRule;
+					await this.save();
+				});
+			});
 	}
 
 	// ---- Privacy & network ----------------------------------------------

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,7 @@ import { TaskFieldsModal } from "./cards/tasks";
 import { hasFileIconPlugin } from "./fileicons";
 import { FILE_TYPE_GROUPS, fileTypeLabel } from "./filetypes";
 import { CommandPickerModal } from "./pickers";
-import { type BackgroundKind, CARD_BORDER_WIDTH_MAX, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, type MobileActionButton } from "./types";
+import { type BackgroundKind, CARD_BORDER_WIDTH_MAX, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, type MobileActionButton, OPEN_IN_MODES, OPEN_SOURCES, type OpenIn, type OpenInRule } from "./types";
 import { exportLayout, exportSettings, importLayout, importSettings } from "./layout";
 import { confirmAction, downloadTextFile, pickTextFile } from "./ui";
 import { isOmnisearchAvailable, OMNISEARCH_PLUGIN_ID } from "./omnisearch";
@@ -334,6 +334,9 @@ export class HomeSettingTab extends PluginSettingTab {
 				break;
 			case "behaviour":
 				this.section(body, s.sections.startup, s.sections.startupDesc, (b) => this.startupSection(b));
+				this.section(body, s.sections.opening, s.sections.openingDesc, (b) =>
+					this.openingSection(b),
+				);
 				this.section(body, s.sections.mobileMode, s.sections.mobileModeDesc, (b) =>
 					this.mobileModeSection(b),
 				);
@@ -749,6 +752,50 @@ export class HomeSettingTab extends PluginSettingTab {
 					await this.save();
 				}),
 			);
+	}
+
+	// ---- Opening notes ---------------------------------------------------
+
+	/**
+	 * Where notes Hearth opens end up (#106). One dropdown decides it for
+	 * everything; the per-source rows below it start on "Same as above", so the
+	 * detail is there for anyone who wants a link to behave differently from a
+	 * search hit without getting in the way of anyone who doesn't.
+	 */
+	private openingSection(containerEl: HTMLElement): void {
+		const s = this.plugin.settings;
+		const labels = t().settings.behaviour.openInModes;
+
+		new Setting(containerEl)
+			.setName(t().settings.behaviour.openIn)
+			.setDesc(t().settings.behaviour.openInDesc)
+			.addDropdown((d) => {
+				for (const mode of OPEN_IN_MODES) d.addOption(mode, labels[mode]);
+				d.setValue(s.openIn).onChange(async (v) => {
+					s.openIn = v as OpenIn;
+					await this.save();
+				});
+			});
+
+		const sources = t().settings.behaviour.openInSources;
+		const descKey = { link: "linkDesc", search: "searchDesc", card: "cardDesc", newNote: "newNoteDesc" } as const;
+		for (const source of OPEN_SOURCES) {
+			new Setting(containerEl)
+				.setName(sources[source])
+				.setDesc(sources[descKey[source]])
+				.addDropdown((d) => {
+					d.addOption("default", t().settings.behaviour.openInFollow);
+					for (const mode of OPEN_IN_MODES) d.addOption(mode, labels[mode]);
+					d.setValue(s.openInOverrides?.[source] ?? "default").onChange(async (v) => {
+						// Rebuilt from the defaults so a settings file written before this
+						// feature (or hand-edited into a partial map) ends up complete.
+						const overrides = { ...DEFAULT_SETTINGS.openInOverrides, ...s.openInOverrides };
+						overrides[source] = v as OpenInRule;
+						s.openInOverrides = overrides;
+						await this.save();
+					});
+				});
+		}
 	}
 
 	// ---- Privacy & network ----------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -705,8 +705,12 @@ export interface DashboardCard {
 	 * free-form and may overlap. */
 	tileAutoFlow?: boolean;
 
-	/** kind === "daily": show a button that opens today's note in the editor.
-	 * Defaults to shown; set false to hide. */
+	/** Show a button that opens the card's file in the editor.
+	 *
+	 * The two cards that offer it default differently, because one of them
+	 * predates the other: on `kind === "daily"` the button is shown unless this
+	 * is `false`, while on `kind === "embed"` (added for #144) it is hidden
+	 * unless this is `true`, so no existing embed card sprouts a new control. */
 	showOpenButton?: boolean;
 
 	/** Show this card on every dashboard, sharing one definition and position
@@ -826,6 +830,40 @@ export interface Dashboard {
 
 export type ChromeVisibility = "always" | "hover";
 
+/**
+ * Where Hearth puts a note when you open one from the home view.
+ *
+ * `"same"` reuses the tab Hearth itself is in, so the note replaces the home
+ * view exactly like clicking a link inside a normal editor tab (#106). The
+ * other three map straight onto Obsidian's own pane types — a new tab (the
+ * historical behaviour, and still the default), a split beside the current
+ * pane, or a separate window.
+ */
+export type OpenIn = "tab" | "same" | "split" | "window";
+
+/** Every {@link OpenIn} value, in the order the settings dropdown lists them. */
+export const OPEN_IN_MODES: readonly OpenIn[] = ["tab", "same", "split", "window"];
+
+/**
+ * The kinds of click that open a note, each of which can override the global
+ * choice:
+ *
+ * - `link` — a link inside a rendered note, a task, or the Links card
+ * - `search` — a result from the search bar or the Search card
+ * - `card` — a note listed by a card (Recent, Bookmarks, Favourites, Calendar,
+ *   Heatmap, Tasks) or by a mobile action button
+ * - `newNote` — a note Hearth has just created (new note, daily note, event
+ *   note), which is opened for editing straight away
+ */
+export type OpenSource = "link" | "search" | "card" | "newNote";
+
+/** Every {@link OpenSource}, in the order the settings tab lists them. */
+export const OPEN_SOURCES: readonly OpenSource[] = ["link", "search", "card", "newNote"];
+
+/** A per-source rule: an explicit destination, or `"default"` to follow the
+ * global {@link HomeSettings.openIn} choice. */
+export type OpenInRule = OpenIn | "default";
+
 export interface HomeSettings {
 	// ---- Header ----
 	title: string;
@@ -881,6 +919,15 @@ export interface HomeSettings {
 	 * requests are configured live-content cards (including Jira) and the
 	 * calculator's key-less, ECB-backed currency-rate fetch. */
 	disableExternalCalls: boolean;
+
+	// ---- Opening notes ----
+	/** Where every note Hearth opens goes by default (#106). `"tab"` is the
+	 * historical behaviour. */
+	openIn: OpenIn;
+	/** Per-source exceptions to {@link openIn}. Every source defaults to
+	 * `"default"` (follow the global choice), so the single dropdown above is
+	 * enough for anyone who doesn't want the detail. */
+	openInOverrides: Record<OpenSource, OpenInRule>;
 
 	// ---- Appearance (layout density) ----
 	/** Tighten card and top-of-page spacing to enlarge the usable area. */
@@ -994,6 +1041,12 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	// and existing vaults aren't silently reset if the list is emptied.
 	mobileActionButtons: [],
 	disableExternalCalls: false,
+
+	// A new tab is what Hearth has always done; existing vaults must not change
+	// behaviour on upgrade, so both the global default and every per-source rule
+	// start out as "open a new tab".
+	openIn: "tab",
+	openInOverrides: { link: "default", search: "default", card: "default", newNote: "default" },
 
 	compact: false,
 	arrangeButtonVisibility: "always",

--- a/src/types.ts
+++ b/src/types.ts
@@ -864,6 +864,24 @@ export const OPEN_SOURCES: readonly OpenSource[] = ["link", "search", "card", "n
  * global {@link HomeSettings.openIn} choice. */
 export type OpenInRule = OpenIn | "default";
 
+/**
+ * What happens to a focused Hearth tab when a note is opened by something
+ * Hearth doesn't control — the file explorer, the quick switcher, the graph, or
+ * a view embedded in a card that opens links itself (an embedded Bases table).
+ *
+ * Obsidian makes that call, not Hearth: it reuses the focused tab when the view
+ * in it reports itself navigable, so this is expressed by flipping
+ * `View.navigation` rather than by picking a leaf. Only two outcomes are
+ * possible — Hearth is taken over (`"same"`) or it is left alone and the note
+ * goes to another tab (`"tab"`) — plus `"default"` to follow
+ * {@link HomeSettings.openIn}, where anything but "same tab" counts as leaving
+ * Hearth alone.
+ */
+export type OpenOutsideRule = "default" | "same" | "tab";
+
+/** Every {@link OpenOutsideRule}, in the order the settings dropdown lists. */
+export const OPEN_OUTSIDE_RULES: readonly OpenOutsideRule[] = ["default", "same", "tab"];
+
 export interface HomeSettings {
 	// ---- Header ----
 	title: string;
@@ -928,6 +946,12 @@ export interface HomeSettings {
 	 * `"default"` (follow the global choice), so the single dropdown above is
 	 * enough for anyone who doesn't want the detail. */
 	openInOverrides: Record<OpenSource, OpenInRule>;
+	/** Whether a note opened from outside Hearth may take over a focused Hearth
+	 * tab. Defaults to `"same"` — the behaviour Hearth has had since #84, where
+	 * the dashboard acts like an ordinary tab and the file explorer's selection
+	 * tracks what you open. Deliberately *not* `"default"`: following the global
+	 * choice would flip this for everyone on upgrade. */
+	openFromOutside: OpenOutsideRule;
 
 	// ---- Appearance (layout density) ----
 	/** Tighten card and top-of-page spacing to enlarge the usable area. */
@@ -1047,6 +1071,7 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	// start out as "open a new tab".
 	openIn: "tab",
 	openInOverrides: { link: "default", search: "default", card: "default", newNote: "default" },
+	openFromOutside: "same",
 
 	compact: false,
 	arrangeButtonVisibility: "always",

--- a/src/view.ts
+++ b/src/view.ts
@@ -13,6 +13,7 @@ import {
 	renderCards,
 } from "./types";
 import { hearthIconIdFor } from "./icon";
+import { hearthLeafIsNavigable } from "./opener";
 import { t } from "./i18n";
 
 export const VIEW_TYPE_HOME = "hearth-home-view";
@@ -20,13 +21,17 @@ export const VIEW_TYPE_HOME = "hearth-home-view";
 export class HomeView extends ItemView {
 	plugin: HearthPlugin;
 	/**
-	 * Mark the dashboard as a navigable pane (the base `View` default is
+	 * Whether the dashboard is a navigable pane (the base `View` default is
 	 * `false`). A non-navigable leaf is treated like the file explorer or
 	 * calendar: Obsidian won't reuse it to open a file, so clicking a note in
 	 * the file explorer while the dashboard is focused spawns a *new* tab and
 	 * leaves the file explorer's selection stuck on that note (#84). With
 	 * navigation enabled, opening a file replaces the dashboard in place — the
 	 * dashboard behaves like any editor tab and the selection tracks correctly.
+	 *
+	 * That is still the default, but it is now the user's call: it is also the
+	 * only lever over opens Hearth never sees (#106), so `render()` keeps it in
+	 * step with the "Notes opened from outside Hearth" setting.
 	 */
 	navigation = true;
 	/** Whether the dashboard is in layout/arrange mode (drag & resize). */
@@ -121,6 +126,12 @@ export class HomeView extends ItemView {
 
 	/** Full rebuild of the view. Cheap enough to call on any settings change. */
 	render(): void {
+		// Re-read on every render (which includes every settings save) so the
+		// choice takes effect without reopening the tab. Obsidian reads this at
+		// the moment it looks for a leaf to open a file in, so the current value
+		// is the one that counts.
+		this.navigation = hearthLeafIsNavigable(this.plugin.settings);
+
 		this.cleanupChild();
 		const child = new Component();
 		this.addChild(child);

--- a/test/opener.test.ts
+++ b/test/opener.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { openTarget, resolveOpenIn } from "../src/opener";
+import { DEFAULT_SETTINGS, type HomeSettings, type OpenIn, type OpenInRule } from "../src/types";
+
+/**
+ * The two pure halves of the open-behaviour setting (#106): which mode applies
+ * to a click, and which destination that mode plus the held modifiers imply.
+ * Actually reaching for a leaf needs a live workspace, so `targetLeaf`,
+ * `openFile` and `openLink` are deliberately not covered here (no Obsidian API
+ * mocks) — everything they decide happens in these two functions.
+ */
+
+function settings(openIn: OpenIn, overrides: Partial<Record<string, OpenInRule>> = {}): HomeSettings {
+	return {
+		...DEFAULT_SETTINGS,
+		openIn,
+		openInOverrides: { ...DEFAULT_SETTINGS.openInOverrides, ...overrides },
+	};
+}
+
+describe("resolveOpenIn", () => {
+	it("uses the global choice when a source has no rule of its own", () => {
+		const s = settings("same");
+		expect(resolveOpenIn(s, "link")).toBe("same");
+		expect(resolveOpenIn(s, "search")).toBe("same");
+		expect(resolveOpenIn(s, "card")).toBe("same");
+		expect(resolveOpenIn(s, "newNote")).toBe("same");
+	});
+
+	it("lets a source override the global choice", () => {
+		const s = settings("same", { newNote: "tab" });
+		expect(resolveOpenIn(s, "newNote")).toBe("tab");
+		expect(resolveOpenIn(s, "card")).toBe("same");
+	});
+
+	it('treats "default" as "follow the global choice"', () => {
+		expect(resolveOpenIn(settings("split", { link: "default" }), "link")).toBe("split");
+	});
+
+	it("falls back to a new tab for a missing or unknown value", () => {
+		const noMap = { ...DEFAULT_SETTINGS, openIn: "same" } as HomeSettings;
+		// A settings file written before this feature has neither field.
+		delete (noMap as Partial<HomeSettings>).openInOverrides;
+		delete (noMap as Partial<HomeSettings>).openIn;
+		expect(resolveOpenIn(noMap, "card")).toBe("tab");
+
+		const bogus = settings("sidebar" as OpenIn, { link: "elsewhere" as OpenInRule });
+		expect(resolveOpenIn(bogus, "card")).toBe("tab");
+		expect(resolveOpenIn(bogus, "link")).toBe("tab");
+	});
+
+	it("ships defaulting to a new tab, so upgrades keep the old behaviour", () => {
+		expect(resolveOpenIn(DEFAULT_SETTINGS, "link")).toBe("tab");
+		expect(resolveOpenIn(DEFAULT_SETTINGS, "card")).toBe("tab");
+	});
+});
+
+describe("openTarget", () => {
+	it("maps each mode to its destination", () => {
+		expect(openTarget("tab")).toEqual({ kind: "pane", pane: "tab" });
+		expect(openTarget("split")).toEqual({ kind: "pane", pane: "split" });
+		expect(openTarget("window")).toEqual({ kind: "pane", pane: "window" });
+		expect(openTarget("same")).toEqual({ kind: "reuse" });
+	});
+
+	it("lets a modifier override the setting", () => {
+		// A bare Mod-click means "new tab" everywhere else in Obsidian.
+		expect(openTarget("same", true)).toEqual({ kind: "pane", pane: "tab" });
+		// Modifier combinations that name a pane type are honoured as-is.
+		expect(openTarget("same", "split")).toEqual({ kind: "pane", pane: "split" });
+		expect(openTarget("tab", "window")).toEqual({ kind: "pane", pane: "window" });
+	});
+
+	it("ignores a plain click's absent modifiers", () => {
+		expect(openTarget("same", false)).toEqual({ kind: "reuse" });
+		expect(openTarget("tab", false)).toEqual({ kind: "pane", pane: "tab" });
+	});
+});

--- a/test/opener.test.ts
+++ b/test/opener.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { openTarget, resolveOpenIn } from "../src/opener";
+import { hearthLeafIsNavigable, internalLinkText, openTarget, resolveOpenIn } from "../src/opener";
 import { DEFAULT_SETTINGS, type HomeSettings, type OpenIn, type OpenInRule } from "../src/types";
 
 /**
- * The two pure halves of the open-behaviour setting (#106): which mode applies
- * to a click, and which destination that mode plus the held modifiers imply.
+ * The pure decisions behind the open-behaviour setting (#106): which mode
+ * applies to a click, which destination that mode plus the held modifiers
+ * imply, whether the Hearth tab is there to be taken over by an open it never
+ * sees, and which anchors count as links to a note.
+ *
  * Actually reaching for a leaf needs a live workspace, so `targetLeaf`,
  * `openFile` and `openLink` are deliberately not covered here (no Obsidian API
- * mocks) — everything they decide happens in these two functions.
+ * mocks) — everything they decide happens in these functions.
  */
 
 function settings(openIn: OpenIn, overrides: Partial<Record<string, OpenInRule>> = {}): HomeSettings {
@@ -52,6 +55,51 @@ describe("resolveOpenIn", () => {
 	it("ships defaulting to a new tab, so upgrades keep the old behaviour", () => {
 		expect(resolveOpenIn(DEFAULT_SETTINGS, "link")).toBe("tab");
 		expect(resolveOpenIn(DEFAULT_SETTINGS, "card")).toBe("tab");
+	});
+});
+
+describe("hearthLeafIsNavigable", () => {
+	it("defaults to navigable, so the file explorer keeps behaving as it did (#84)", () => {
+		expect(hearthLeafIsNavigable(DEFAULT_SETTINGS)).toBe(true);
+		// Even with everything else pointed at a new tab.
+		expect(hearthLeafIsNavigable(settings("tab"))).toBe(true);
+	});
+
+	it("stops outside opens taking over the Hearth tab when asked", () => {
+		expect(hearthLeafIsNavigable({ ...settings("tab"), openFromOutside: "tab" })).toBe(false);
+		// An explicit "current tab" wins even when the global says otherwise.
+		expect(hearthLeafIsNavigable({ ...settings("window"), openFromOutside: "same" })).toBe(true);
+	});
+
+	it('follows the global choice on "default" — and only "same" is a takeover', () => {
+		expect(hearthLeafIsNavigable({ ...settings("same"), openFromOutside: "default" })).toBe(true);
+		expect(hearthLeafIsNavigable({ ...settings("tab"), openFromOutside: "default" })).toBe(false);
+		// Split and window can't be expressed here; they mean "not this tab".
+		expect(hearthLeafIsNavigable({ ...settings("split"), openFromOutside: "default" })).toBe(false);
+	});
+});
+
+describe("internalLinkText", () => {
+	it("prefers data-href, which is what Obsidian's renderer emits", () => {
+		expect(internalLinkText("Some Note", "Some%20Note")).toBe("Some Note");
+		expect(internalLinkText("Note#^block-ref", "Note")).toBe("Note#^block-ref");
+	});
+
+	it("takes a plain href for content rendered without the class or data-href", () => {
+		// An embedded Bases table's note column, which is what #106's follow-up
+		// was about.
+		expect(internalLinkText(null, "Projects/Alpha.md")).toBe("Projects/Alpha.md");
+	});
+
+	it("ignores anything that isn't a link to a note", () => {
+		expect(internalLinkText(null, null)).toBeNull();
+		expect(internalLinkText(null, "")).toBeNull();
+		// Footnote and heading jumps within the rendered content.
+		expect(internalLinkText(null, "#fnref-1")).toBeNull();
+		// Anything with a URL scheme belongs to the external-link path.
+		expect(internalLinkText(null, "https://example.com")).toBeNull();
+		expect(internalLinkText(null, "mailto:me@example.com")).toBeNull();
+		expect(internalLinkText(null, "obsidian://open?vault=x")).toBeNull();
 	});
 });
 

--- a/test/support/obsidian-shim.ts
+++ b/test/support/obsidian-shim.ts
@@ -58,6 +58,15 @@ export class MarkdownRenderer {}
 export class MarkdownView {}
 export class WorkspaceLeaf {}
 export class ButtonComponent {}
+
+// `opener.ts` imports Keymap for its runtime modifier check. The pure decision
+// functions under test never reach it — a call here would mean a test wandered
+// into the Obsidian API.
+export class Keymap {
+	static isModEvent(): never {
+		throw new Error("Keymap.isModEvent is not implemented in tests (Obsidian API)");
+	}
+}
 export class SliderComponent {}
 export class TextComponent {}
 


### PR DESCRIPTION
## What does this PR do?

Adds a global **Opening notes** section to Settings → Hearth → **Behaviour**, so a note clicked in Hearth lands where the user wants instead of always in a new tab.

**One setting does everything.** *Open notes in* → **a new tab** (unchanged default), **the current tab** (replaces the home view — the original ask: Hearth behaves like any other tab, and the back arrow brings it right back), **a split pane**, or **a new window**.

**Flexible when you want it.** Four rows below it take exceptions, each starting on *Same as above*:

| Source | Covers |
| --- | --- |
| Links | links in rendered notes, task text, the Links card |
| Search results | the search bar and the Search card |
| Notes in cards | Recent, Bookmarks, Favourites, Calendar, Heatmap, Tasks, mobile action buttons |
| Notes Hearth creates | new note, daily note, event note |

Ctrl/Cmd-click still opens a new tab whatever the setting says, and the modifier combinations Obsidian maps to a split or a window are honoured too.

### How it works

Every open path used to hard-code `workspace.getLeaf(true)`. They now go through one small module, `src/opener.ts`:

- `resolveOpenIn(settings, source)` — per-source rule, else the global one, else `"tab"` for anything a hand-edited or future settings file might hold.
- `openTarget(mode, mod)` — mode + held modifiers → reuse-this-leaf or a `PaneType`. Both are pure, and both are covered by `test/opener.test.ts` (no Obsidian API mocks).
- `openFile` / `openLink` / `targetLeaf` — the thin workspace calls around them.

Two details worth reviewing:

- **"Same tab" reuses the leaf the click came from**, not `getLeaf(false)`'s active leaf, so a click inside Hearth can never take over an editor sitting beside it. `EventDetailModal` now takes the view instead of the app so it can do the same; `createNewNote` takes an optional view for the same reason (the command-palette path falls back to the active leaf).
- **Links still go through `openLinkText`**, so aliases, headings, block refs and missing notes resolve exactly as before. For "same tab" the Hearth leaf is made active first, since `openLinkText` can only be told *which kind* of pane to use, not which leaf.

Callers that already have the click event pass it; the rest fall back to `app.lastEvent`, which is how commands read modifier keys they were never handed.

### Also here: #144

Note **embed** cards get an optional **Open button** in their card settings that lifts the embedded file into its own tab (following the same setting). Off by default, so no existing board sprouts a control — unlike the Daily card's button, which predates this and stays on by default.

### One behaviour change

A `[[wikilink]]` inside a task's text used to take over the current tab (so, in a Hearth tab, replace the home view), while the same link on a card opened a new tab. Both now follow the setting, so task links default to a new tab. Setting **Links** to *The current tab* restores the old feel. Called out under `### Changed` in the changelog.

### Not included

Web URLs (bookmarks, RSS, link tiles) still go to the system browser via `window.open` — Obsidian has no supported in-app browser to open them "in a tab", so the URL half of the original comment isn't actionable as a tab choice.

## Related issue

Closes #106. Also covers #144 (consolidated into #106).

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (`npm run lint` clean — 0 errors, only the repo's pre-existing deprecation warnings; `npm test` 277 passed)
- [x] I've tested this in an actual vault — **not done**: this was built in a headless environment with no Obsidian to run it in. Worth a pass over the four modes in a real vault before merge, particularly "same tab" from the search bar and from a card.

Settings round-trip through the JSON import/export with each field validated on its own, and existing vaults are untouched on upgrade: both the global choice and every per-source rule default to "new tab".

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7gJw1PpEKE1N1r95itaF4)_