### PR TITLE
Honour card opacity in embedded Bases table view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,14 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **Embedded bases follow the card opacity in table view.** A `.base` card in
+  list or cards view faded with the board like any other card, but the table
+  view stayed a solid slab: it fills its container and rows with Obsidian's base
+  surface colour (it needs opaque paint so its sticky header and first column
+  cover what scrolls beneath). Base embeds now clear those surfaces so the
+  card's own translucent background shows through, and the sticky header is
+  painted with the card's surface colour, so it fades with the card instead of
+  staying opaque. Row hover and selection highlights are untouched.
 - **The task filter's Status row is readable again.** With more than a handful
   of statuses — TaskNotes states, Kanban columns, your own checkbox statuses —
   the chips took the whole row and squeezed the label down to *Sta…*, then

--- a/src/cards/embed.ts
+++ b/src/cards/embed.ts
@@ -95,6 +95,10 @@ export function renderEmbed(
 
 	const host = body.createDiv("hearth-embed markdown-rendered");
 	body.addClass("is-embed-host");
+	// A Bases view paints its own surfaces (the table view most of all), which
+	// hides the card's translucent background. This class scopes the CSS that
+	// makes those surfaces defer to the card's --card-opacity.
+	if (ext === "base") host.addClass("hearth-embed-base");
 	// Optionally hide the embedded Bases view's own toolbar/header (view switcher
 	// + filter/property controls) so only the results show. Scoped via a class on
 	// the host so it only affects this card's base embed.

--- a/styles.css
+++ b/styles.css
@@ -511,12 +511,17 @@
 	border-radius: var(--hearth-card-radius, 14px);
 	border: var(--card-border-width, 1px) solid
 		var(--background-modifier-border);
-	/* --card-opacity (0..1) tints the card surface without dimming content. */
-	background: color-mix(
+	/* --card-opacity (0..1) tints the card surface without dimming content.
+	 * Published as a variable so content INSIDE the card that has to paint its
+	 * own surface (a Bases table's sticky header, say) can reuse the exact same
+	 * colour. It resolves here, against the card's real --background-primary, so
+	 * it stays correct even where a descendant neutralises that variable. */
+	--hearth-card-surface: color-mix(
 		in srgb,
 		var(--background-primary) calc(var(--card-opacity, 1) * 100%),
 		transparent
 	);
+	background: var(--hearth-card-surface);
 	/* Drop shadow via a variable so merged edges can drop it (see below) and
 	 * hover can lift it without re-declaring the whole shadow. */
 	--hearth-card-lift: 0 2px 12px rgba(0, 0, 0, 0.06);
@@ -791,6 +796,12 @@
 	--background-primary-alt: transparent;
 	--background-secondary: transparent;
 	--background-secondary-alt: transparent;
+	/* A hosted view may be a Bases table, which paints through the table
+	 * variables as well — see the .hearth-embed-base block for the reasoning. */
+	--table-background: transparent;
+	--table-row-background: transparent;
+	--table-row-alt-background: transparent;
+	--table-header-background: var(--hearth-card-surface, var(--background-primary));
 }
 
 .hearth-leaf-host > .workspace-leaf {
@@ -4103,6 +4114,48 @@ body.hearth-dv-resizing {
 .hearth-embed-hide-base-header .bases-header,
 .hearth-embed-hide-base-header .bases-toolbar {
 	display: none !important;
+}
+
+/* Embedded Bases: let the view show the card's translucent surface (#opacity).
+ * The list/cards views paint nothing of their own, so they honoured
+ * --card-opacity for free; the table view fills its container, rows and cells
+ * with the base surface (it needs opaque paint for its sticky header and sticky
+ * first column to cover what scrolls beneath), which read as a solid slab on a
+ * translucent card.
+ *
+ * Same fix as .hearth-leaf-host: rather than chase every element that paints —
+ * Bases' internals are not a public API and its class names can change between
+ * releases — neutralise the base-surface variables *within the embed host*, so
+ * whichever element does the painting resolves to transparent and the card's own
+ * tint shows through. Accent surfaces (hover, selection, form fields) use
+ * --*-modifier-* variables, which are untouched, so row hover and selection keep
+ * their look. Scoped to .base embeds so no other embed kind is affected. */
+.hearth-embed-base {
+	--background-primary: transparent;
+	--background-primary-alt: transparent;
+	--background-secondary: transparent;
+	--background-secondary-alt: transparent;
+	/* Obsidian's table variables default to the base surfaces above, but a theme
+	 * may point them at a literal colour, so clear them here too. */
+	--table-background: transparent;
+	--table-row-background: transparent;
+	--table-row-alt-background: transparent;
+	/* The header row is sticky, so it can't be fully transparent or the rows
+	 * scrolling under it would collide with the column titles. Give it the card's
+	 * own surface colour: at opacity 1 it's exactly the old opaque header, and
+	 * below 1 it fades with the card like everything else. */
+	--table-header-background: var(--hearth-card-surface, var(--background-primary));
+}
+
+/* Belt-and-braces, mirroring the leaf-host rule: clear the structural wrappers
+ * directly in case a theme hard-codes their fill to a literal colour instead of
+ * the variables neutralised above. Deliberately limited to containers — cells
+ * and rows are left alone so hover/selection highlights still paint. */
+.hearth-embed-base .bases-view,
+.hearth-embed-base .bases-table-container,
+.hearth-embed-base .bases-table,
+.hearth-embed-base .bases-tbody {
+	background: transparent !important;
 }
 
 /* ---- Embed second-view switcher ------------------------------------- */


### PR DESCRIPTION
## What does this PR do?

An embedded `.base` card faded with the board in list/cards view but stayed a solid slab in table view. That view paints its container, rows and cells with Obsidian's base surface colour — it needs opaque paint so its sticky header and sticky first column cover what scrolls beneath — so `--card-opacity` never showed through.

- `.base` embed hosts get a `hearth-embed-base` class (`src/cards/embed.ts`), and the CSS scoped to it neutralises the base-surface variables (`--background-primary`/`-alt`, `--background-secondary`/`-alt`) plus the table background variables. Same approach `.hearth-leaf-host` already uses, so it doesn't depend on Bases' non-public class names. A small belt-and-braces rule clears the structural `.bases-*` wrappers in case a theme hard-codes a literal colour — limited to containers, so row hover and selection (which use `--*-modifier-*` variables) are untouched.
- The sticky header still needs its own paint, so it now uses the card's surface colour instead of `--background-primary`. `.hearth-card` exports that as `--hearth-card-surface`, resolved on the card against its real `--background-primary`, so it stays correct where a descendant neutralises that variable. At opacity 1 the header is byte-for-byte what it was; below 1 it fades with the card.
- `.hearth-leaf-host` gets the table variables too, for a Bases view hosted as a workspace-leaf card.

Tradeoff worth knowing: below full opacity the sticky header is translucent by definition, so rows scrolling under it are faintly visible through it — inherent to respecting the opacity. If Bases also paints a sticky first column with the base surface, it becomes fully transparent; I could not verify that selector while writing this, so it's worth a look on a real board.

## Related issue

None — reported directly.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (also `npm run lint`: 0 errors, 27 pre-existing warnings; `vitest run`: 283 passed)
- [x] I've tested this in an actual vault — not done; this was written in a sandbox with no Obsidian, so the visual result needs a check on a real board

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2mKitSVHDnqjY42AHGhbF)_