### PR TITLE
feat(calendar): take TaskNotes as a calendar source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
+- **TaskNotes as a calendar source.** A calendar card can now pick up your
+  TaskNotes calendar and show it as a calendar card: scheduled tasks (sized by
+  their time estimate), due dates, recurring tasks unrolled into one entry per
+  occurrence, timeblocks from daily notes, and the ICS calendars subscribed
+  inside TaskNotes itself. Everything is read the way TaskNotes reads it — its
+  field mapping, its tag-or-property rule for what counts as a task, its custom
+  statuses and priorities with their colours — and each layer defaults to
+  whatever TaskNotes' own calendar is showing, so switching the source on
+  mirrors your existing setup. Per card you can override any layer, hide
+  completed or archived tasks, colour entries by status, priority or one fixed
+  colour, and give due dates and timeblocks their own colours. Completed tasks
+  show struck through with a faded day dot; a checkbox on each agenda entry
+  completes it in place (per-occurrence for recurring tasks, exactly as
+  TaskNotes records it), and the event popup shows the task's status, priority,
+  contexts, projects and estimate with an **Open task** button that hands off to
+  TaskNotes' own editor.
+
 - **Choose where Hearth opens notes.** Settings → Hearth → Behaviour → **Opening
   notes** has a single **Open notes in** choice that governs every note Hearth
   opens: **a new tab** (what it has always done), **the current tab**, which

--- a/README.md
+++ b/README.md
@@ -248,6 +248,20 @@ toolbar; configure each one from the card itself (title, content, colors, size).
   route each value how you like (date/time into custom frontmatter, description
   into the body, or ignored). The note is linked back to the event by its ID so
   it's reopened rather than duplicated.
+
+  The card can also take **TaskNotes as a source**, mirroring what TaskNotes'
+  own calendar shows: scheduled tasks (sized by their time estimate), due
+  dates, recurring tasks unrolled into one entry per occurrence, timeblocks
+  from your daily notes, and the ICS calendars subscribed inside TaskNotes —
+  no need to re-enter their URLs. It reads TaskNotes' own configuration, so
+  renamed frontmatter fields, custom statuses and priorities (and their
+  colours), and the tag-or-property rule that marks a note as a task all
+  carry over; each layer starts from whatever TaskNotes itself is showing and
+  can be overridden per card. Entries colour by status, priority or one fixed
+  colour, completed tasks show struck through, and a checkbox on each task
+  completes it straight from the calendar — writing exactly what TaskNotes
+  writes, including per-occurrence completion for recurring tasks. Clicking one
+  opens it in TaskNotes' own task editor.
 - **Vault statistics** — notes, attachments, folders, unique tags and your
   daily-note streak, read entirely from the in-memory vault index.
 - **Saved search** — runs a stored query (the same syntax as the search bar) and

--- a/src/cardbodies.ts
+++ b/src/cardbodies.ts
@@ -44,10 +44,15 @@ export interface Moment {
 	year(): number;
 	diff(other: Moment, unit?: string): number;
 	valueOf(): number;
+	/** False when the input didn't parse (used for strict format parsing). */
+	isValid(): boolean;
 }
 
 interface MomentFn {
 	(input?: Date | string): Moment;
+	/** Strict parse against an explicit format — how a daily note's date is
+	 * recovered from its filename. */
+	(input: string, format: string, strict?: boolean): Moment;
 	localeData(): { firstDayOfWeek(): number };
 }
 

--- a/src/cards/calendar.ts
+++ b/src/cards/calendar.ts
@@ -36,7 +36,25 @@ import { t } from "../i18n";
 import { cachedCalendar, eventsByDay, expandEvents, loadCalendar, type IcsOccurrence } from "../ics";
 import { openFile } from "../opener";
 import { FilePickerModal } from "../pickers";
-import { type CalendarConfig, type DashboardCard } from "../types";
+import {
+	applyCompletion,
+	cachedLocalCalendar,
+	collectTaskNotesTasks,
+	collectTimeblockOccurrences,
+	dailyNoteDayKey,
+	loadLocalCalendar,
+	openInTaskNotes,
+	readTaskAt,
+	readTaskNotesSetup,
+	taskNotesEnabled,
+	taskNotesEvents,
+	taskNotesMeta,
+	type TaskNotesLayerOptions,
+	type TaskNotesMeta,
+	type TaskNotesSetup,
+	type TaskNotesSubscription,
+} from "../tasknotes";
+import { type CalendarConfig, type DashboardCard, type TaskNotesSourceConfig } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
 import { type CardDefinition, type CardEditorContext } from "./definition";
@@ -58,10 +76,11 @@ export function renderCalendar(
 	const options = dailyNotesOptions(view);
 	const cfg = card.calendar ?? {};
 	const sources = (cfg.sources ?? []).filter((s) => s.url.trim() && s.enabled !== false);
+	const useTaskNotes = cfg.taskNotes?.enabled === true && taskNotesEnabled(view.app);
 
-	// The card needs a reason to exist: either daily notes (for the note grid) or
-	// at least one external calendar to overlay.
-	if (!options && sources.length === 0) {
+	// The card needs a reason to exist: daily notes (for the note grid), an
+	// external calendar to overlay, or TaskNotes as a source.
+	if (!options && sources.length === 0 && !useTaskNotes) {
 		emptyState(body, "calendar-days", t().cards.empty.dailyEnable);
 		return;
 	}
@@ -115,10 +134,11 @@ export function renderCalendar(
 }
 
 
-/** Per-render helper bundling the external-calendar state for a calendar card:
- * lazily fetches each ICS source, expands events for a given window, and hands
- * the card per-day occurrences plus each source's colour and label. When there
- * are no sources every method is a cheap no-op, so the note grid pays nothing. */
+/** Per-render helper bundling the event state for a calendar card: lazily
+ * fetches each ICS source, reads the TaskNotes source when it's switched on,
+ * expands everything for a given window, and hands the card per-day
+ * occurrences plus each source's colour and label. When there are no sources
+ * every method is a cheap no-op, so the note grid pays nothing. */
 interface IcsContext {
 	/** Recompute the day buckets for `[startMs, endMs)` from cached feeds. */
 	expand(startMs: number, endMs: number): void;
@@ -126,19 +146,68 @@ interface IcsContext {
 	on(dayKey: string): IcsOccurrence[];
 	/** CSS colour for a source id. */
 	color(sourceId: string | undefined): string;
+	/** CSS colour for one occurrence: a TaskNotes entry carries its own status/
+	 * priority colour, anything else takes its source's. */
+	eventColor(ev: IcsOccurrence): string;
 	/** Friendly label for a source id. */
 	label(sourceId: string | undefined): string;
-	/** Whether any external calendars are configured. */
+	/** Whether any event source (ICS feed or TaskNotes) is configured. */
 	readonly hasSources: boolean;
-	/** Whether more than one external calendar is configured (badges shown only
-	 * then, since with a single source the label is redundant). */
+	/** Whether more than one source is configured (badges shown only then,
+	 * since with a single source the label is redundant). */
 	readonly multiSource: boolean;
 	/** The event → note configuration for the "Create note" modal action. */
 	readonly eventNote: EventNoteConfig | undefined;
-	/** Register a redraw to run after a background fetch resolves. */
+	/** The live TaskNotes source, or null when it's off/unavailable. */
+	readonly taskNotes: TaskNotesSource | null;
+	/** Register a redraw to run after a background fetch (or a write) resolves. */
 	onLoaded(cb: () => void): void;
+	/** Redraw now — used after a task is completed from the event popup. */
+	refresh(): void;
 	/** Kick the initial fetch (and schedule auto-refresh). */
 	start(): void;
+}
+
+
+/** The resolved TaskNotes source for one card render. */
+interface TaskNotesSource {
+	setup: TaskNotesSetup;
+	layers: TaskNotesLayerOptions;
+	/** Offer a complete/reopen action in the event popup. */
+	allowComplete: boolean;
+}
+
+
+/** Source id given to every TaskNotes task/timeblock entry, so it resolves a
+ * label and colour through the same lookup as an ICS feed. */
+const TASKNOTES_SOURCE_ID = "hearth:tasknotes";
+
+/** Source id prefix for a calendar subscribed inside TaskNotes. */
+const TASKNOTES_SUB_PREFIX = "hearth:tnsub:";
+
+
+/** Resolve the card's TaskNotes source: its live settings plus the layers to
+ * draw. Each layer follows TaskNotes' own calendar settings unless this card
+ * overrides it, so switching the source on mirrors TaskNotes as configured. */
+function buildTaskNotesSource(view: HomeView, cfg: TaskNotesSourceConfig | undefined): TaskNotesSource | null {
+	if (cfg?.enabled !== true || !taskNotesEnabled(view.app)) return null;
+	const setup = readTaskNotesSetup(view.app);
+	const pick = (own: boolean | undefined, mirrored: boolean): boolean => own ?? mirrored;
+	return {
+		setup,
+		layers: {
+			scheduled: pick(cfg.scheduled, setup.calendar.scheduled),
+			due: pick(cfg.due, setup.calendar.due),
+			recurring: pick(cfg.recurring, setup.calendar.recurring),
+			timeblocks: pick(cfg.timeblocks, setup.calendar.timeblocks),
+			completed: cfg.completed ?? true,
+			archived: cfg.archived ?? false,
+			colorBy: cfg.colorBy ?? "status",
+			fallbackColor: cfg.color || "var(--interactive-accent)",
+			dueColor: cfg.dueColor || "",
+		},
+		allowComplete: cfg.allowComplete !== false,
+	};
 }
 
 
@@ -158,13 +227,73 @@ function buildIcsContext(
 		destroyed = true;
 	});
 
+	const taskNotes = buildTaskNotesSource(view, cfg.taskNotes);
+	// TaskNotes' own calendar subscriptions, mirrored onto this card unless the
+	// user turned that off. They keep their TaskNotes colour and name.
+	const subs: TaskNotesSubscription[] =
+		taskNotes && cfg.taskNotes?.subscriptions !== false
+			? taskNotes.setup.subscriptions.filter((s) => s.enabled)
+			: [];
+
+	// The vault is read once per render: the card is rebuilt wholesale on any
+	// vault change (liveness: "vault"), so month navigation costs nothing extra.
+	let tasksCache: ReturnType<typeof collectTaskNotesTasks> | null = null;
+	let timeblockCache: IcsOccurrence[] | null = null;
+	const invalidate = (): void => {
+		tasksCache = null;
+		timeblockCache = null;
+	};
+
 	const src = (id: string | undefined) => sources.find((s) => s.id === id);
-	const color = (id: string | undefined): string =>
-		src(id)?.color || "var(--interactive-accent)";
+	const sub = (id: string | undefined) =>
+		id?.startsWith(TASKNOTES_SUB_PREFIX)
+			? subs.find((s) => `${TASKNOTES_SUB_PREFIX}${s.id}` === id)
+			: undefined;
+	const color = (id: string | undefined): string => {
+		if (id === TASKNOTES_SOURCE_ID) return taskNotes?.layers.fallbackColor || "var(--interactive-accent)";
+		return sub(id)?.color || src(id)?.color || "var(--interactive-accent)";
+	};
+	const eventColor = (ev: IcsOccurrence): string =>
+		taskNotesMeta(ev)?.color || color(ev.sourceId);
 	const label = (id: string | undefined): string => {
+		if (id === TASKNOTES_SOURCE_ID) return t().cards.calendar.taskNotesSource;
+		const subscription = sub(id);
+		if (subscription) {
+			return (
+				subscription.name ||
+				(subscription.type === "local"
+					? subscription.filePath
+					: cachedCalendar(subscription.url)?.name || feedHost(subscription.url))
+			);
+		}
 		const s = src(id);
 		if (!s) return "";
 		return s.name.trim() || cachedCalendar(s.url)?.name || feedHost(s.url);
+	};
+
+	/** Every TaskNotes entry inside the window: tasks (scheduled / due /
+	 * recurring occurrences) plus timeblocks from daily notes. */
+	const taskNotesOccurrences = (startMs: number, endMs: number): IcsOccurrence[] => {
+		if (!taskNotes) return [];
+		tasksCache ??= collectTaskNotesTasks(view.app, taskNotes.setup);
+		const out = taskNotesEvents(tasksCache, taskNotes.setup, taskNotes.layers, startMs, endMs);
+		if (taskNotes.layers.timeblocks) {
+			const options = dailyNotesOptions(view);
+			timeblockCache ??= collectTimeblockOccurrences(
+				view.app,
+				(path) =>
+					dailyNoteDayKey(path, (options?.format || "YYYY-MM-DD").trim(), (input, fmt) =>
+						moment(input, fmt, true),
+					),
+				cfg.taskNotes?.timeblockColor || taskNotes.layers.fallbackColor,
+			);
+			for (const o of timeblockCache) {
+				const end = o.end ?? o.start;
+				if (o.start < endMs && end >= startMs) out.push(o);
+			}
+		}
+		for (const o of out) o.sourceId = TASKNOTES_SOURCE_ID;
+		return out;
 	};
 
 	const expand = (startMs: number, endMs: number): void => {
@@ -177,14 +306,31 @@ function buildIcsContext(
 				occ.push(o);
 			}
 		}
+		for (const s of subs) {
+			const cal = s.type === "local" ? cachedLocalCalendar(s.filePath) : cachedCalendar(s.url);
+			if (!cal) continue;
+			for (const o of expandEvents(cal.events, startMs, endMs)) {
+				o.sourceId = `${TASKNOTES_SUB_PREFIX}${s.id}`;
+				occ.push(o);
+			}
+		}
+		occ.push(...taskNotesOccurrences(startMs, endMs));
 		byDay = eventsByDay(occ);
 	};
 
 	const load = (force: boolean): void => {
-		if (sources.length === 0) return;
-		void Promise.all(
-			sources.map((s) => loadCalendar(s.url, { ttlMs, disabled, force })),
-		).then(() => {
+		const pending: Promise<unknown>[] = sources.map((s) =>
+			loadCalendar(s.url, { ttlMs, disabled, force }),
+		);
+		for (const s of subs) {
+			pending.push(
+				s.type === "local"
+					? loadLocalCalendar(view.app, s.filePath)
+					: loadCalendar(s.url, { ttlMs, disabled, force }),
+			);
+		}
+		if (pending.length === 0) return;
+		void Promise.all(pending).then(() => {
 			if (destroyed) return;
 			redraw?.();
 		});
@@ -194,12 +340,18 @@ function buildIcsContext(
 		expand,
 		on: (key) => byDay.get(key) ?? [],
 		color,
+		eventColor,
 		label,
-		hasSources: sources.length > 0,
-		multiSource: sources.length > 1,
+		hasSources: sources.length > 0 || taskNotes !== null,
+		multiSource: sources.length + subs.length + (taskNotes ? 1 : 0) > 1,
 		eventNote: cfg.eventNote,
+		taskNotes,
 		onLoaded: (cb) => {
 			redraw = cb;
+		},
+		refresh: () => {
+			invalidate();
+			if (!destroyed) redraw?.();
 		},
 		start: () => {
 			load(false);
@@ -311,10 +463,12 @@ class EventDetailModal extends Modal {
 		this.modalEl.addClass("hearth-event-modal");
 		this.titleEl.setText(ev.summary || t().cards.calendar.untitledEvent);
 
+		const task = taskNotesMeta(ev);
 		const rows = this.contentEl.createDiv("hearth-event-rows");
 		this.row(rows, "calendar-days", eventDateLabel(ev));
 		this.row(rows, "clock", eventTimeLabel(ev));
 		if (ev.location) this.row(rows, "map-pin", ev.location);
+		if (task) this.renderTaskRows(rows, task);
 
 		const label = this.ics.label(ev.sourceId);
 		if (label) {
@@ -323,7 +477,7 @@ class EventDetailModal extends Modal {
 			const dot = row.querySelector<HTMLElement>(".hearth-event-icon")!.createDiv(
 				"hearth-event-caldot",
 			);
-			dot.style.setProperty("--ev-color", this.ics.color(ev.sourceId));
+			dot.style.setProperty("--ev-color", this.ics.eventColor(ev));
 		}
 
 		if (ev.description) {
@@ -344,9 +498,78 @@ class EventDetailModal extends Modal {
 			});
 		}
 
-		// "Create note" / "Open note" — the note-from-event action. Shown unless
-		// explicitly disabled in the card's event-note config.
-		if (this.ics.eventNote?.enabled !== false) this.renderNoteAction();
+		// A TaskNotes entry already *is* a note, so it gets its own actions
+		// (open it where TaskNotes would, complete this occurrence) instead of
+		// the create-a-note-from-this-event action an ICS event gets.
+		if (task) this.renderTaskActions(task);
+		else if (this.ics.eventNote?.enabled !== false) this.renderNoteAction();
+	}
+
+	/** The TaskNotes-specific detail rows: status, priority, contexts, projects,
+	 * time estimate and the recurring marker — everything the task carries, so
+	 * the popup shows what TaskNotes itself would. */
+	private renderTaskRows(rows: HTMLElement, task: TaskNotesMeta): void {
+		const strings = t().cards.calendar;
+		if (task.statusLabel) {
+			const row = this.row(rows, null, task.statusLabel);
+			const dot = row.querySelector<HTMLElement>(".hearth-event-icon")!.createDiv(
+				"hearth-event-caldot",
+			);
+			dot.style.setProperty("--ev-color", task.color || "var(--interactive-accent)");
+		}
+		if (task.priorityLabel) this.row(rows, "flag", task.priorityLabel);
+		if (task.contexts.length) this.row(rows, "at-sign", task.contexts.join(", "));
+		if (task.projects.length) {
+			// Project values are often wikilinks — show them as plain names.
+			this.row(rows, "folder", task.projects.map((p) => p.replace(/^\[\[|\]\]$/g, "")).join(", "));
+		}
+		if (task.timeEstimate) this.row(rows, "hourglass", strings.taskEstimate(task.timeEstimate));
+		if (task.recurring) this.row(rows, "repeat", t().cards.tasks.recurring);
+		if (task.kind === "due") this.row(rows, "target", strings.taskDue);
+		if (task.kind === "timeblock") this.row(rows, "layout-grid", strings.taskTimeblock);
+	}
+
+	/** Footer actions for a TaskNotes entry: open it (in TaskNotes' own editor
+	 * when it can be, otherwise the note), and complete/reopen this occurrence. */
+	private renderTaskActions(task: TaskNotesMeta): void {
+		const footer = this.contentEl.createDiv("hearth-event-footer");
+		const open = footer.createEl("button", { cls: "mod-cta" });
+		setIcon(open.createSpan("hearth-event-btnicon"), "file-text");
+		open.createSpan({
+			text: task.kind === "timeblock"
+				? t().cards.calendar.openDailyNote
+				: t().cards.calendar.openTaskNote,
+		});
+		open.addEventListener("click", () => {
+			void this.openTaskTarget(task);
+		});
+
+		if (task.kind === "timeblock" || !this.ics.taskNotes?.allowComplete) return;
+		const toggle = footer.createEl("button");
+		setIcon(toggle.createSpan("hearth-event-btnicon"), task.done ? "rotate-ccw" : "check");
+		toggle.createSpan({
+			text: task.done ? t().cards.calendar.taskReopen : t().cards.calendar.taskComplete,
+		});
+		toggle.addEventListener("click", () => {
+			void toggleTaskCompletion(this.view, task, !task.done, this.ics).then(() => this.close());
+		});
+	}
+
+	/** Open the note behind a TaskNotes entry: a task opens in TaskNotes' edit
+	 * modal when the plugin can resolve it, a timeblock (and any task TaskNotes
+	 * won't open) falls back to the note itself. */
+	private async openTaskTarget(task: TaskNotesMeta): Promise<void> {
+		if (task.kind !== "timeblock" && (await openInTaskNotes(this.app, task.path))) {
+			this.close();
+			return;
+		}
+		const file = this.app.vault.getAbstractFileByPath(task.path);
+		if (file instanceof TFile) {
+			void openFile(this.view, file, "card");
+			this.close();
+		} else {
+			new Notice(t().notices.couldNotOpenTaskNote);
+		}
 	}
 
 	/** The footer button that creates the event's note (or opens it when one
@@ -514,10 +737,22 @@ function showDayMenu(
 	menu.addItem((item) => item.setTitle(t().cards.calendar.eventsHeading).setIsLabel(true));
 	for (const ev of events) {
 		const time = ev.allDay ? t().cards.calendar.allDay : moment(new Date(ev.start)).format("LT");
+		// TaskNotes entries are recognisable in the picker too: a checked circle
+		// for a finished task, a target for a deadline, a block for a timeblock.
+		const task = taskNotesMeta(ev);
+		const icon = !task
+			? "calendar-clock"
+			: task.kind === "timeblock"
+				? "layout-grid"
+				: task.done
+					? "check-circle-2"
+					: task.kind === "due"
+						? "target"
+						: "circle";
 		menu.addItem((item) =>
 			item
 				.setTitle(`${time}  ${ev.summary || t().cards.calendar.untitledEvent}`)
-				.setIcon("calendar-clock")
+				.setIcon(icon)
 				.onClick(() => showEventDetail(view, ev, ics)),
 		);
 	}
@@ -598,7 +833,10 @@ function renderCalendarGrid(
 			if (file instanceof TFile) dots.createDiv("hearth-calendar-dot");
 			for (const ev of events.slice(0, 3)) {
 				const dot = dots.createDiv("hearth-calendar-evdot");
-				dot.style.setProperty("--ev-color", ics.color(ev.sourceId));
+				dot.style.setProperty("--ev-color", ics.eventColor(ev));
+				// A finished task's dot fades, so a busy day still reads as
+				// "what's left" at a glance — the way TaskNotes shows it.
+				dot.toggleClass("is-done", taskNotesMeta(ev)?.done === true);
 			}
 			if (events.length) {
 				cell.setAttribute(
@@ -711,9 +949,11 @@ function renderCalendarAgenda(
 }
 
 
-/** One external-calendar event line in the agenda: a coloured bullet, its time
- * (or "All day"), and the summary, with the source name as a trailing badge
- * when more than one calendar is subscribed. */
+/** One event line in the agenda: a coloured bullet, its time (or "All day"),
+ * and the summary, with the source name as a trailing badge when more than one
+ * calendar is in play. A TaskNotes entry additionally carries a completion box,
+ * its due/recurring markers, and strikes through once it's done — so the agenda
+ * reads like TaskNotes' own list while staying a calendar. */
 function renderAgendaEvent(
 	view: HomeView,
 	parent: HTMLElement,
@@ -721,15 +961,46 @@ function renderAgendaEvent(
 	day: Moment,
 	ics: IcsContext,
 ): void {
+	const task = taskNotesMeta(ev);
 	const row = parent.createDiv("hearth-agenda-event");
-	const bullet = row.createDiv("hearth-agenda-evbullet");
-	bullet.style.setProperty("--ev-color", ics.color(ev.sourceId));
+	row.toggleClass("is-task", task !== null);
+	row.toggleClass("is-done", task?.done === true);
+
+	// A completable task swaps the bullet for a checkbox that writes straight
+	// back to the note (the whole occurrence for a recurring task).
+	if (task && task.kind !== "timeblock" && ics.taskNotes?.allowComplete) {
+		renderTaskCompleteBox(view, row, task, ics);
+	} else {
+		const bullet = row.createDiv("hearth-agenda-evbullet");
+		bullet.style.setProperty("--ev-color", ics.eventColor(ev));
+	}
 
 	const time = row.createDiv("hearth-agenda-evtime");
 	time.setText(ev.allDay ? t().cards.calendar.allDay : moment(new Date(ev.start)).format("LT"));
 
 	const body = row.createDiv("hearth-agenda-evbody");
 	body.createSpan({ cls: "hearth-agenda-evtitle", text: ev.summary || t().cards.calendar.untitledEvent });
+	if (task) {
+		if (task.kind === "due") {
+			const badge = body.createSpan({
+				cls: "hearth-agenda-evbadge is-due",
+				text: t().cards.calendar.taskDue,
+			});
+			badge.style.setProperty("--ev-color", ics.eventColor(ev));
+		}
+		if (task.kind === "timeblock") {
+			body.createSpan({
+				cls: "hearth-agenda-evbadge is-timeblock",
+				text: t().cards.calendar.taskTimeblock,
+			});
+		}
+		if (task.recurring) {
+			body.createSpan({ cls: "hearth-agenda-evbadge", text: t().cards.tasks.recurring });
+		}
+		if (task.priorityLabel) {
+			body.createSpan({ cls: "hearth-agenda-evbadge", text: task.priorityLabel });
+		}
+	}
 	if (ics.multiSource) {
 		const label = ics.label(ev.sourceId);
 		if (label) body.createSpan({ cls: "hearth-agenda-evbadge", text: label });
@@ -738,6 +1009,46 @@ function renderAgendaEvent(
 	const open = () => showEventDetail(view, ev, ics);
 	row.addEventListener("click", open);
 	makeClickable(row, open, `${ev.summary || t().cards.calendar.untitledEvent} — ${day.format("MMM D")}`);
+}
+
+
+/** The completion checkbox on a TaskNotes agenda row. Writes exactly what
+ * TaskNotes writes — this day's entry in `complete_instances` for a recurring
+ * task, the status for a one-off — then redraws the card. */
+function renderTaskCompleteBox(
+	view: HomeView,
+	row: HTMLElement,
+	task: TaskNotesMeta,
+	ics: IcsContext,
+): void {
+	const box = row.createEl("input", {
+		cls: "hearth-agenda-evcheck",
+		attr: { type: "checkbox", "aria-label": t().cards.calendar.taskComplete },
+	});
+	box.checked = task.done;
+	box.style.setProperty("--ev-color", task.color || "var(--interactive-accent)");
+	// The row itself opens the event popup; the box must not.
+	box.addEventListener("click", (e) => e.stopPropagation());
+	box.addEventListener("change", () => {
+		void toggleTaskCompletion(view, task, box.checked, ics);
+	});
+}
+
+
+/** Complete (or reopen) one TaskNotes occurrence from the calendar. */
+async function toggleTaskCompletion(
+	view: HomeView,
+	task: TaskNotesMeta,
+	complete: boolean,
+	ics: IcsContext,
+): Promise<void> {
+	const source = ics.taskNotes;
+	if (!source) return;
+	const current = readTaskAt(view.app, source.setup, task.path);
+	if (!current || !(await applyCompletion(view.app, source.setup, current, task.dayKey, complete))) {
+		new Notice(t().notices.couldNotUpdateTaskStatus);
+	}
+	ics.refresh();
 }
 
 
@@ -812,7 +1123,206 @@ export function calendarEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 			});
 	}
 
+	taskNotesSourceEditor(ctx, containerEl, cfg);
 	calendarSourcesEditor(ctx, containerEl, cfg);
+}
+
+
+/** The "TaskNotes" section of the calendar editor: switch TaskNotes on as an
+ * event source and choose which of its layers this card mirrors. Each layer
+ * toggle starts from TaskNotes' own calendar settings, so a card that is simply
+ * switched on already shows what TaskNotes shows. */
+export function taskNotesSourceEditor(
+	ctx: CardEditorContext,
+	containerEl: HTMLElement,
+	cfg: CalendarConfig,
+): void {
+	const strings = t().editors.calendar;
+	const installed = taskNotesEnabled(ctx.app);
+
+	new Setting(containerEl).setName(strings.taskNotesHeading).setHeading();
+	new Setting(containerEl).setDesc(
+		installed ? strings.taskNotesDesc : strings.taskNotesMissing,
+	);
+	// Nothing is written into the card until TaskNotes is actually there to
+	// configure, so a vault without it keeps a clean card config.
+	if (!installed) return;
+	const tn = (cfg.taskNotes ??= {});
+
+	new Setting(containerEl)
+		.setName(strings.taskNotesEnabled)
+		.setDesc(strings.taskNotesEnabledDesc)
+		.addToggle((tg) =>
+			tg.setValue(tn.enabled === true).onChange((v) => {
+				tn.enabled = v || undefined;
+				ctx.opts.save();
+				ctx.requestRender();
+			}),
+		);
+	if (tn.enabled !== true) return;
+
+	// The live TaskNotes settings the unset toggles inherit from, so each row
+	// can say what "follow TaskNotes" currently means.
+	const setup = readTaskNotesSetup(ctx.app);
+	const layer = (
+		name: string,
+		desc: string,
+		read: () => boolean | undefined,
+		write: (v: boolean | undefined) => void,
+		mirrored: boolean,
+	): void => {
+		const setting = new Setting(containerEl)
+			.setName(name)
+			.setDesc(`${desc} ${strings.taskNotesFollows(mirrored)}`);
+		setting.addToggle((tg) =>
+			tg.setValue(read() ?? mirrored).onChange((v) => {
+				write(v === mirrored ? undefined : v);
+				ctx.opts.save();
+				ctx.requestRender();
+			}),
+		);
+		setting.addExtraButton((b) =>
+			b
+				.setIcon("rotate-ccw")
+				.setTooltip(strings.taskNotesFollowReset)
+				.onClick(() => {
+					write(undefined);
+					ctx.opts.save();
+					ctx.requestRender();
+				}),
+		);
+	};
+
+	layer(
+		strings.taskNotesScheduled,
+		strings.taskNotesScheduledDesc,
+		() => tn.scheduled,
+		(v) => (tn.scheduled = v),
+		setup.calendar.scheduled,
+	);
+	layer(
+		strings.taskNotesDue,
+		strings.taskNotesDueDesc,
+		() => tn.due,
+		(v) => (tn.due = v),
+		setup.calendar.due,
+	);
+	layer(
+		strings.taskNotesRecurring,
+		strings.taskNotesRecurringDesc,
+		() => tn.recurring,
+		(v) => (tn.recurring = v),
+		setup.calendar.recurring,
+	);
+	layer(
+		strings.taskNotesTimeblocks,
+		strings.taskNotesTimeblocksDesc,
+		() => tn.timeblocks,
+		(v) => (tn.timeblocks = v),
+		setup.calendar.timeblocks,
+	);
+
+	new Setting(containerEl)
+		.setName(strings.taskNotesCompleted)
+		.setDesc(strings.taskNotesCompletedDesc)
+		.addToggle((tg) =>
+			tg.setValue(tn.completed !== false).onChange((v) => {
+				tn.completed = v ? undefined : false;
+				ctx.opts.save();
+				ctx.requestRender();
+			}),
+		);
+
+	new Setting(containerEl)
+		.setName(strings.taskNotesArchived)
+		.setDesc(strings.taskNotesArchivedDesc)
+		.addToggle((tg) =>
+			tg.setValue(tn.archived === true).onChange((v) => {
+				tn.archived = v || undefined;
+				ctx.opts.save();
+				ctx.requestRender();
+			}),
+		);
+
+	new Setting(containerEl)
+		.setName(strings.taskNotesComplete)
+		.setDesc(strings.taskNotesCompleteDesc)
+		.addToggle((tg) =>
+			tg.setValue(tn.allowComplete !== false).onChange((v) => {
+				tn.allowComplete = v ? undefined : false;
+				ctx.opts.save();
+				ctx.requestRender();
+			}),
+		);
+
+	new Setting(containerEl)
+		.setName(strings.taskNotesSubscriptions)
+		.setDesc(
+			setup.subscriptions.length
+				? strings.taskNotesSubscriptionsDesc(setup.subscriptions.length)
+				: strings.taskNotesSubscriptionsNone,
+		)
+		.addToggle((tg) =>
+			tg.setValue(tn.subscriptions !== false).onChange((v) => {
+				tn.subscriptions = v ? undefined : false;
+				ctx.opts.save();
+				ctx.requestRender();
+			}),
+		);
+
+	new Setting(containerEl)
+		.setName(strings.taskNotesColorBy)
+		.setDesc(strings.taskNotesColorByDesc)
+		.addDropdown((d) => {
+			d.addOption("status", strings.taskNotesColorStatus);
+			d.addOption("priority", strings.taskNotesColorPriority);
+			d.addOption("fixed", strings.taskNotesColorFixed);
+			d.setValue(tn.colorBy ?? "status").onChange((v) => {
+				tn.colorBy = v === "status" ? undefined : (v as NonNullable<typeof tn.colorBy>);
+				ctx.opts.save();
+				ctx.requestRender();
+			});
+		});
+
+	const colorRow = (name: string, desc: string, read: () => string | undefined, write: (v: string | undefined) => void): void => {
+		const setting = new Setting(containerEl).setName(name).setDesc(desc);
+		setting.addColorPicker((c) =>
+			c.setValue(read() || "#7c6cff").onChange((v) => {
+				write(v);
+				ctx.opts.save();
+				ctx.opts.rerender();
+			}),
+		);
+		setting.addExtraButton((b) =>
+			b
+				.setIcon("rotate-ccw")
+				.setTooltip(t().settings.resetSlider)
+				.onClick(() => {
+					write(undefined);
+					ctx.opts.save();
+					ctx.requestRender();
+				}),
+		);
+	};
+
+	colorRow(
+		strings.taskNotesColor,
+		strings.taskNotesColorDesc,
+		() => tn.color,
+		(v) => (tn.color = v),
+	);
+	colorRow(
+		strings.taskNotesDueColor,
+		strings.taskNotesDueColorDesc,
+		() => tn.dueColor,
+		(v) => (tn.dueColor = v),
+	);
+	colorRow(
+		strings.taskNotesTimeblockColor,
+		strings.taskNotesTimeblockColorDesc,
+		() => tn.timeblockColor,
+		(v) => (tn.timeblockColor = v),
+	);
 }
 
 
@@ -1158,6 +1668,7 @@ export const calendarCard: CardDefinition<"calendar"> = {
 			copy.calendar = {
 				...source.calendar,
 				sources: source.calendar.sources ? source.calendar.sources.map((s) => ({ ...s })) : undefined,
+				taskNotes: source.calendar.taskNotes ? { ...source.calendar.taskNotes } : undefined,
 				eventNote: source.calendar.eventNote
 					? {
 							...source.calendar.eventNote,

--- a/src/cards/calendar.ts
+++ b/src/cards/calendar.ts
@@ -47,6 +47,7 @@ import {
 	openInTaskNotes,
 	readTaskAt,
 	readTaskNotesSetup,
+	subscriptionStatus,
 	taskNotesEnabled,
 	taskNotesEvents,
 	taskNotesMeta,
@@ -1293,6 +1294,9 @@ export function taskNotesSourceEditor(
 				ctx.requestRender();
 			}),
 		);
+	if (tn.subscriptions !== false && known.length) {
+		subscriptionStatusList(ctx, containerEl, known);
+	}
 
 	new Setting(containerEl)
 		.setName(strings.taskNotesColorBy)
@@ -1471,6 +1475,73 @@ export function calendarSourcesEditor(ctx: CardEditorContext, containerEl: HTMLE
 	);
 
 	eventNoteEditor(ctx, containerEl, cfg);
+}
+
+
+/**
+ * One row per TaskNotes subscription, each reporting what actually happened to
+ * it: how many events came through, that it was blocked by the "disable
+ * external calls" setting, or why it failed. A feed that can't be fetched
+ * otherwise just shows nothing on the card, with no way to tell it apart from
+ * an empty calendar — which is exactly the case where a user sees only some of
+ * their subscribed calendars.
+ */
+function subscriptionStatusList(
+	ctx: CardEditorContext,
+	containerEl: HTMLElement,
+	subs: TaskNotesSubscription[],
+): void {
+	const strings = t().editors.calendar;
+	for (const sub of subs) {
+		const status = subscriptionStatus(sub);
+		const where = sub.type === "local" ? sub.filePath : feedHost(sub.url);
+		const state = !sub.enabled
+			? strings.taskNotesSubDisabled
+			: status.blocked
+				? strings.taskNotesSubBlocked
+				: status.error
+					? strings.taskNotesSubFailed(subscriptionError(status.error))
+					: status.loaded
+						? strings.taskNotesSubLoaded(status.events)
+						: strings.taskNotesSubPending;
+		new Setting(containerEl)
+			.setName(sub.name || where)
+			.setDesc(`${where} — ${state}`)
+			.setClass("hearth-rss-setting");
+	}
+
+	new Setting(containerEl).addButton((b) =>
+		b.setButtonText(strings.taskNotesSubRefresh).onClick(() => {
+			void refreshSubscriptions(ctx, subs).then(() => ctx.requestRender());
+		}),
+	);
+}
+
+
+/** A failure reason in the user's language, falling back to whatever the
+ * network/vault layer reported. */
+function subscriptionError(error: string): string {
+	const strings = t().editors.calendar;
+	if (error === "not-calendar") return strings.taskNotesSubNotCalendar;
+	if (error === "missing-file") return strings.taskNotesSubMissingFile;
+	return error;
+}
+
+
+/** Re-fetch every TaskNotes subscription now, bypassing the freshness window,
+ * so the rows above report a fresh verdict. */
+async function refreshSubscriptions(
+	ctx: CardEditorContext,
+	subs: TaskNotesSubscription[],
+): Promise<void> {
+	const disabled = ctx.opts.externalCallsDisabled;
+	await Promise.all(
+		subs.map((s) =>
+			s.type === "local"
+				? loadLocalCalendar(ctx.app, s.filePath)
+				: loadCalendar(s.url, { ttlMs: 0, disabled, force: true }),
+		),
+	);
 }
 
 

--- a/src/cards/calendar.ts
+++ b/src/cards/calendar.ts
@@ -43,12 +43,14 @@ import {
 	collectTimeblockOccurrences,
 	dailyNoteDayKey,
 	loadLocalCalendar,
+	loadTaskNotesSubscriptions,
 	openInTaskNotes,
 	readTaskAt,
 	readTaskNotesSetup,
 	taskNotesEnabled,
 	taskNotesEvents,
 	taskNotesMeta,
+	taskNotesSubscriptions,
 	type TaskNotesLayerOptions,
 	type TaskNotesMeta,
 	type TaskNotesSetup,
@@ -229,10 +231,13 @@ function buildIcsContext(
 
 	const taskNotes = buildTaskNotesSource(view, cfg.taskNotes);
 	// TaskNotes' own calendar subscriptions, mirrored onto this card unless the
-	// user turned that off. They keep their TaskNotes colour and name.
-	const subs: TaskNotesSubscription[] =
-		taskNotes && cfg.taskNotes?.subscriptions !== false
-			? taskNotes.setup.subscriptions.filter((s) => s.enabled)
+	// user turned that off. They keep their TaskNotes colour and name. The list
+	// is re-read on every load: TaskNotes keeps it in its plugin data, which
+	// only the asynchronous read can reach (see loadTaskNotesSubscriptions).
+	const mirrorSubs = taskNotes !== null && cfg.taskNotes?.subscriptions !== false;
+	let subs: TaskNotesSubscription[] =
+		mirrorSubs && taskNotes
+			? taskNotesSubscriptions(view.app, taskNotes.setup).filter((s) => s.enabled)
 			: [];
 
 	// The vault is read once per render: the card is rebuilt wholesale on any
@@ -319,21 +324,31 @@ function buildIcsContext(
 	};
 
 	const load = (force: boolean): void => {
-		const pending: Promise<unknown>[] = sources.map((s) =>
-			loadCalendar(s.url, { ttlMs, disabled, force }),
-		);
-		for (const s of subs) {
-			pending.push(
-				s.type === "local"
-					? loadLocalCalendar(view.app, s.filePath)
-					: loadCalendar(s.url, { ttlMs, disabled, force }),
+		if (sources.length === 0 && !mirrorSubs) return;
+		void (async () => {
+			// Re-read TaskNotes' subscription list first: it lives in TaskNotes'
+			// plugin data, so the synchronous list above can be empty on the very
+			// first render even when subscriptions exist.
+			if (mirrorSubs && taskNotes) {
+				subs = (await loadTaskNotesSubscriptions(view.app, taskNotes.setup)).filter(
+					(s) => s.enabled,
+				);
+			}
+			if (destroyed) return;
+			const pending: Promise<unknown>[] = sources.map((s) =>
+				loadCalendar(s.url, { ttlMs, disabled, force }),
 			);
-		}
-		if (pending.length === 0) return;
-		void Promise.all(pending).then(() => {
+			for (const s of subs) {
+				pending.push(
+					s.type === "local"
+						? loadLocalCalendar(view.app, s.filePath)
+						: loadCalendar(s.url, { ttlMs, disabled, force }),
+				);
+			}
+			await Promise.all(pending);
 			if (destroyed) return;
 			redraw?.();
-		});
+		})();
 	};
 
 	return {
@@ -1255,11 +1270,20 @@ export function taskNotesSourceEditor(
 			}),
 		);
 
+	// TaskNotes keeps its subscriptions in its plugin data, so the count may only
+	// be known after an async read — rebuild the editor once when that lands.
+	const known = taskNotesSubscriptions(ctx.app, setup);
+	if (!known.length && ctx.session.tnSubsProbed !== true) {
+		ctx.session.tnSubsProbed = true;
+		void loadTaskNotesSubscriptions(ctx.app, setup).then((found) => {
+			if (found.length) ctx.requestRender();
+		});
+	}
 	new Setting(containerEl)
 		.setName(strings.taskNotesSubscriptions)
 		.setDesc(
-			setup.subscriptions.length
-				? strings.taskNotesSubscriptionsDesc(setup.subscriptions.length)
+			known.length
+				? strings.taskNotesSubscriptionsDesc(known.length)
 				: strings.taskNotesSubscriptionsNone,
 		)
 		.addToggle((tg) =>

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -69,13 +69,10 @@ import {
 	type TaskSortField,
 	type TaskSortRule,
 } from "../types";
+import { openInTaskNotes, TASKNOTES_PLUGIN_ID } from "../tasknotes";
 import { confirmAction, makeClickable } from "../ui";
 import { type HomeView } from "../view";
 import { type CardDefinition, type CardEditorContext } from "./definition";
-
-
-/** Community plugin id for TaskNotes (used by "tasks" cards in TaskNotes mode). */
-const TASKNOTES_PLUGIN_ID = "tasknotes";
 
 
 /** Frontmatter key the Kanban plugin writes on every board note. Used both to
@@ -4523,69 +4520,6 @@ function renderLineRecurringCheckbox(
 }
 
 
-/** The slice of TaskNotes' plugin surface this uses. All optional and duck-typed:
- * TaskNotes ships no stable public types, so each accessor is probed before use
- * and may be absent or reshaped between versions. */
-interface TaskNotesLike {
-	openTaskEditModal?: (task: unknown) => unknown;
-	cacheManager?: { getTaskInfo?: (path: string) => unknown };
-	api?: { tasks?: { get?: (path: string) => unknown } };
-}
-
-
-/** Best-effort: open a TaskNotes task in TaskNotes' own edit modal rather than
- * the raw Markdown note. TaskNotes exposes no stable public API, so this resolves
- * the plugin's own task object for the file and hands it to `openTaskEditModal`,
- * returning whether it handled the open; the caller falls back to opening the
- * file when it didn't.
- *
- * The modal requires TaskNotes' `TaskInfo` (title/status/priority/…), not a
- * `TFile`: passing the file leaves the modal with a broken change-detection
- * baseline that traps every button but Delete (see issue #72). `openTaskEditModal`
- * is async, so a bad argument never throws synchronously — resolving the info up
- * front (and awaiting the open) is the only way to know we really handled it. */
-async function openInTaskNotes(view: HomeView, file: TFile): Promise<boolean> {
-	const plugin = view.app.plugins.plugins[TASKNOTES_PLUGIN_ID] as TaskNotesLike | undefined;
-	if (!plugin || typeof plugin.openTaskEditModal !== "function") return false;
-	const task = await resolveTaskNotesInfo(plugin, file.path);
-	if (!task) return false;
-	try {
-		await plugin.openTaskEditModal(task);
-		return true;
-	} catch {
-		// Internal error — fall through to a plain file open.
-		return false;
-	}
-}
-
-
-/** Resolve TaskNotes' `TaskInfo` for a note path via whichever accessor the
- * installed version exposes: the cache manager first, then the public runtime
- * API (`api.tasks.get`). Both are best-effort and may be absent or reshaped
- * between TaskNotes versions, so failures fall through to the next. */
-async function resolveTaskNotesInfo(plugin: TaskNotesLike, path: string): Promise<unknown> {
-	const cache = plugin.cacheManager;
-	if (typeof cache?.getTaskInfo === "function") {
-		try {
-			const info = await cache.getTaskInfo(path);
-			if (info) return info;
-		} catch {
-			// Fall through to the public API.
-		}
-	}
-	const get = plugin.api?.tasks?.get;
-	if (typeof get === "function") {
-		try {
-			const info = await get(path);
-			if (info) return info;
-		} catch {
-			// No resolver worked.
-		}
-	}
-	return null;
-}
-
-
 async function openTask(view: HomeView, cfg: TasksConfig, hit: TaskHit, refresh: () => void): Promise<void> {
 	// Line-based tasks (checkboxes / Kanban cards) open a compact quick-view by
 	// default — metadata + description with open-note / delete actions — instead
@@ -4610,7 +4544,7 @@ async function openTaskFile(view: HomeView, hit: TaskHit): Promise<void> {
 		return;
 	}
 	// TaskNotes tasks (no line) open in TaskNotes' own editor when possible.
-	if (hit.line < 0 && (await openInTaskNotes(view, hit.file))) return;
+	if (hit.line < 0 && (await openInTaskNotes(view.app, hit.file.path))) return;
 
 	const leaf = targetLeaf(view, "card");
 	// Scroll to the task's line via ephemeral state rather than a setCursor call

--- a/src/ics.ts
+++ b/src/ics.ts
@@ -45,6 +45,10 @@ export interface IcsEvent {
 	rrule: string | null;
 	/** Epoch ms of excluded occurrence starts (EXDATE). */
 	exdates: number[];
+	/** Opaque payload for events synthesised by a non-ICS provider (currently
+	 * the TaskNotes source), carried onto every occurrence so the card can
+	 * recognise and style them. Never set by the ICS parser. */
+	meta?: unknown;
 }
 
 /** A parsed calendar: its display name plus its events. */
@@ -68,6 +72,8 @@ export interface IcsOccurrence {
 	allDay: boolean;
 	/** Filled by the caller: which configured source this came from. */
 	sourceId?: string;
+	/** The originating event's provider payload (see `IcsEvent.meta`). */
+	meta?: unknown;
 }
 
 interface CacheEntry {
@@ -337,6 +343,7 @@ export function expandEvents(
 					start,
 					end,
 					allDay: ev.allDay,
+					meta: ev.meta,
 				});
 			}
 		};

--- a/src/ics.ts
+++ b/src/ics.ts
@@ -76,9 +76,27 @@ export interface IcsOccurrence {
 	meta?: unknown;
 }
 
+/** What became of the last attempt to load a feed. A failed fetch is otherwise
+ * invisible — the card just shows nothing for that calendar — so the reason is
+ * kept here for the editor to report. */
+export interface IcsStatus {
+	/** Whether a calendar has ever been parsed for this URL. */
+	loaded: boolean;
+	/** Events in the last successfully parsed calendar. */
+	events: number;
+	/** When that parse happened (epoch ms), or null. */
+	fetched: number | null;
+	/** Why the last attempt failed, or null when it didn't. */
+	error: string | null;
+	/** Whether an attempt was skipped because external calls are disabled. */
+	blocked: boolean;
+}
+
 interface CacheEntry {
 	cal: IcsCalendar | null;
 	inflight: Promise<IcsCalendar | null> | null;
+	error: string | null;
+	blocked: boolean;
 }
 
 const cache = new Map<string, CacheEntry>();
@@ -86,6 +104,19 @@ const cache = new Map<string, CacheEntry>();
 /** The last-fetched calendar for a URL (possibly stale), or null if never loaded. */
 export function cachedCalendar(url: string): IcsCalendar | null {
 	return cache.get(url)?.cal ?? null;
+}
+
+/** How the last load of a feed went: loaded and how many events, blocked by the
+ * privacy setting, failed (and why), or never attempted. */
+export function calendarStatus(url: string): IcsStatus {
+	const entry = cache.get(url);
+	return {
+		loaded: !!entry?.cal,
+		events: entry?.cal?.events.length ?? 0,
+		fetched: entry?.cal?.fetched ?? null,
+		error: entry?.error ?? null,
+		blocked: entry?.blocked ?? false,
+	};
 }
 
 /**
@@ -103,10 +134,14 @@ export async function loadCalendar(
 ): Promise<IcsCalendar | null> {
 	let entry = cache.get(url);
 	if (!entry) {
-		entry = { cal: null, inflight: null };
+		entry = { cal: null, inflight: null, error: null, blocked: false };
 		cache.set(url, entry);
 	}
-	if (opts.disabled) return entry.cal;
+	if (opts.disabled) {
+		entry.blocked = true;
+		return entry.cal;
+	}
+	entry.blocked = false;
 	const fresh = entry.cal && Date.now() - entry.cal.fetched < opts.ttlMs;
 	if (fresh && !opts.force) return entry.cal;
 	if (entry.inflight) return entry.inflight;
@@ -116,13 +151,28 @@ export async function loadCalendar(
 		try {
 			// webcal:// is just https for subscription URLs; normalise it so
 			// requestUrl (and pasted Apple/Google links) work unchanged.
-			const res = await requestUrl({ url: url.replace(/^webcal:/i, "https:") });
+			// `throw: false` keeps the HTTP status readable — "HTTP 403" tells the
+			// user their feed needs a different (secret/public) address, where a
+			// bare thrown error would not.
+			const res = await requestUrl({ url: url.replace(/^webcal:/i, "https:"), throw: false });
+			if (res.status >= 400) {
+				current.error = `HTTP ${res.status}`;
+				return current.cal;
+			}
 			const parsed = parseIcs(res.text);
-			// Keep prior events when a fetch returns something unparseable.
-			if (parsed) current.cal = parsed;
+			// Keep prior events when a fetch returns something unparseable, but
+			// record that it wasn't a calendar — otherwise the feed just silently
+			// shows nothing and there's no way to tell why.
+			if (parsed) {
+				current.cal = parsed;
+				current.error = null;
+			} else {
+				current.error = "not-calendar";
+			}
 			return current.cal;
-		} catch {
-			// Offline or blocked — keep any prior events.
+		} catch (e) {
+			// Offline, blocked or refused — keep any prior events and remember why.
+			current.error = e instanceof Error ? e.message : String(e);
 			return current.cal;
 		} finally {
 			current.inflight = null;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -780,6 +780,15 @@ export const en = {
 			taskNotesSubscriptionsDesc: (count: number) =>
 				`Also show the ${count} calendar${count === 1 ? "" : "s"} subscribed inside TaskNotes.`,
 			taskNotesSubscriptionsNone: "TaskNotes has no calendar subscriptions to show.",
+			taskNotesSubLoaded: (count: number) =>
+				`${count} event${count === 1 ? "" : "s"} loaded.`,
+			taskNotesSubPending: "Not loaded yet — refresh below.",
+			taskNotesSubDisabled: "Disabled in TaskNotes.",
+			taskNotesSubBlocked: "Not fetched: external calls are disabled in Hearth's settings.",
+			taskNotesSubFailed: (reason: string) => `Couldn't load: ${reason}`,
+			taskNotesSubNotCalendar: "the response wasn't an iCalendar feed.",
+			taskNotesSubMissingFile: "that file isn't in the vault.",
+			taskNotesSubRefresh: "Refresh calendars",
 			taskNotesColorBy: "Colour by",
 			taskNotesColorByDesc: "Where each task's colour comes from.",
 			taskNotesColorStatus: "TaskNotes status",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -46,6 +46,7 @@ export const en = {
 		couldNotCreateEventNote: "Hearth: couldn't create a note for that event.",
 		taskNotesCreateFailed: "Hearth: couldn't run TaskNotes: Create new task.",
 		taskChangedOnDisk: "Hearth: that task changed on disk — refreshed.",
+		couldNotOpenTaskNote: "Hearth: couldn't open that task's note.",
 		couldNotUpdateTaskStatus: "Hearth: couldn't update the task status.",
 		couldNotCompleteRecurring:
 			"Hearth: couldn't mark the recurring task instance complete.",
@@ -748,6 +749,48 @@ export const en = {
 			eventNotePropertyPlaceholder: "Property name",
 			eventNoteHeadingPlaceholder: "Heading (optional)",
 			eventNoteFormatPlaceholder: "Format (e.g. HH:mm)",
+			taskNotesHeading: "TaskNotes",
+			taskNotesDesc:
+				"Use TaskNotes as an event source. The card mirrors what TaskNotes' own calendar shows — scheduled tasks, due dates, recurring occurrences, timeblocks and the calendars subscribed inside TaskNotes — using TaskNotes' own field names, statuses and colours.",
+			taskNotesMissing:
+				"TaskNotes isn't enabled in this vault. Install and enable it to use it as a calendar source.",
+			taskNotesEnabled: "Use TaskNotes",
+			taskNotesEnabledDesc: "Draw TaskNotes items on this calendar.",
+			taskNotesScheduled: "Scheduled tasks",
+			taskNotesScheduledDesc:
+				"Tasks on their scheduled date, sized by their time estimate.",
+			taskNotesDue: "Due dates",
+			taskNotesDueDesc: "Tasks on their due date.",
+			taskNotesRecurring: "Recurring tasks",
+			taskNotesRecurringDesc:
+				"Unroll a recurring task into one entry per occurrence. Off shows only its next date.",
+			taskNotesTimeblocks: "Timeblocks",
+			taskNotesTimeblocksDesc: "Timeblocks written into your daily notes.",
+			taskNotesFollows: (on: boolean) =>
+				`TaskNotes currently has this ${on ? "on" : "off"}.`,
+			taskNotesFollowReset: "Follow TaskNotes",
+			taskNotesCompleted: "Show completed",
+			taskNotesCompletedDesc: "Keep finished tasks on the calendar, struck through.",
+			taskNotesArchived: "Show archived",
+			taskNotesArchivedDesc: "Include tasks carrying TaskNotes' archive tag.",
+			taskNotesComplete: "Complete from the calendar",
+			taskNotesCompleteDesc:
+				"Offer a completion box on each task, writing back exactly what TaskNotes writes (per-occurrence for recurring tasks).",
+			taskNotesSubscriptions: "TaskNotes calendars",
+			taskNotesSubscriptionsDesc: (count: number) =>
+				`Also show the ${count} calendar${count === 1 ? "" : "s"} subscribed inside TaskNotes.`,
+			taskNotesSubscriptionsNone: "TaskNotes has no calendar subscriptions to show.",
+			taskNotesColorBy: "Colour by",
+			taskNotesColorByDesc: "Where each task's colour comes from.",
+			taskNotesColorStatus: "TaskNotes status",
+			taskNotesColorPriority: "TaskNotes priority",
+			taskNotesColorFixed: "One fixed colour",
+			taskNotesColor: "Task colour",
+			taskNotesColorDesc: "Used for the fixed colour, and when TaskNotes defines none.",
+			taskNotesDueColor: "Due colour",
+			taskNotesDueColorDesc: "Optional separate colour for due-date entries.",
+			taskNotesTimeblockColor: "Timeblock colour",
+			taskNotesTimeblockColorDesc: "Used for timeblocks that carry no colour of their own.",
 		},
 		heatmap: {
 			metric: "Metric",
@@ -1323,6 +1366,16 @@ export const en = {
 			eventNotes: "Notes",
 			createEventNote: "Create note",
 			openEventNote: "Open note",
+			taskNotesSource: "TaskNotes",
+			taskDue: "Due",
+			taskTimeblock: "Timeblock",
+			taskComplete: "Complete",
+			taskReopen: "Reopen",
+			taskEstimate: (minutes: number) =>
+				minutes >= 60
+					? `${Math.floor(minutes / 60)}h${minutes % 60 ? ` ${minutes % 60}m` : ""}`
+					: `${minutes}m`,
+			openTaskNote: "Open task",
 		},
 		stats: {
 			notes: "Notes",

--- a/src/tasknotes.ts
+++ b/src/tasknotes.ts
@@ -207,18 +207,27 @@ export function parseTaskNotesSettings(raw: unknown): TaskNotesSetup {
 		if (mapped) fields[key] = mapped;
 	}
 
+	// Statuses carry an explicit `order` (the cycle the checkbox walks); keeping
+	// them in it matters because "the first open status" is what a reopened task
+	// is written back to.
 	const statuses: TaskNotesStatus[] = [];
-	for (const entry of Array.isArray(s.customStatuses) ? s.customStatuses : []) {
+	const ordered: { status: TaskNotesStatus; order: number }[] = [];
+	for (const [index, entry] of (Array.isArray(s.customStatuses) ? s.customStatuses : []).entries()) {
 		const rec = asRecord(entry);
 		const value = str(rec?.value);
 		if (!value) continue;
-		statuses.push({
-			value,
-			label: str(rec?.label) || value,
-			color: str(rec?.color),
-			isCompleted: bool(rec?.isCompleted, false),
+		ordered.push({
+			status: {
+				value,
+				label: str(rec?.label) || value,
+				color: str(rec?.color),
+				isCompleted: bool(rec?.isCompleted, false),
+			},
+			order: num(rec?.order) ?? index,
 		});
 	}
+	ordered.sort((a, b) => a.order - b.order);
+	statuses.push(...ordered.map((o) => o.status));
 
 	const priorities: TaskNotesPriority[] = [];
 	for (const entry of Array.isArray(s.customPriorities) ? s.customPriorities : []) {
@@ -244,9 +253,12 @@ export function parseTaskNotesSettings(raw: unknown): TaskNotesSetup {
 			calendarSettings.defaultShowRecurring ?? calendarSettings.showRecurring,
 			true,
 		),
+		// Timeblocking is opt-in inside TaskNotes (`enableTimeblocking`, off by
+		// default) and lives with the calendar settings — a vault that never
+		// turned it on has no timeblocks to draw.
 		timeblocks: bool(
 			calendarSettings.defaultShowTimeblocks ?? calendarSettings.showTimeblocks,
-			bool(s.enableTimeblocking, true),
+			bool(calendarSettings.enableTimeblocking ?? s.enableTimeblocking, false),
 		),
 	};
 
@@ -267,7 +279,10 @@ export function parseTaskNotesSettings(raw: unknown): TaskNotesSetup {
 			property: str(s.taskPropertyName),
 			value: str(s.taskPropertyValue),
 		},
-		defaultTimeEstimate: Math.max(0, num(s.defaultTimeEstimate) ?? 60),
+		// TaskNotes defaults this to 0 ("no estimate"), which is a length a
+		// calendar can't draw — a timed task with no estimate gets an hour, the
+		// same block TaskNotes' own calendar gives it.
+		defaultTimeEstimate: Math.max(0, num(s.defaultTimeEstimate) || 0) || 60,
 		calendar,
 		subscriptions,
 	};
@@ -855,17 +870,27 @@ export function completionEdit(
 }
 
 
-/** The status value a finished task takes: TaskNotes' first completed status,
- * or plain "done" when none is configured. */
+/** The status value a finished task takes: TaskNotes' own first completed
+ * status (in its configured order), or plain "done" when its statuses couldn't
+ * be read. Writing a value TaskNotes doesn't define would leave the task in a
+ * status its own views don't understand, so its list always wins. */
 export function completeStatusValue(setup: TaskNotesSetup): string {
 	return setup.statuses.find((s) => s.isCompleted)?.value ?? "done";
 }
 
 
-/** The status value a reopened task takes: TaskNotes' first open status, or
- * "open". */
+/**
+ * The status value a reopened task takes: TaskNotes' first open status, skipping
+ * its placeholder "none" (which means "no status set", not "open") so reopening
+ * lands a task somewhere its own views actually show it. Falls back to "open".
+ */
 export function openStatusValue(setup: TaskNotesSetup): string {
-	return setup.statuses.find((s) => !s.isCompleted)?.value ?? "open";
+	const open = setup.statuses.filter((s) => !s.isCompleted);
+	return (
+		open.find((s) => s.value.trim().toLowerCase() !== "none")?.value ??
+		open[0]?.value ??
+		"open"
+	);
 }
 
 

--- a/src/tasknotes.ts
+++ b/src/tasknotes.ts
@@ -242,30 +242,11 @@ export function parseTaskNotesSettings(raw: unknown): TaskNotesSetup {
 		),
 	};
 
+	// Calendar subscriptions normally live in TaskNotes' plugin *data* rather
+	// than its settings (see `loadTaskNotesSubscriptions`); these two keys are
+	// only the fallback for versions that do keep them in settings.
 	const ics = asRecord(s.icsIntegration) ?? {};
-	const subs = Array.isArray(ics.subscriptions)
-		? ics.subscriptions
-		: Array.isArray(s.icsSubscriptions)
-			? s.icsSubscriptions
-			: [];
-	const subscriptions: TaskNotesSubscription[] = [];
-	for (const entry of subs) {
-		const rec = asRecord(entry);
-		if (!rec) continue;
-		const url = str(rec.url);
-		const filePath = str(rec.filePath);
-		if (!url && !filePath) continue;
-		const type = str(rec.type).toLowerCase() === "local" || (!url && filePath) ? "local" : "remote";
-		subscriptions.push({
-			id: str(rec.id) || url || filePath,
-			name: str(rec.name),
-			type,
-			url,
-			filePath,
-			color: str(rec.color),
-			enabled: bool(rec.enabled, true),
-		});
-	}
+	const subscriptions = parseSubscriptions(ics.subscriptions ?? s.icsSubscriptions);
 
 	const method = str(s.taskIdentificationMethod).toLowerCase() === "property" ? "property" : "tag";
 	return {
@@ -282,6 +263,34 @@ export function parseTaskNotesSettings(raw: unknown): TaskNotesSetup {
 		calendar,
 		subscriptions,
 	};
+}
+
+
+/** Read a list of TaskNotes calendar subscriptions from whatever shape it
+ * arrives in (its settings, its plugin data, or its subscription service).
+ * Entries with neither a URL nor a file path are dropped — there is nothing to
+ * fetch — and a missing `type` is inferred from which of the two is set. */
+export function parseSubscriptions(raw: unknown): TaskNotesSubscription[] {
+	if (!Array.isArray(raw)) return [];
+	const out: TaskNotesSubscription[] = [];
+	for (const entry of raw) {
+		const rec = asRecord(entry);
+		if (!rec) continue;
+		const url = str(rec.url);
+		const filePath = str(rec.filePath);
+		if (!url && !filePath) continue;
+		const type = str(rec.type).toLowerCase() === "local" || (!url && filePath) ? "local" : "remote";
+		out.push({
+			id: str(rec.id) || url || filePath,
+			name: str(rec.name),
+			type,
+			url,
+			filePath,
+			color: str(rec.color),
+			enabled: bool(rec.enabled, true),
+		});
+	}
+	return out;
 }
 
 
@@ -862,6 +871,12 @@ export interface TaskNotesLike {
 	openTaskEditModal?: (task: unknown) => unknown;
 	cacheManager?: { getTaskInfo?: (path: string) => unknown };
 	api?: { tasks?: { get?: (path: string) => unknown } };
+	/** TaskNotes' calendar-subscription service. Its `getSubscriptions()` is the
+	 * live list, including any added since the plugin loaded. */
+	icsSubscriptionService?: { getSubscriptions?: () => unknown };
+	/** Obsidian's own plugin-data reader. TaskNotes persists its subscriptions
+	 * under `icsSubscriptions` in that data, *outside* its settings object. */
+	loadData?: () => Promise<unknown>;
 }
 
 
@@ -876,6 +891,72 @@ export function taskNotesPlugin(app: App): TaskNotesLike | null {
  * isn't installed (so callers never branch on null). */
 export function readTaskNotesSetup(app: App): TaskNotesSetup {
 	return parseTaskNotesSettings(taskNotesPlugin(app)?.settings);
+}
+
+
+/** Last list read from TaskNotes' plugin data, so a synchronous caller (a card
+ * render, the editor) can show subscriptions the async read already found. */
+let dataSubscriptions: TaskNotesSubscription[] | null = null;
+
+
+/**
+ * TaskNotes' calendar subscriptions, read synchronously.
+ *
+ * They are *not* part of TaskNotes' settings object: its subscription service
+ * persists them under `icsSubscriptions` in the plugin's own data file. So the
+ * live service is asked first, then whatever the last async read of that data
+ * found, and only then the settings — which older versions did use.
+ */
+export function taskNotesSubscriptions(app: App, setup: TaskNotesSetup): TaskNotesSubscription[] {
+	const service = taskNotesPlugin(app)?.icsSubscriptionService;
+	if (typeof service?.getSubscriptions === "function") {
+		try {
+			const live = parseSubscriptions(service.getSubscriptions());
+			if (live.length) return live;
+		} catch {
+			// Service present but unhappy — fall through to the cached data.
+		}
+	}
+	if (dataSubscriptions?.length) return dataSubscriptions;
+	return setup.subscriptions;
+}
+
+
+/** Re-read TaskNotes' subscriptions, including the asynchronous plugin-data
+ * path the synchronous reader can't take. Call it alongside a feed refresh;
+ * the result is cached for `taskNotesSubscriptions`. */
+export async function loadTaskNotesSubscriptions(
+	app: App,
+	setup: TaskNotesSetup,
+): Promise<TaskNotesSubscription[]> {
+	const plugin = taskNotesPlugin(app);
+	const service = plugin?.icsSubscriptionService;
+	if (typeof service?.getSubscriptions === "function") {
+		try {
+			const live = parseSubscriptions(service.getSubscriptions());
+			if (live.length) {
+				dataSubscriptions = live;
+				return live;
+			}
+		} catch {
+			// Fall through to the plugin data.
+		}
+	}
+	if (typeof plugin?.loadData === "function") {
+		try {
+			const data = await plugin.loadData();
+			const stored = parseSubscriptions(
+				(data && typeof data === "object" ? (data as Record<string, unknown>) : {}).icsSubscriptions,
+			);
+			if (stored.length) {
+				dataSubscriptions = stored;
+				return stored;
+			}
+		} catch {
+			// Unreadable data — fall back to the settings copy.
+		}
+	}
+	return taskNotesSubscriptions(app, setup);
 }
 
 

--- a/src/tasknotes.ts
+++ b/src/tasknotes.ts
@@ -25,7 +25,15 @@
  */
 import { TFile, type App } from "obsidian";
 import { localDayKey } from "./dates";
-import { expandEvents, parseIcs, type IcsCalendar, type IcsEvent, type IcsOccurrence } from "./ics";
+import {
+	calendarStatus,
+	expandEvents,
+	parseIcs,
+	type IcsCalendar,
+	type IcsEvent,
+	type IcsOccurrence,
+	type IcsStatus,
+} from "./ics";
 
 
 /** Community plugin id for TaskNotes. */
@@ -1050,22 +1058,34 @@ export function readTaskAt(app: App, setup: TaskNotesSetup, path: string): TaskN
 
 /** Cache for local (in-vault) .ics subscriptions, keyed by path and
  * invalidated by the file's mtime — the remote ones are cached by ics.ts. */
-const localCache = new Map<string, { mtime: number; cal: IcsCalendar | null }>();
+const localCache = new Map<string, { mtime: number; cal: IcsCalendar | null; error: string | null }>();
 
 
 /** The parsed calendar for an in-vault .ics file, re-read only when the file
- * changed. Never throws: an unreadable or unparseable file yields null. */
+ * changed. Never throws: an unreadable or unparseable file yields null, with
+ * the reason kept for `subscriptionStatus`. */
 export async function loadLocalCalendar(app: App, path: string): Promise<IcsCalendar | null> {
 	const file = app.vault.getAbstractFileByPath(path);
-	if (!(file instanceof TFile)) return null;
+	if (!(file instanceof TFile)) {
+		localCache.set(path, { mtime: 0, cal: null, error: "missing-file" });
+		return null;
+	}
 	const cached = localCache.get(path);
 	if (cached && cached.mtime === file.stat.mtime) return cached.cal;
 	try {
 		const cal = parseIcs(await app.vault.cachedRead(file));
-		localCache.set(path, { mtime: file.stat.mtime, cal });
+		localCache.set(path, {
+			mtime: file.stat.mtime,
+			cal,
+			error: cal ? null : "not-calendar",
+		});
 		return cal;
-	} catch {
-		localCache.set(path, { mtime: file.stat.mtime, cal: null });
+	} catch (e) {
+		localCache.set(path, {
+			mtime: file.stat.mtime,
+			cal: null,
+			error: e instanceof Error ? e.message : String(e),
+		});
 		return null;
 	}
 }
@@ -1074,6 +1094,22 @@ export async function loadLocalCalendar(app: App, path: string): Promise<IcsCale
 /** The last-read calendar for an in-vault .ics file, without touching disk. */
 export function cachedLocalCalendar(path: string): IcsCalendar | null {
 	return localCache.get(path)?.cal ?? null;
+}
+
+
+/** How the last load of one subscription went, whichever kind it is — so the
+ * editor can say which calendar didn't come through, and why, instead of the
+ * card silently showing nothing for it. */
+export function subscriptionStatus(sub: TaskNotesSubscription): IcsStatus {
+	if (sub.type !== "local") return calendarStatus(sub.url);
+	const entry = localCache.get(sub.filePath);
+	return {
+		loaded: !!entry?.cal,
+		events: entry?.cal?.events.length ?? 0,
+		fetched: entry?.cal?.fetched ?? null,
+		error: entry?.error ?? null,
+		blocked: false,
+	};
 }
 
 

--- a/src/tasknotes.ts
+++ b/src/tasknotes.ts
@@ -1,0 +1,1050 @@
+/**
+ * TaskNotes integration.
+ *
+ * TaskNotes stores everything it knows in note frontmatter and in its own
+ * plugin settings — it ships no stable public API and no published types, so
+ * every accessor here is duck-typed and defensive: a missing, renamed or
+ * reshaped field falls back to the documented default rather than throwing.
+ *
+ * Two consumers use this module:
+ *
+ *   - "tasks" cards, for opening a task in TaskNotes' own edit modal.
+ *   - "calendar" cards, which can take TaskNotes as an event source and mirror
+ *     what TaskNotes' own calendar view shows: scheduled tasks (with their time
+ *     estimate as the event length), due dates, recurring instances expanded
+ *     per occurrence, timeblocks from daily notes, and the ICS subscriptions
+ *     configured inside TaskNotes itself.
+ *
+ * Because TaskNotes' field names, statuses, priorities and identification rule
+ * are all user-configurable, the card reads them from TaskNotes' settings
+ * instead of hard-coding them: a vault that renamed `due` to `deadline`, or
+ * marks tasks with a property instead of a tag, still resolves correctly.
+ *
+ * Everything below the "Reading the vault" divider needs the Obsidian runtime;
+ * everything above it is pure, so the resolution rules are unit-tested.
+ */
+import { TFile, type App } from "obsidian";
+import { localDayKey } from "./dates";
+import { expandEvents, parseIcs, type IcsCalendar, type IcsEvent, type IcsOccurrence } from "./ics";
+
+
+/** Community plugin id for TaskNotes. */
+export const TASKNOTES_PLUGIN_ID = "tasknotes";
+
+
+/** Whether TaskNotes is installed and enabled in this vault. */
+export function taskNotesEnabled(app: App): boolean {
+	return app.plugins.enabledPlugins.has(TASKNOTES_PLUGIN_ID);
+}
+
+
+// ---- TaskNotes settings ---------------------------------------------------
+
+/** The frontmatter property each TaskNotes value lives in. TaskNotes lets the
+ * user remap every one of them (Settings → TaskNotes → Field mapping), so the
+ * names below are only the defaults. */
+export interface TaskNotesFieldMapping {
+	title: string;
+	status: string;
+	priority: string;
+	due: string;
+	scheduled: string;
+	contexts: string;
+	projects: string;
+	timeEstimate: string;
+	recurrence: string;
+	completeInstances: string;
+	completedDate: string;
+	/** Tag marking an archived task (stored without the leading "#"). */
+	archiveTag: string;
+}
+
+
+export const DEFAULT_TASKNOTES_FIELDS: TaskNotesFieldMapping = {
+	title: "title",
+	status: "status",
+	priority: "priority",
+	due: "due",
+	scheduled: "scheduled",
+	contexts: "contexts",
+	projects: "projects",
+	timeEstimate: "timeEstimate",
+	recurrence: "recurrence",
+	completeInstances: "complete_instances",
+	completedDate: "completedDate",
+	archiveTag: "archived",
+};
+
+
+/** One of TaskNotes' configurable statuses: the raw frontmatter value, how it
+ * reads, the colour its dot/chip takes, and whether it counts as complete. */
+export interface TaskNotesStatus {
+	value: string;
+	label: string;
+	color: string;
+	isCompleted: boolean;
+}
+
+
+/** One of TaskNotes' configurable priorities. */
+export interface TaskNotesPriority {
+	value: string;
+	label: string;
+	color: string;
+	weight: number;
+}
+
+
+/** An ICS calendar subscribed inside TaskNotes (Settings → TaskNotes →
+ * Calendar subscriptions). Either a remote feed (`url`) or a `.ics` file in
+ * the vault (`filePath`). */
+export interface TaskNotesSubscription {
+	id: string;
+	name: string;
+	type: "remote" | "local";
+	url: string;
+	filePath: string;
+	color: string;
+	enabled: boolean;
+}
+
+
+/** Which layers TaskNotes' own calendar view is showing. Used as the default
+ * for the card's per-layer toggles, so an unconfigured Hearth calendar mirrors
+ * whatever the user already set up inside TaskNotes. */
+export interface TaskNotesCalendarDefaults {
+	scheduled: boolean;
+	due: boolean;
+	recurring: boolean;
+	timeblocks: boolean;
+}
+
+
+/** Everything the calendar card needs to read a vault the way TaskNotes does. */
+export interface TaskNotesSetup {
+	fields: TaskNotesFieldMapping;
+	statuses: TaskNotesStatus[];
+	priorities: TaskNotesPriority[];
+	/** How TaskNotes decides a note is a task. */
+	identify: { method: "tag" | "property"; tag: string; property: string; value: string };
+	/** Minutes a scheduled task occupies when it carries no time estimate. */
+	defaultTimeEstimate: number;
+	calendar: TaskNotesCalendarDefaults;
+	subscriptions: TaskNotesSubscription[];
+}
+
+
+/** A record-ish view of an unknown value, or null when it isn't an object. */
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+
+/** A trimmed string from an unknown value, or "" when it isn't usable text. */
+function str(value: unknown): string {
+	if (typeof value === "string") return value.trim();
+	if (typeof value === "number" && Number.isFinite(value)) return String(value);
+	return "";
+}
+
+
+/** A finite number from an unknown value, or null. Strings are accepted since
+ * frontmatter often carries `timeEstimate: "45"`. */
+function num(value: unknown): number | null {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim()) {
+		const n = Number(value.trim());
+		if (Number.isFinite(n)) return n;
+	}
+	return null;
+}
+
+
+/** A boolean from an unknown value, or the fallback when it isn't one. */
+function bool(value: unknown, fallback: boolean): boolean {
+	return typeof value === "boolean" ? value : fallback;
+}
+
+
+/** A string list from an unknown value: a YAML list becomes its entries, a
+ * scalar becomes a single entry, anything else becomes nothing. */
+function strList(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		const out: string[] = [];
+		for (const v of value) {
+			const s = str(v);
+			if (s && !out.includes(s)) out.push(s);
+		}
+		return out;
+	}
+	const s = str(value);
+	return s ? [s] : [];
+}
+
+
+/**
+ * Read TaskNotes' settings object into the shape this module works with.
+ * Pure, so the (necessarily loose) duck-typing is testable: every field is
+ * probed and falls back to TaskNotes' own documented default when absent.
+ */
+export function parseTaskNotesSettings(raw: unknown): TaskNotesSetup {
+	const s = asRecord(raw) ?? {};
+
+	const mapping = asRecord(s.fieldMapping) ?? {};
+	const fields: TaskNotesFieldMapping = { ...DEFAULT_TASKNOTES_FIELDS };
+	for (const key of Object.keys(fields) as (keyof TaskNotesFieldMapping)[]) {
+		const mapped = str(mapping[key]);
+		if (mapped) fields[key] = mapped;
+	}
+
+	const statuses: TaskNotesStatus[] = [];
+	for (const entry of Array.isArray(s.customStatuses) ? s.customStatuses : []) {
+		const rec = asRecord(entry);
+		const value = str(rec?.value);
+		if (!value) continue;
+		statuses.push({
+			value,
+			label: str(rec?.label) || value,
+			color: str(rec?.color),
+			isCompleted: bool(rec?.isCompleted, false),
+		});
+	}
+
+	const priorities: TaskNotesPriority[] = [];
+	for (const entry of Array.isArray(s.customPriorities) ? s.customPriorities : []) {
+		const rec = asRecord(entry);
+		const value = str(rec?.value);
+		if (!value) continue;
+		priorities.push({
+			value,
+			label: str(rec?.label) || value,
+			color: str(rec?.color),
+			weight: num(rec?.weight) ?? 0,
+		});
+	}
+
+	// TaskNotes' calendar view settings live under one of a couple of keys
+	// depending on version; both are read, the first that exists wins.
+	const calendarSettings =
+		asRecord(s.calendarViewSettings) ?? asRecord(s.advancedCalendarViewSettings) ?? {};
+	const calendar: TaskNotesCalendarDefaults = {
+		scheduled: bool(calendarSettings.defaultShowScheduled ?? calendarSettings.showScheduled, true),
+		due: bool(calendarSettings.defaultShowDue ?? calendarSettings.showDue, true),
+		recurring: bool(
+			calendarSettings.defaultShowRecurring ?? calendarSettings.showRecurring,
+			true,
+		),
+		timeblocks: bool(
+			calendarSettings.defaultShowTimeblocks ?? calendarSettings.showTimeblocks,
+			bool(s.enableTimeblocking, true),
+		),
+	};
+
+	const ics = asRecord(s.icsIntegration) ?? {};
+	const subs = Array.isArray(ics.subscriptions)
+		? ics.subscriptions
+		: Array.isArray(s.icsSubscriptions)
+			? s.icsSubscriptions
+			: [];
+	const subscriptions: TaskNotesSubscription[] = [];
+	for (const entry of subs) {
+		const rec = asRecord(entry);
+		if (!rec) continue;
+		const url = str(rec.url);
+		const filePath = str(rec.filePath);
+		if (!url && !filePath) continue;
+		const type = str(rec.type).toLowerCase() === "local" || (!url && filePath) ? "local" : "remote";
+		subscriptions.push({
+			id: str(rec.id) || url || filePath,
+			name: str(rec.name),
+			type,
+			url,
+			filePath,
+			color: str(rec.color),
+			enabled: bool(rec.enabled, true),
+		});
+	}
+
+	const method = str(s.taskIdentificationMethod).toLowerCase() === "property" ? "property" : "tag";
+	return {
+		fields,
+		statuses,
+		priorities,
+		identify: {
+			method,
+			tag: str(s.taskTag).replace(/^#/, "") || "task",
+			property: str(s.taskPropertyName),
+			value: str(s.taskPropertyValue),
+		},
+		defaultTimeEstimate: Math.max(0, num(s.defaultTimeEstimate) ?? 60),
+		calendar,
+		subscriptions,
+	};
+}
+
+
+/** The colour TaskNotes draws a status value in, or "" when it defines none. */
+export function statusColor(setup: TaskNotesSetup, value: string): string {
+	return statusDef(setup, value)?.color ?? "";
+}
+
+
+/** The status definition matching a raw frontmatter value (case-insensitive). */
+export function statusDef(setup: TaskNotesSetup, value: string): TaskNotesStatus | null {
+	const needle = value.trim().toLowerCase();
+	if (!needle) return null;
+	return (
+		setup.statuses.find((s) => s.value.trim().toLowerCase() === needle) ??
+		setup.statuses.find((s) => s.label.trim().toLowerCase() === needle) ??
+		null
+	);
+}
+
+
+/** The priority definition matching a raw frontmatter value. */
+export function priorityDef(setup: TaskNotesSetup, value: string): TaskNotesPriority | null {
+	const needle = value.trim().toLowerCase();
+	if (!needle) return null;
+	return (
+		setup.priorities.find((p) => p.value.trim().toLowerCase() === needle) ??
+		setup.priorities.find((p) => p.label.trim().toLowerCase() === needle) ??
+		null
+	);
+}
+
+
+/** Whether a status value counts as complete. TaskNotes marks that on the
+ * status itself (`isCompleted`); with no matching definition — a vault that
+ * never customised its statuses — the conventional "done"/"completed"/
+ * "cancelled" wording is used. */
+export function isCompletedStatus(setup: TaskNotesSetup, value: string): boolean {
+	const def = statusDef(setup, value);
+	if (def) return def.isCompleted;
+	const v = value.trim().toLowerCase();
+	return v === "done" || v === "complete" || v === "completed" || v === "cancelled" || v === "canceled";
+}
+
+
+// ---- Tasks ----------------------------------------------------------------
+
+/** A TaskNotes task, as read from one note's frontmatter. */
+export interface TaskNotesTask {
+	path: string;
+	title: string;
+	status: string;
+	priority: string;
+	/** Raw frontmatter dates, date-only or with a time component. */
+	due: string | null;
+	scheduled: string | null;
+	recurrence: string | null;
+	completeInstances: string[];
+	contexts: string[];
+	projects: string[];
+	/** Minutes, when the task carries an estimate. */
+	timeEstimate: number | null;
+	archived: boolean;
+	done: boolean;
+}
+
+
+/**
+ * Read one note's frontmatter as a TaskNotes task, or null when the note isn't
+ * one. Identification mirrors TaskNotes' own rule: either the task tag (the
+ * default) or a property/value pair. `tags` should hold the note's tags without
+ * their leading "#".
+ */
+export function readTaskNotesTask(
+	setup: TaskNotesSetup,
+	path: string,
+	frontmatter: Record<string, unknown> | undefined,
+	tags: string[],
+): TaskNotesTask | null {
+	if (!frontmatter) return null;
+	const f = setup.fields;
+	if (!isTaskNote(setup, frontmatter, tags)) return null;
+
+	const status = str(frontmatter[f.status]);
+	const projects = strList(frontmatter[f.projects]);
+	const title = str(frontmatter[f.title]) || basename(path);
+	return {
+		path,
+		title,
+		status,
+		priority: str(frontmatter[f.priority]),
+		due: str(frontmatter[f.due]) || null,
+		scheduled: str(frontmatter[f.scheduled]) || null,
+		recurrence: str(frontmatter[f.recurrence]) || null,
+		completeInstances: strList(frontmatter[f.completeInstances]).map((d) => d.slice(0, 10)),
+		contexts: strList(frontmatter[f.contexts]),
+		projects,
+		timeEstimate: num(frontmatter[f.timeEstimate]),
+		archived: tags.some((t) => t.toLowerCase() === f.archiveTag.toLowerCase()),
+		done: isCompletedStatus(setup, status),
+	};
+}
+
+
+/** Whether a note is one of TaskNotes' task notes. */
+function isTaskNote(
+	setup: TaskNotesSetup,
+	frontmatter: Record<string, unknown>,
+	tags: string[],
+): boolean {
+	const { method, tag, property, value } = setup.identify;
+	if (method === "property" && property) {
+		const held = frontmatter[property];
+		if (held === undefined || held === null) return false;
+		if (!value) return true;
+		const needle = value.trim().toLowerCase();
+		return strList(held).some((v) => v.trim().toLowerCase() === needle);
+	}
+	if (tag && tags.some((t) => t.toLowerCase() === tag.toLowerCase())) return true;
+	// A vault whose tag/property rule doesn't match still yields tasks when the
+	// note carries TaskNotes' status field — the same fallback the tasks card
+	// has always used, so a hand-rolled setup isn't silently empty.
+	return setup.fields.status in frontmatter;
+}
+
+
+function basename(path: string): string {
+	const name = path.slice(path.lastIndexOf("/") + 1);
+	return name.replace(/\.md$/i, "");
+}
+
+
+// ---- Calendar entries -----------------------------------------------------
+
+/** What a calendar entry produced from TaskNotes represents. */
+export type TaskNotesEntryKind = "scheduled" | "due" | "timeblock";
+
+
+/** The TaskNotes payload carried on an occurrence, so the calendar card can
+ * style the entry, open the right note and complete the right occurrence. */
+export interface TaskNotesMeta {
+	kind: TaskNotesEntryKind;
+	/** The note the entry lives in: the task note, or the daily note holding
+	 * the timeblock. */
+	path: string;
+	title: string;
+	status: string;
+	statusLabel: string;
+	priority: string;
+	priorityLabel: string;
+	contexts: string[];
+	projects: string[];
+	/** Whether the task carries a recurrence rule. */
+	recurring: boolean;
+	/** Whether this occurrence is complete: a done task, or a recurring task
+	 * whose `complete_instances` already lists this day. */
+	done: boolean;
+	/** The occurrence's local day (YYYY-MM-DD), the key recurring completion
+	 * is recorded under. */
+	dayKey: string;
+	/** Colour TaskNotes would draw this entry in, when it defines one. */
+	color: string;
+	/** Minutes the task estimates, when it carries an estimate. */
+	timeEstimate: number | null;
+}
+
+
+/** The TaskNotes payload on an occurrence, or null for an ordinary ICS event. */
+export function taskNotesMeta(ev: IcsOccurrence): TaskNotesMeta | null {
+	const meta = ev.meta;
+	if (!meta || typeof meta !== "object") return null;
+	const candidate = meta as Partial<TaskNotesMeta>;
+	return typeof candidate.kind === "string" && typeof candidate.path === "string"
+		? (meta as TaskNotesMeta)
+		: null;
+}
+
+
+/** Which TaskNotes layers a calendar card draws, and how it colours them.
+ * Every flag is resolved by the caller (card config → TaskNotes' own calendar
+ * settings → the defaults here), so this stays a plain data input. */
+export interface TaskNotesLayerOptions {
+	scheduled: boolean;
+	due: boolean;
+	recurring: boolean;
+	timeblocks: boolean;
+	/** Include tasks whose status counts as complete. */
+	completed: boolean;
+	/** Include tasks tagged with TaskNotes' archive tag. */
+	archived: boolean;
+	/** Where an entry's colour comes from. */
+	colorBy: "status" | "priority" | "fixed";
+	/** Colour used when `colorBy` is "fixed", or when the chosen source
+	 * defines none. */
+	fallbackColor: string;
+	/** Colour for due-date entries, when set (they read differently from a
+	 * scheduled block, so TaskNotes colours them separately too). */
+	dueColor?: string;
+}
+
+
+export const DEFAULT_TASKNOTES_LAYERS: TaskNotesLayerOptions = {
+	scheduled: true,
+	due: true,
+	recurring: true,
+	timeblocks: true,
+	completed: true,
+	archived: false,
+	colorBy: "status",
+	fallbackColor: "",
+	dueColor: "",
+};
+
+
+/** Parse a TaskNotes date value (`YYYY-MM-DD`, or with a time component) into
+ * epoch ms plus whether it is date-only. Null when unparseable. Times are read
+ * as local wall-clock, matching how TaskNotes writes and shows them. */
+export function parseTaskDate(value: string): { ms: number; allDay: boolean } | null {
+	const v = value.trim();
+	const m = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/.exec(v);
+	if (!m) return null;
+	const [, y, mo, d, h, mi, s] = m;
+	if (h === undefined) return { ms: new Date(+y, +mo - 1, +d).getTime(), allDay: true };
+	return { ms: new Date(+y, +mo - 1, +d, +h, +mi, +(s ?? 0)).getTime(), allDay: false };
+}
+
+
+/**
+ * Normalise a TaskNotes recurrence value into an RRULE body (no `RRULE:`
+ * prefix), or null when it says nothing. TaskNotes writes real RRULEs, but
+ * older notes (and its own legacy `recurrence: {frequency: weekly, days: […]}`
+ * form) use plain words, which map onto the same FREQ values.
+ */
+export function normalizeRecurrence(rule: string): string | null {
+	const raw = rule.trim();
+	if (!raw) return null;
+	const body = raw.replace(/^RRULE:/i, "").trim();
+	if (/FREQ=/i.test(body)) return body;
+	const word = body.toLowerCase();
+	const simple: Record<string, string> = {
+		daily: "FREQ=DAILY",
+		weekly: "FREQ=WEEKLY",
+		biweekly: "FREQ=WEEKLY;INTERVAL=2",
+		fortnightly: "FREQ=WEEKLY;INTERVAL=2",
+		monthly: "FREQ=MONTHLY",
+		yearly: "FREQ=YEARLY",
+		annually: "FREQ=YEARLY",
+	};
+	return simple[word] ?? null;
+}
+
+
+/** The colour an entry takes, per the card's colouring rule. */
+function entryColor(
+	setup: TaskNotesSetup,
+	task: TaskNotesTask,
+	opts: TaskNotesLayerOptions,
+	kind: TaskNotesEntryKind,
+): string {
+	if (kind === "due" && opts.dueColor) return opts.dueColor;
+	if (opts.colorBy === "fixed") return opts.fallbackColor;
+	const primary =
+		opts.colorBy === "priority"
+			? priorityDef(setup, task.priority)?.color
+			: statusDef(setup, task.status)?.color;
+	if (primary) return primary;
+	const secondary =
+		opts.colorBy === "priority"
+			? statusDef(setup, task.status)?.color
+			: priorityDef(setup, task.priority)?.color;
+	return secondary || opts.fallbackColor;
+}
+
+
+/** The base (occurrence-independent) meta for one task entry. */
+function baseMeta(
+	setup: TaskNotesSetup,
+	task: TaskNotesTask,
+	opts: TaskNotesLayerOptions,
+	kind: TaskNotesEntryKind,
+): TaskNotesMeta {
+	return {
+		kind,
+		path: task.path,
+		title: task.title,
+		status: task.status,
+		statusLabel: statusDef(setup, task.status)?.label || task.status,
+		priority: task.priority,
+		priorityLabel: priorityDef(setup, task.priority)?.label || task.priority,
+		contexts: task.contexts,
+		projects: task.projects,
+		recurring: !!task.recurrence,
+		done: task.done,
+		dayKey: "",
+		color: entryColor(setup, task, opts, kind),
+		timeEstimate: task.timeEstimate,
+	};
+}
+
+
+/**
+ * Build the calendar occurrences a set of TaskNotes tasks produces inside
+ * `[windowStart, windowEnd)`: one entry per scheduled date, one per due date,
+ * and — for a recurring task — one per occurrence of its rule, each carrying
+ * whether that specific day is already complete.
+ *
+ * Recurrence is unrolled by the same RRULE engine the ICS feeds use, so a
+ * TaskNotes task and a subscribed calendar event expand identically.
+ */
+export function taskNotesEvents(
+	tasks: TaskNotesTask[],
+	setup: TaskNotesSetup,
+	opts: TaskNotesLayerOptions,
+	windowStart: number,
+	windowEnd: number,
+): IcsOccurrence[] {
+	const events: IcsEvent[] = [];
+	for (const task of tasks) {
+		if (task.archived && !opts.archived) continue;
+		if (task.done && !opts.completed) continue;
+		const rrule = task.recurrence ? normalizeRecurrence(task.recurrence) : null;
+		// A recurring task is a series; with the recurring layer off only its
+		// anchor date is drawn, exactly as a one-off would be.
+		const rule = opts.recurring ? rrule : null;
+
+		if (opts.scheduled && task.scheduled) {
+			const at = parseTaskDate(task.scheduled);
+			if (at) {
+				const minutes = task.timeEstimate ?? setup.defaultTimeEstimate;
+				events.push({
+					uid: `tasknotes:${task.path}:scheduled`,
+					summary: task.title,
+					location: "",
+					description: "",
+					url: "",
+					start: at.ms,
+					end: at.allDay
+						? at.ms + 86400_000
+						: minutes > 0
+							? at.ms + minutes * 60_000
+							: null,
+					allDay: at.allDay,
+					rrule: rule,
+					exdates: [],
+					meta: baseMeta(setup, task, opts, "scheduled"),
+				});
+			}
+		}
+
+		if (opts.due && task.due) {
+			const at = parseTaskDate(task.due);
+			// A task with the same scheduled and due date would otherwise draw
+			// twice on the same day; TaskNotes shows the block once.
+			const sameAsScheduled =
+				opts.scheduled && task.scheduled ? task.due.slice(0, 10) === task.scheduled.slice(0, 10) : false;
+			if (at && !sameAsScheduled) {
+				events.push({
+					uid: `tasknotes:${task.path}:due`,
+					summary: task.title,
+					location: "",
+					description: "",
+					url: "",
+					start: at.ms,
+					end: at.allDay ? at.ms + 86400_000 : null,
+					allDay: at.allDay,
+					// Only the scheduled series recurs; the due date of a recurring
+					// task follows its scheduled roll-forward, so it isn't unrolled.
+					rrule: task.scheduled ? null : rule,
+					exdates: [],
+					meta: baseMeta(setup, task, opts, "due"),
+				});
+			}
+		}
+	}
+
+	const done = new Map<string, Set<string>>();
+	for (const task of tasks) {
+		if (task.completeInstances.length) done.set(task.path, new Set(task.completeInstances));
+	}
+
+	const out = expandEvents(events, windowStart, windowEnd);
+	for (const occ of out) {
+		const meta = taskNotesMeta(occ);
+		if (!meta) continue;
+		const dayKey = localDayKey(occ.start);
+		// The shared base meta is one object per event; each occurrence needs its
+		// own day and completion state.
+		occ.meta = {
+			...meta,
+			dayKey,
+			done: meta.recurring ? (done.get(meta.path)?.has(dayKey) ?? false) : meta.done,
+		} satisfies TaskNotesMeta;
+	}
+	return out;
+}
+
+
+// ---- Timeblocks -----------------------------------------------------------
+
+/** A TaskNotes timeblock, stored in a daily note's `timeblocks` frontmatter. */
+export interface TaskNotesTimeblock {
+	id: string;
+	title: string;
+	/** Local wall-clock "HH:mm". */
+	startTime: string;
+	endTime: string;
+	color: string;
+	attachments: string[];
+	description: string;
+}
+
+
+/** Read a daily note's `timeblocks` frontmatter value into timeblocks,
+ * skipping entries with no usable start time. */
+export function readTimeblocks(raw: unknown): TaskNotesTimeblock[] {
+	if (!Array.isArray(raw)) return [];
+	const out: TaskNotesTimeblock[] = [];
+	for (const entry of raw) {
+		const rec = asRecord(entry);
+		if (!rec) continue;
+		const startTime = normalizeClock(str(rec.startTime));
+		if (!startTime) continue;
+		out.push({
+			id: str(rec.id),
+			title: str(rec.title) || str(rec.name),
+			startTime,
+			endTime: normalizeClock(str(rec.endTime)),
+			color: str(rec.color),
+			attachments: strList(rec.attachments),
+			description: str(rec.description),
+		});
+	}
+	return out;
+}
+
+
+/** Normalise an "H:mm"/"HH:mm"/"HH:mm:ss" clock value to "HH:mm", or "". */
+function normalizeClock(value: string): string {
+	const m = /^(\d{1,2}):(\d{2})(?::\d{2})?$/.exec(value.trim());
+	if (!m) return "";
+	const h = Math.min(23, +m[1]);
+	return `${String(h).padStart(2, "0")}:${m[2]}`;
+}
+
+
+/** Turn one day's timeblocks into calendar occurrences. `dayKey` is the daily
+ * note's date (YYYY-MM-DD) and `path` the note holding them, so clicking a
+ * block opens the day it belongs to. */
+export function timeblockOccurrences(
+	dayKey: string,
+	blocks: TaskNotesTimeblock[],
+	path: string,
+	fallbackColor: string,
+): IcsOccurrence[] {
+	const day = parseTaskDate(dayKey);
+	if (!day) return [];
+	const out: IcsOccurrence[] = [];
+	for (const block of blocks) {
+		const start = clockMs(day.ms, block.startTime);
+		if (start === null) continue;
+		const end = block.endTime ? clockMs(day.ms, block.endTime) : null;
+		const meta: TaskNotesMeta = {
+			kind: "timeblock",
+			path,
+			title: block.title,
+			status: "",
+			statusLabel: "",
+			priority: "",
+			priorityLabel: "",
+			contexts: [],
+			projects: [],
+			recurring: false,
+			done: false,
+			dayKey,
+			color: block.color || fallbackColor,
+			timeEstimate: null,
+		};
+		out.push({
+			uid: `tasknotes:timeblock:${path}:${block.id || block.startTime}`,
+			summary: block.title,
+			location: "",
+			description: block.description,
+			url: "",
+			start,
+			// An end before the start (a block crossing midnight was written the
+			// other way round) is dropped rather than drawn backwards.
+			end: end !== null && end > start ? end : null,
+			allDay: false,
+			meta,
+		});
+	}
+	return out;
+}
+
+
+/** Epoch ms of "HH:mm" on the local day starting at `dayMs`. */
+function clockMs(dayMs: number, clock: string): number | null {
+	const m = /^(\d{2}):(\d{2})$/.exec(clock);
+	if (!m) return null;
+	const d = new Date(dayMs);
+	return new Date(d.getFullYear(), d.getMonth(), d.getDate(), +m[1], +m[2]).getTime();
+}
+
+
+/** The day a daily note covers, resolved from its basename against the core
+ * Daily notes format. Falls back to any `YYYY-MM-DD` in the name, so a note
+ * whose format is unknown (or non-standard) still places its timeblocks. */
+export function dailyNoteDayKey(
+	basenameOrPath: string,
+	format: string,
+	parse: (input: string, format: string) => { isValid(): boolean; format(f: string): string },
+): string | null {
+	const name = basename(basenameOrPath);
+	if (format) {
+		const m = parse(name, format);
+		if (m.isValid()) return m.format("YYYY-MM-DD");
+	}
+	return /(\d{4}-\d{2}-\d{2})/.exec(name)?.[1] ?? null;
+}
+
+
+// ---- Completion -----------------------------------------------------------
+
+/**
+ * The frontmatter edit that toggles one occurrence's completion, mirroring what
+ * TaskNotes writes:
+ *
+ *   - a recurring task records each finished day in `complete_instances`
+ *     (deduped and sorted) and keeps its status untouched;
+ *   - a one-off task moves its status to a complete value (and back to an open
+ *     one when un-completed).
+ *
+ * Returns the properties to write. Pure, so the rules are testable; the caller
+ * applies them through `processFrontMatter`.
+ */
+export function completionEdit(
+	setup: TaskNotesSetup,
+	task: TaskNotesTask,
+	dayKey: string,
+	complete: boolean,
+): Record<string, unknown> {
+	const f = setup.fields;
+	if (task.recurrence) {
+		const days = new Set(task.completeInstances);
+		if (complete) days.add(dayKey);
+		else days.delete(dayKey);
+		return { [f.completeInstances]: [...days].sort() };
+	}
+	const target = complete ? completeStatusValue(setup) : openStatusValue(setup);
+	const edit: Record<string, unknown> = { [f.status]: target };
+	// TaskNotes stamps the completion date alongside the status.
+	edit[f.completedDate] = complete ? dayKey : "";
+	return edit;
+}
+
+
+/** The status value a finished task takes: TaskNotes' first completed status,
+ * or plain "done" when none is configured. */
+export function completeStatusValue(setup: TaskNotesSetup): string {
+	return setup.statuses.find((s) => s.isCompleted)?.value ?? "done";
+}
+
+
+/** The status value a reopened task takes: TaskNotes' first open status, or
+ * "open". */
+export function openStatusValue(setup: TaskNotesSetup): string {
+	return setup.statuses.find((s) => !s.isCompleted)?.value ?? "open";
+}
+
+
+// ---- Reading the vault ----------------------------------------------------
+
+/** The slice of TaskNotes' plugin surface this uses. All optional and
+ * duck-typed: TaskNotes ships no stable public types, so each accessor is
+ * probed before use and may be absent or reshaped between versions. */
+export interface TaskNotesLike {
+	settings?: unknown;
+	openTaskEditModal?: (task: unknown) => unknown;
+	cacheManager?: { getTaskInfo?: (path: string) => unknown };
+	api?: { tasks?: { get?: (path: string) => unknown } };
+}
+
+
+/** The loaded TaskNotes plugin instance, or null when it isn't enabled. */
+export function taskNotesPlugin(app: App): TaskNotesLike | null {
+	if (!taskNotesEnabled(app)) return null;
+	return (app.plugins.plugins[TASKNOTES_PLUGIN_ID] as TaskNotesLike | undefined) ?? null;
+}
+
+
+/** TaskNotes' live configuration, or the documented defaults when the plugin
+ * isn't installed (so callers never branch on null). */
+export function readTaskNotesSetup(app: App): TaskNotesSetup {
+	return parseTaskNotesSettings(taskNotesPlugin(app)?.settings);
+}
+
+
+/** The tags on a note (frontmatter and inline), without their leading "#". */
+function noteTags(app: App, file: TFile): string[] {
+	const cache = app.metadataCache.getFileCache(file);
+	const out: string[] = [];
+	for (const tag of cache?.tags ?? []) {
+		const t = tag.tag.replace(/^#/, "");
+		if (t && !out.includes(t)) out.push(t);
+	}
+	for (const t of strList(cache?.frontmatter?.tags)) {
+		const clean = t.replace(/^#/, "");
+		if (clean && !out.includes(clean)) out.push(clean);
+	}
+	return out;
+}
+
+
+/** Every TaskNotes task in the vault. */
+export function collectTaskNotesTasks(app: App, setup: TaskNotesSetup): TaskNotesTask[] {
+	const out: TaskNotesTask[] = [];
+	for (const file of app.vault.getMarkdownFiles()) {
+		const fm = app.metadataCache.getFileCache(file)?.frontmatter;
+		if (!fm) continue;
+		const task = readTaskNotesTask(setup, file.path, fm, noteTags(app, file));
+		if (task) out.push(task);
+	}
+	return out;
+}
+
+
+/** Every timeblock in the vault, as calendar occurrences. Timeblocks live in
+ * daily-note frontmatter, so the day comes from the note's own name via
+ * `resolveDayKey` (the caller supplies the daily-notes format). */
+export function collectTimeblockOccurrences(
+	app: App,
+	resolveDayKey: (path: string) => string | null,
+	fallbackColor: string,
+): IcsOccurrence[] {
+	const out: IcsOccurrence[] = [];
+	for (const file of app.vault.getMarkdownFiles()) {
+		const raw: unknown = app.metadataCache.getFileCache(file)?.frontmatter?.timeblocks;
+		if (!Array.isArray(raw) || raw.length === 0) continue;
+		const dayKey = resolveDayKey(file.path);
+		if (!dayKey) continue;
+		out.push(...timeblockOccurrences(dayKey, readTimeblocks(raw), file.path, fallbackColor));
+	}
+	return out;
+}
+
+
+/** Apply a completion toggle to a task note. Best-effort: a failed write
+ * leaves the note untouched and reports false. */
+export async function applyCompletion(
+	app: App,
+	setup: TaskNotesSetup,
+	task: TaskNotesTask,
+	dayKey: string,
+	complete: boolean,
+): Promise<boolean> {
+	const file = app.vault.getAbstractFileByPath(task.path);
+	if (!(file instanceof TFile)) return false;
+	const edit = completionEdit(setup, task, dayKey, complete);
+	try {
+		await app.fileManager.processFrontMatter(file, (fm) => {
+			for (const [key, value] of Object.entries(edit)) {
+				// An empty completion date means "clear it" rather than "store ''".
+				if (value === "") delete fm[key];
+				else fm[key] = value;
+			}
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+
+/** Read one task straight from a note path (used after a completion toggle, so
+ * the next render sees fresh frontmatter). */
+export function readTaskAt(app: App, setup: TaskNotesSetup, path: string): TaskNotesTask | null {
+	const file = app.vault.getAbstractFileByPath(path);
+	if (!(file instanceof TFile)) return null;
+	const fm = app.metadataCache.getFileCache(file)?.frontmatter;
+	return readTaskNotesTask(setup, file.path, fm, noteTags(app, file));
+}
+
+
+// ---- TaskNotes' own ICS subscriptions --------------------------------------
+
+/** Cache for local (in-vault) .ics subscriptions, keyed by path and
+ * invalidated by the file's mtime — the remote ones are cached by ics.ts. */
+const localCache = new Map<string, { mtime: number; cal: IcsCalendar | null }>();
+
+
+/** The parsed calendar for an in-vault .ics file, re-read only when the file
+ * changed. Never throws: an unreadable or unparseable file yields null. */
+export async function loadLocalCalendar(app: App, path: string): Promise<IcsCalendar | null> {
+	const file = app.vault.getAbstractFileByPath(path);
+	if (!(file instanceof TFile)) return null;
+	const cached = localCache.get(path);
+	if (cached && cached.mtime === file.stat.mtime) return cached.cal;
+	try {
+		const cal = parseIcs(await app.vault.cachedRead(file));
+		localCache.set(path, { mtime: file.stat.mtime, cal });
+		return cal;
+	} catch {
+		localCache.set(path, { mtime: file.stat.mtime, cal: null });
+		return null;
+	}
+}
+
+
+/** The last-read calendar for an in-vault .ics file, without touching disk. */
+export function cachedLocalCalendar(path: string): IcsCalendar | null {
+	return localCache.get(path)?.cal ?? null;
+}
+
+
+/** Open a TaskNotes task in TaskNotes' own edit modal rather than the raw
+ * Markdown note. TaskNotes exposes no stable public API, so this resolves the
+ * plugin's own task object for the file and hands it to `openTaskEditModal`,
+ * returning whether it handled the open; the caller falls back to opening the
+ * file when it didn't.
+ *
+ * The modal requires TaskNotes' `TaskInfo` (title/status/priority/…), not a
+ * `TFile`: passing the file leaves the modal with a broken change-detection
+ * baseline that traps every button but Delete (see issue #72).
+ * `openTaskEditModal` is async, so a bad argument never throws synchronously —
+ * resolving the info up front (and awaiting the open) is the only way to know
+ * we really handled it. */
+export async function openInTaskNotes(app: App, path: string): Promise<boolean> {
+	const plugin = taskNotesPlugin(app);
+	if (!plugin || typeof plugin.openTaskEditModal !== "function") return false;
+	const task = await resolveTaskNotesInfo(plugin, path);
+	if (!task) return false;
+	try {
+		await plugin.openTaskEditModal(task);
+		return true;
+	} catch {
+		// Internal error — fall through to a plain file open.
+		return false;
+	}
+}
+
+
+/** Resolve TaskNotes' `TaskInfo` for a note path via whichever accessor the
+ * installed version exposes: the cache manager first, then the public runtime
+ * API (`api.tasks.get`). Both are best-effort and may be absent or reshaped
+ * between TaskNotes versions, so failures fall through to the next. */
+async function resolveTaskNotesInfo(plugin: TaskNotesLike, path: string): Promise<unknown> {
+	const cache = plugin.cacheManager;
+	if (typeof cache?.getTaskInfo === "function") {
+		try {
+			const info = await cache.getTaskInfo(path);
+			if (info) return info;
+		} catch {
+			// Fall through to the public API.
+		}
+	}
+	const get = plugin.api?.tasks?.get;
+	if (typeof get === "function") {
+		try {
+			const info = await get(path);
+			if (info) return info;
+		} catch {
+			// No resolver worked.
+		}
+	}
+	return null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -337,6 +337,55 @@ export interface CalendarConfig {
 	/** How the "Create note" action in the event modal builds a note from an
 	 * event (template, filename, per-field routing). */
 	eventNote?: EventNoteConfig;
+	/** TaskNotes as an event source: scheduled tasks, due dates, recurring
+	 * instances, timeblocks and TaskNotes' own calendar subscriptions, drawn on
+	 * this card alongside any ICS feeds. Off unless `enabled`. */
+	taskNotes?: TaskNotesSourceConfig;
+}
+
+
+/**
+ * Per-card configuration for the TaskNotes calendar source.
+ *
+ * Every layer toggle is tri-state on purpose: left undefined it follows
+ * TaskNotes' own calendar settings, so a card that was simply switched on
+ * mirrors whatever the user already configured inside TaskNotes. Setting one
+ * here overrides that for this card only.
+ */
+export interface TaskNotesSourceConfig {
+	/** Master switch. Off (the default) means the card reads no TaskNotes data
+	 * at all — not even the plugin's settings. */
+	enabled?: boolean;
+	/** Draw tasks on their `scheduled` date, sized by their time estimate. */
+	scheduled?: boolean;
+	/** Draw tasks on their `due` date. */
+	due?: boolean;
+	/** Unroll recurring tasks into one entry per occurrence. Off draws only the
+	 * task's anchor date. */
+	recurring?: boolean;
+	/** Draw timeblocks written into daily-note frontmatter. */
+	timeblocks?: boolean;
+	/** Include tasks whose status counts as complete (shown struck through).
+	 * Default true — TaskNotes shows them too. */
+	completed?: boolean;
+	/** Include tasks carrying TaskNotes' archive tag. Default false. */
+	archived?: boolean;
+	/** Also overlay the ICS calendars subscribed inside TaskNotes, so both
+	 * plugins show the same feeds without re-entering the URLs. Default true. */
+	subscriptions?: boolean;
+	/** Where an entry's colour comes from: its TaskNotes status colour
+	 * (default), its priority colour, or the fixed colour below. */
+	colorBy?: "status" | "priority" | "fixed";
+	/** Colour used when `colorBy` is "fixed", and whenever the chosen source
+	 * defines none. */
+	color?: string;
+	/** Separate colour for due-date entries, so a deadline reads differently
+	 * from a scheduled block. */
+	dueColor?: string;
+	/** Colour for timeblocks that don't carry their own. */
+	timeblockColor?: string;
+	/** Offer completing a task straight from the event popup. Default true. */
+	allowComplete?: boolean;
 }
 
 /** Per-card configuration for a "search" (query) card. */

--- a/styles.css
+++ b/styles.css
@@ -2608,6 +2608,45 @@
 	background: var(--background-modifier-hover);
 }
 
+/* TaskNotes entries in the agenda: a completion box in place of the bullet,
+   markers for a due date / timeblock, and a struck-through, faded row once the
+   task (or, for a recurring task, this occurrence) is complete. */
+.hearth-agenda-evcheck {
+	flex: 0 0 auto;
+	align-self: center;
+	margin: 0;
+	width: 12px;
+	height: 12px;
+	accent-color: var(--ev-color, var(--interactive-accent));
+	cursor: pointer;
+}
+
+.hearth-agenda-event.is-done .hearth-agenda-evtitle {
+	text-decoration: line-through;
+	color: var(--text-faint);
+}
+
+.hearth-agenda-event.is-done .hearth-agenda-evtime {
+	opacity: 0.6;
+}
+
+.hearth-agenda-evbadge.is-due {
+	color: var(--text-on-accent);
+	background: var(--ev-color, var(--color-red));
+}
+
+.hearth-agenda-evbadge.is-timeblock {
+	color: var(--text-muted);
+	border: 1px solid var(--background-modifier-border);
+	background: transparent;
+}
+
+/* A completed task's day-grid dot fades, so a busy day still reads as what is
+   left to do. */
+.hearth-calendar-evdot.is-done {
+	opacity: 0.4;
+}
+
 /* Event details modal (opened from a calendar day picker or agenda event) */
 .hearth-event-modal .modal-content {
 	padding-top: 4px;

--- a/test/ics.test.ts
+++ b/test/ics.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { moment } from "obsidian";
 import "moment/locale/cs";
 import {
+	calendarStatus,
 	eventsByDay,
 	expandEvents,
 	parseIcs,
@@ -281,6 +282,18 @@ describe("expandEvents — recurrence", () => {
 			base + 100_000 * day,
 		);
 		expect(occ.length).toBeLessThanOrEqual(750);
+	});
+});
+
+describe("calendarStatus", () => {
+	it("reports a URL that was never loaded as neither loaded nor failed", () => {
+		expect(calendarStatus("https://example.com/never-fetched.ics")).toEqual({
+			loaded: false,
+			events: 0,
+			fetched: null,
+			error: null,
+			blocked: false,
+		});
 	});
 });
 

--- a/test/tasknotes.test.ts
+++ b/test/tasknotes.test.ts
@@ -6,6 +6,7 @@ import {
 	isCompletedStatus,
 	normalizeRecurrence,
 	parseTaskDate,
+	parseSubscriptions,
 	parseTaskNotesSettings,
 	readTaskNotesTask,
 	readTimeblocks,
@@ -101,7 +102,7 @@ describe("parseTaskNotesSettings", () => {
 		});
 	});
 
-	it("reads calendar subscriptions, classifying local files and remote feeds", () => {
+	it("reads calendar subscriptions from settings when a version keeps them there", () => {
 		const setup = setupFrom({
 			icsIntegration: {
 				subscriptions: [
@@ -133,6 +134,10 @@ describe("parseTaskNotesSettings", () => {
 		]);
 	});
 
+	it("finds no subscriptions in the settings of a current TaskNotes (they live in its plugin data)", () => {
+		expect(setupFrom().subscriptions).toEqual([]);
+	});
+
 	it("mirrors TaskNotes' calendar layer toggles", () => {
 		const setup = setupFrom({
 			calendarViewSettings: { defaultShowDue: false, defaultShowTimeblocks: false },
@@ -140,6 +145,39 @@ describe("parseTaskNotesSettings", () => {
 		expect(setup.calendar.due).toBe(false);
 		expect(setup.calendar.timeblocks).toBe(false);
 		expect(setup.calendar.scheduled).toBe(true);
+	});
+});
+
+describe("parseSubscriptions", () => {
+	it("reads the list TaskNotes persists in its plugin data", () => {
+		// Exactly the shape TaskNotes' subscription service writes under
+		// `icsSubscriptions` in .obsidian/plugins/tasknotes/data.json.
+		const list = parseSubscriptions([
+			{
+				id: "ics_1",
+				name: "Family",
+				type: "remote",
+				url: "https://calendar.google.com/basic.ics",
+				enabled: true,
+				refreshInterval: 60,
+				color: "#3b82f6",
+			},
+			{ id: "ics_2", name: "Holidays", type: "local", filePath: "Calendars/holidays.ics", enabled: true },
+		]);
+		expect(list.map((s) => [s.id, s.type, s.enabled])).toEqual([
+			["ics_1", "remote", true],
+			["ics_2", "local", true],
+		]);
+	});
+
+	it("infers a missing type from which location is set", () => {
+		expect(parseSubscriptions([{ id: "x", url: "https://a/b.ics" }])[0].type).toBe("remote");
+		expect(parseSubscriptions([{ id: "y", filePath: "a.ics" }])[0].type).toBe("local");
+	});
+
+	it("ignores anything that isn't a list of fetchable subscriptions", () => {
+		expect(parseSubscriptions(undefined)).toEqual([]);
+		expect(parseSubscriptions([{ id: "z", name: "No location" }, "nonsense"])).toEqual([]);
 	});
 });
 

--- a/test/tasknotes.test.ts
+++ b/test/tasknotes.test.ts
@@ -1,0 +1,494 @@
+import { describe, expect, it } from "vitest";
+import {
+	completionEdit,
+	DEFAULT_TASKNOTES_LAYERS,
+	dailyNoteDayKey,
+	isCompletedStatus,
+	normalizeRecurrence,
+	parseTaskDate,
+	parseTaskNotesSettings,
+	readTaskNotesTask,
+	readTimeblocks,
+	taskNotesEvents,
+	taskNotesMeta,
+	timeblockOccurrences,
+	type TaskNotesLayerOptions,
+	type TaskNotesSetup,
+	type TaskNotesTask,
+} from "../src/tasknotes";
+import { moment } from "obsidian";
+
+/**
+ * The TaskNotes reader is tested against the shapes TaskNotes actually writes:
+ * its settings object (field mapping, custom statuses/priorities, calendar
+ * subscriptions), task frontmatter, and daily-note timeblocks. vitest forces
+ * TZ=UTC (see vitest.config.ts), so every epoch assertion is deterministic.
+ */
+
+const day = (iso: string): number => new Date(`${iso}T00:00:00Z`).getTime();
+
+/** Settings as a default TaskNotes install writes them. */
+function settings(overrides: Record<string, unknown> = {}): unknown {
+	return {
+		taskTag: "task",
+		taskIdentificationMethod: "tag",
+		fieldMapping: { due: "due", scheduled: "scheduled", status: "status", priority: "priority" },
+		customStatuses: [
+			{ value: "open", label: "Open", color: "#888888", isCompleted: false },
+			{ value: "in-progress", label: "In progress", color: "#3b82f6", isCompleted: false },
+			{ value: "done", label: "Done", color: "#22c55e", isCompleted: true },
+		],
+		customPriorities: [
+			{ value: "high", label: "High", color: "#ef4444", weight: 3 },
+			{ value: "normal", label: "Normal", color: "#eab308", weight: 2 },
+		],
+		...overrides,
+	};
+}
+
+function setupFrom(overrides: Record<string, unknown> = {}): TaskNotesSetup {
+	return parseTaskNotesSettings(settings(overrides));
+}
+
+function layers(overrides: Partial<TaskNotesLayerOptions> = {}): TaskNotesLayerOptions {
+	return { ...DEFAULT_TASKNOTES_LAYERS, ...overrides };
+}
+
+function task(overrides: Partial<TaskNotesTask> = {}): TaskNotesTask {
+	return {
+		path: "Tasks/Write docs.md",
+		title: "Write docs",
+		status: "open",
+		priority: "normal",
+		due: null,
+		scheduled: null,
+		recurrence: null,
+		completeInstances: [],
+		contexts: [],
+		projects: [],
+		timeEstimate: null,
+		archived: false,
+		done: false,
+		...overrides,
+	};
+}
+
+describe("parseTaskNotesSettings", () => {
+	it("falls back to TaskNotes' defaults for an empty/absent settings object", () => {
+		const setup = parseTaskNotesSettings(undefined);
+		expect(setup.fields.due).toBe("due");
+		expect(setup.fields.completeInstances).toBe("complete_instances");
+		expect(setup.identify).toEqual({ method: "tag", tag: "task", property: "", value: "" });
+		expect(setup.defaultTimeEstimate).toBe(60);
+		expect(setup.calendar).toEqual({ scheduled: true, due: true, recurring: true, timeblocks: true });
+	});
+
+	it("reads a remapped field name and leaves the rest defaulted", () => {
+		const setup = setupFrom({ fieldMapping: { due: "deadline" } });
+		expect(setup.fields.due).toBe("deadline");
+		expect(setup.fields.scheduled).toBe("scheduled");
+	});
+
+	it("reads custom statuses and priorities with their colours", () => {
+		const setup = setupFrom();
+		expect(setup.statuses.map((s) => s.value)).toEqual(["open", "in-progress", "done"]);
+		expect(setup.statuses[2].isCompleted).toBe(true);
+		expect(setup.priorities[0]).toEqual({
+			value: "high",
+			label: "High",
+			color: "#ef4444",
+			weight: 3,
+		});
+	});
+
+	it("reads calendar subscriptions, classifying local files and remote feeds", () => {
+		const setup = setupFrom({
+			icsIntegration: {
+				subscriptions: [
+					{ id: "a", name: "Work", type: "remote", url: "https://example.com/w.ics", color: "#f00" },
+					{ id: "b", name: "Local", filePath: "Calendars/home.ics", enabled: false },
+					{ id: "c", name: "Nothing" },
+				],
+			},
+		});
+		expect(setup.subscriptions).toEqual([
+			{
+				id: "a",
+				name: "Work",
+				type: "remote",
+				url: "https://example.com/w.ics",
+				filePath: "",
+				color: "#f00",
+				enabled: true,
+			},
+			{
+				id: "b",
+				name: "Local",
+				type: "local",
+				url: "",
+				filePath: "Calendars/home.ics",
+				color: "",
+				enabled: false,
+			},
+		]);
+	});
+
+	it("mirrors TaskNotes' calendar layer toggles", () => {
+		const setup = setupFrom({
+			calendarViewSettings: { defaultShowDue: false, defaultShowTimeblocks: false },
+		});
+		expect(setup.calendar.due).toBe(false);
+		expect(setup.calendar.timeblocks).toBe(false);
+		expect(setup.calendar.scheduled).toBe(true);
+	});
+});
+
+describe("isCompletedStatus", () => {
+	it("uses the status' own isCompleted flag", () => {
+		const setup = setupFrom();
+		expect(isCompletedStatus(setup, "done")).toBe(true);
+		expect(isCompletedStatus(setup, "in-progress")).toBe(false);
+	});
+
+	it("falls back to conventional wording when the status isn't defined", () => {
+		const setup = parseTaskNotesSettings({});
+		expect(isCompletedStatus(setup, "completed")).toBe(true);
+		expect(isCompletedStatus(setup, "waiting")).toBe(false);
+	});
+});
+
+describe("readTaskNotesTask", () => {
+	const setup = setupFrom();
+
+	it("reads a tagged task note", () => {
+		const read = readTaskNotesTask(
+			setup,
+			"Tasks/Ship it.md",
+			{
+				title: "Ship it",
+				status: "in-progress",
+				priority: "high",
+				due: "2026-08-10",
+				scheduled: "2026-08-07T09:00",
+				timeEstimate: 45,
+				contexts: ["work"],
+				complete_instances: ["2026-08-01"],
+			},
+			["task"],
+		);
+		expect(read).toMatchObject({
+			title: "Ship it",
+			status: "in-progress",
+			priority: "high",
+			due: "2026-08-10",
+			scheduled: "2026-08-07T09:00",
+			timeEstimate: 45,
+			contexts: ["work"],
+			completeInstances: ["2026-08-01"],
+			done: false,
+		});
+	});
+
+	it("ignores a note that isn't a task", () => {
+		expect(readTaskNotesTask(setup, "Notes/Idea.md", { summary: "nope" }, [])).toBeNull();
+	});
+
+	it("honours the property identification method", () => {
+		const byProperty = setupFrom({
+			taskIdentificationMethod: "property",
+			taskPropertyName: "type",
+			taskPropertyValue: "task",
+		});
+		expect(readTaskNotesTask(byProperty, "a.md", { type: "task" }, [])).not.toBeNull();
+		expect(readTaskNotesTask(byProperty, "b.md", { type: "note" }, [])).toBeNull();
+	});
+
+	it("marks a task carrying the archive tag", () => {
+		const read = readTaskNotesTask(setup, "a.md", { status: "open" }, ["task", "archived"]);
+		expect(read?.archived).toBe(true);
+	});
+
+	it("falls back to the filename when no title property is set", () => {
+		const read = readTaskNotesTask(setup, "Tasks/Buy milk.md", { status: "open" }, ["task"]);
+		expect(read?.title).toBe("Buy milk");
+	});
+});
+
+describe("parseTaskDate", () => {
+	it("reads a date-only value as all-day", () => {
+		expect(parseTaskDate("2026-08-07")).toEqual({ ms: day("2026-08-07"), allDay: true });
+	});
+
+	it("reads a timed value as local wall-clock", () => {
+		expect(parseTaskDate("2026-08-07T09:30")).toEqual({
+			ms: new Date("2026-08-07T09:30:00Z").getTime(),
+			allDay: false,
+		});
+	});
+
+	it("rejects nonsense", () => {
+		expect(parseTaskDate("tomorrow")).toBeNull();
+	});
+});
+
+describe("normalizeRecurrence", () => {
+	it("strips the RRULE prefix", () => {
+		expect(normalizeRecurrence("RRULE:FREQ=WEEKLY;BYDAY=MO")).toBe("FREQ=WEEKLY;BYDAY=MO");
+	});
+
+	it("maps legacy words onto a FREQ", () => {
+		expect(normalizeRecurrence("weekly")).toBe("FREQ=WEEKLY");
+		expect(normalizeRecurrence("biweekly")).toBe("FREQ=WEEKLY;INTERVAL=2");
+	});
+
+	it("returns null for something it can't read", () => {
+		expect(normalizeRecurrence("every other Tuesday-ish")).toBeNull();
+		expect(normalizeRecurrence("")).toBeNull();
+	});
+});
+
+describe("taskNotesEvents", () => {
+	const setup = setupFrom();
+	const window = { start: day("2026-08-01"), end: day("2026-09-01") };
+
+	it("draws a scheduled task, sized by its time estimate", () => {
+		const [occ] = taskNotesEvents(
+			[task({ scheduled: "2026-08-07T09:00", timeEstimate: 30 })],
+			setup,
+			layers(),
+			window.start,
+			window.end,
+		);
+		expect(occ.allDay).toBe(false);
+		expect(occ.end! - occ.start).toBe(30 * 60_000);
+		expect(taskNotesMeta(occ)).toMatchObject({ kind: "scheduled", dayKey: "2026-08-07" });
+	});
+
+	it("uses TaskNotes' default estimate when the task has none", () => {
+		const [occ] = taskNotesEvents(
+			[task({ scheduled: "2026-08-07T09:00" })],
+			setup,
+			layers(),
+			window.start,
+			window.end,
+		);
+		expect(occ.end! - occ.start).toBe(60 * 60_000);
+	});
+
+	it("draws scheduled and due as separate entries", () => {
+		const occ = taskNotesEvents(
+			[task({ scheduled: "2026-08-07", due: "2026-08-10" })],
+			setup,
+			layers(),
+			window.start,
+			window.end,
+		);
+		expect(occ.map((o) => taskNotesMeta(o)!.kind)).toEqual(["scheduled", "due"]);
+	});
+
+	it("draws one entry when scheduled and due fall on the same day", () => {
+		const occ = taskNotesEvents(
+			[task({ scheduled: "2026-08-07", due: "2026-08-07" })],
+			setup,
+			layers(),
+			window.start,
+			window.end,
+		);
+		expect(occ).toHaveLength(1);
+	});
+
+	it("unrolls a recurring task into one entry per occurrence", () => {
+		const occ = taskNotesEvents(
+			[task({ scheduled: "2026-08-03", recurrence: "FREQ=WEEKLY" })],
+			setup,
+			layers(),
+			window.start,
+			window.end,
+		);
+		expect(occ.map((o) => taskNotesMeta(o)!.dayKey)).toEqual([
+			"2026-08-03",
+			"2026-08-10",
+			"2026-08-17",
+			"2026-08-24",
+			"2026-08-31",
+		]);
+	});
+
+	it("marks only the occurrences listed in complete_instances", () => {
+		const occ = taskNotesEvents(
+			[
+				task({
+					scheduled: "2026-08-03",
+					recurrence: "FREQ=WEEKLY",
+					completeInstances: ["2026-08-10"],
+				}),
+			],
+			setup,
+			layers(),
+			window.start,
+			window.end,
+		);
+		const done = occ.filter((o) => taskNotesMeta(o)!.done).map((o) => taskNotesMeta(o)!.dayKey);
+		expect(done).toEqual(["2026-08-10"]);
+	});
+
+	it("draws only the anchor date when the recurring layer is off", () => {
+		const occ = taskNotesEvents(
+			[task({ scheduled: "2026-08-03", recurrence: "FREQ=WEEKLY" })],
+			setup,
+			layers({ recurring: false }),
+			window.start,
+			window.end,
+		);
+		expect(occ).toHaveLength(1);
+	});
+
+	it("hides completed and archived tasks when their layers are off", () => {
+		const tasks = [
+			task({ path: "a.md", scheduled: "2026-08-07", status: "done", done: true }),
+			task({ path: "b.md", scheduled: "2026-08-07", archived: true }),
+			task({ path: "c.md", scheduled: "2026-08-07" }),
+		];
+		const occ = taskNotesEvents(
+			tasks,
+			setup,
+			layers({ completed: false }),
+			window.start,
+			window.end,
+		);
+		expect(occ.map((o) => taskNotesMeta(o)!.path)).toEqual(["c.md"]);
+	});
+
+	it("colours by status, priority or a fixed colour", () => {
+		const one = task({ scheduled: "2026-08-07", status: "in-progress", priority: "high" });
+		const color = (opts: Partial<TaskNotesLayerOptions>) =>
+			taskNotesMeta(
+				taskNotesEvents([one], setup, layers(opts), window.start, window.end)[0],
+			)!.color;
+		expect(color({ colorBy: "status" })).toBe("#3b82f6");
+		expect(color({ colorBy: "priority" })).toBe("#ef4444");
+		expect(color({ colorBy: "fixed", fallbackColor: "#123456" })).toBe("#123456");
+	});
+
+	it("gives due entries their own colour when one is set", () => {
+		const occ = taskNotesEvents(
+			[task({ due: "2026-08-07" })],
+			setup,
+			layers({ dueColor: "#ff0000" }),
+			window.start,
+			window.end,
+		);
+		expect(taskNotesMeta(occ[0])!.color).toBe("#ff0000");
+	});
+
+	it("skips a layer that is switched off", () => {
+		const occ = taskNotesEvents(
+			[task({ scheduled: "2026-08-07", due: "2026-08-10" })],
+			setup,
+			layers({ due: false }),
+			window.start,
+			window.end,
+		);
+		expect(occ.map((o) => taskNotesMeta(o)!.kind)).toEqual(["scheduled"]);
+	});
+});
+
+describe("timeblocks", () => {
+	it("reads the blocks a daily note carries, skipping unusable entries", () => {
+		const blocks = readTimeblocks([
+			{ id: "1", title: "Deep work", startTime: "9:00", endTime: "10:30", color: "#abc" },
+			{ title: "No start" },
+			"nonsense",
+		]);
+		expect(blocks).toEqual([
+			{
+				id: "1",
+				title: "Deep work",
+				startTime: "09:00",
+				endTime: "10:30",
+				color: "#abc",
+				attachments: [],
+				description: "",
+			},
+		]);
+	});
+
+	it("places a block on its daily note's day", () => {
+		const [occ] = timeblockOccurrences(
+			"2026-08-07",
+			readTimeblocks([{ title: "Deep work", startTime: "09:00", endTime: "10:30" }]),
+			"Daily/2026-08-07.md",
+			"#7c6cff",
+		);
+		expect(occ.start).toBe(new Date("2026-08-07T09:00:00Z").getTime());
+		expect(occ.end).toBe(new Date("2026-08-07T10:30:00Z").getTime());
+		expect(taskNotesMeta(occ)).toMatchObject({ kind: "timeblock", path: "Daily/2026-08-07.md" });
+	});
+
+	it("drops an end that isn't after the start", () => {
+		const [occ] = timeblockOccurrences(
+			"2026-08-07",
+			readTimeblocks([{ title: "Odd", startTime: "23:00", endTime: "01:00" }]),
+			"Daily/2026-08-07.md",
+			"",
+		);
+		expect(occ.end).toBeNull();
+	});
+});
+
+describe("dailyNoteDayKey", () => {
+	const parse = (input: string, format: string) => moment(input, format, true);
+
+	it("reads the date out of a daily note's own format", () => {
+		expect(dailyNoteDayKey("Journal/2026-08-07.md", "YYYY-MM-DD", parse)).toBe("2026-08-07");
+		expect(dailyNoteDayKey("Journal/07-08-2026.md", "DD-MM-YYYY", parse)).toBe("2026-08-07");
+	});
+
+	it("falls back to an embedded ISO date when the format doesn't match", () => {
+		expect(dailyNoteDayKey("Journal/Week 2026-08-07 notes.md", "YYYY-MM-DD", parse)).toBe(
+			"2026-08-07",
+		);
+	});
+
+	it("returns null for a note that carries no date", () => {
+		expect(dailyNoteDayKey("Journal/Random.md", "YYYY-MM-DD", parse)).toBeNull();
+	});
+});
+
+describe("completionEdit", () => {
+	const setup = setupFrom();
+
+	it("records a recurring task's day in complete_instances, sorted", () => {
+		const edit = completionEdit(
+			setup,
+			task({ recurrence: "FREQ=WEEKLY", completeInstances: ["2026-08-17"] }),
+			"2026-08-10",
+			true,
+		);
+		expect(edit).toEqual({ complete_instances: ["2026-08-10", "2026-08-17"] });
+	});
+
+	it("removes the day again when the occurrence is reopened", () => {
+		const edit = completionEdit(
+			setup,
+			task({ recurrence: "FREQ=WEEKLY", completeInstances: ["2026-08-10", "2026-08-17"] }),
+			"2026-08-10",
+			false,
+		);
+		expect(edit).toEqual({ complete_instances: ["2026-08-17"] });
+	});
+
+	it("moves a one-off task's status to TaskNotes' own completed status", () => {
+		expect(completionEdit(setup, task(), "2026-08-10", true)).toEqual({
+			status: "done",
+			completedDate: "2026-08-10",
+		});
+	});
+
+	it("reopens a one-off task to the first open status and clears the date", () => {
+		expect(completionEdit(setup, task({ status: "done", done: true }), "2026-08-10", false)).toEqual({
+			status: "open",
+			completedDate: "",
+		});
+	});
+});

--- a/test/tasknotes.test.ts
+++ b/test/tasknotes.test.ts
@@ -35,9 +35,10 @@ function settings(overrides: Record<string, unknown> = {}): unknown {
 		taskIdentificationMethod: "tag",
 		fieldMapping: { due: "due", scheduled: "scheduled", status: "status", priority: "priority" },
 		customStatuses: [
-			{ value: "open", label: "Open", color: "#888888", isCompleted: false },
-			{ value: "in-progress", label: "In progress", color: "#3b82f6", isCompleted: false },
-			{ value: "done", label: "Done", color: "#22c55e", isCompleted: true },
+			{ value: "none", label: "None", color: "#cccccc", isCompleted: false, order: 0 },
+			{ value: "open", label: "Open", color: "#888888", isCompleted: false, order: 1 },
+			{ value: "in-progress", label: "In progress", color: "#3b82f6", isCompleted: false, order: 2 },
+			{ value: "done", label: "Done", color: "#22c55e", isCompleted: true, order: 3 },
 		],
 		customPriorities: [
 			{ value: "high", label: "High", color: "#ef4444", weight: 3 },
@@ -81,7 +82,12 @@ describe("parseTaskNotesSettings", () => {
 		expect(setup.fields.completeInstances).toBe("complete_instances");
 		expect(setup.identify).toEqual({ method: "tag", tag: "task", property: "", value: "" });
 		expect(setup.defaultTimeEstimate).toBe(60);
-		expect(setup.calendar).toEqual({ scheduled: true, due: true, recurring: true, timeblocks: true });
+		expect(setup.calendar).toEqual({
+			scheduled: true,
+			due: true,
+			recurring: true,
+			timeblocks: false,
+		});
 	});
 
 	it("reads a remapped field name and leaves the rest defaulted", () => {
@@ -92,8 +98,13 @@ describe("parseTaskNotesSettings", () => {
 
 	it("reads custom statuses and priorities with their colours", () => {
 		const setup = setupFrom();
-		expect(setup.statuses.map((s) => s.value)).toEqual(["open", "in-progress", "done"]);
-		expect(setup.statuses[2].isCompleted).toBe(true);
+		expect(setup.statuses.map((s) => s.value)).toEqual([
+			"none",
+			"open",
+			"in-progress",
+			"done",
+		]);
+		expect(setup.statuses[3].isCompleted).toBe(true);
 		expect(setup.priorities[0]).toEqual({
 			value: "high",
 			label: "High",
@@ -140,11 +151,27 @@ describe("parseTaskNotesSettings", () => {
 
 	it("mirrors TaskNotes' calendar layer toggles", () => {
 		const setup = setupFrom({
-			calendarViewSettings: { defaultShowDue: false, defaultShowTimeblocks: false },
+			calendarViewSettings: { defaultShowDue: false, enableTimeblocking: true },
 		});
 		expect(setup.calendar.due).toBe(false);
-		expect(setup.calendar.timeblocks).toBe(false);
+		expect(setup.calendar.timeblocks).toBe(true);
 		expect(setup.calendar.scheduled).toBe(true);
+	});
+
+	it("keeps statuses in TaskNotes' configured order, not file order", () => {
+		const setup = setupFrom({
+			customStatuses: [
+				{ value: "done", label: "Done", isCompleted: true, order: 2 },
+				{ value: "open", label: "Open", isCompleted: false, order: 1 },
+			],
+		});
+		expect(setup.statuses.map((s) => s.value)).toEqual(["open", "done"]);
+	});
+
+	it("gives a timed task an hour when TaskNotes' default estimate is 0", () => {
+		// TaskNotes ships defaultTimeEstimate: 0, which is not a drawable length.
+		expect(setupFrom({ defaultTimeEstimate: 0 }).defaultTimeEstimate).toBe(60);
+		expect(setupFrom({ defaultTimeEstimate: 25 }).defaultTimeEstimate).toBe(25);
 	});
 });
 
@@ -514,6 +541,27 @@ describe("completionEdit", () => {
 			false,
 		);
 		expect(edit).toEqual({ complete_instances: ["2026-08-17"] });
+	});
+
+	it("skips TaskNotes' placeholder \"none\" status when reopening a task", () => {
+		// "none" means "no status set" — reopening into it would hide the task
+		// from TaskNotes' own status-filtered views.
+		expect(completionEdit(setup, task({ status: "done", done: true }), "2026-08-10", false)).toMatchObject(
+			{ status: "open" },
+		);
+	});
+
+	it("never writes a status TaskNotes doesn't define", () => {
+		const custom = setupFrom({
+			customStatuses: [
+				{ value: "todo", label: "To do", isCompleted: false, order: 0 },
+				{ value: "shipped", label: "Shipped", isCompleted: true, order: 1 },
+			],
+		});
+		expect(completionEdit(custom, task(), "2026-08-10", true)).toMatchObject({ status: "shipped" });
+		expect(
+			completionEdit(custom, task({ status: "shipped", done: true }), "2026-08-10", false),
+		).toMatchObject({ status: "todo" });
 	});
 
 	it("moves a one-off task's status to TaskNotes' own completed status", () => {


### PR DESCRIPTION
## What does this PR do?

Adds TaskNotes as an optional **event source** for the calendar card, so a Hearth calendar can pick up the TaskNotes calendar and render its contents while still behaving like a calendar card.

Switched on (Card settings → Calendar → **TaskNotes** → *Use TaskNotes*), the card mirrors what TaskNotes' own calendar view shows:

- **Scheduled tasks**, sized by their time estimate (falling back to TaskNotes' default estimate).
- **Due dates**, as their own entries with an optional separate colour. A task scheduled and due on the same day draws once.
- **Recurring tasks**, unrolled into one entry per occurrence, each knowing whether that day is already listed in `complete_instances`.
- **Timeblocks** read from daily-note frontmatter, placed on the day their daily note covers.
- **The ICS calendars subscribed inside TaskNotes** — remote feeds and in-vault `.ics` files — so their URLs don't have to be entered twice.

Everything is read the way TaskNotes reads it. A new `src/tasknotes.ts` resolves TaskNotes' live settings — field mapping, the tag-or-property rule for what counts as a task, custom statuses and priorities with their colours, the default time estimate — and each layer defaults to whatever TaskNotes' own calendar view is currently showing, so a card that was simply switched on already reflects the existing setup. TaskNotes ships no stable public API, so every accessor is duck-typed and falls back to its documented defaults.

Per card you can override any layer, hide completed or archived tasks, colour entries by status, priority or one fixed colour, and give due dates and timeblocks their own colours.

**Interaction**

- Completed tasks render struck through, with a faded dot in the month grid.
- A checkbox on each agenda entry completes a task in place, writing exactly what TaskNotes writes: this day's entry in `complete_instances` for a recurring task, the configured completed status (and completion date) for a one-off.
- The event popup shows the task's status, priority, contexts, projects, estimate and recurrence, with an **Open task** button that hands off to TaskNotes' own task editor (timeblocks open their daily note).

**Under the hood**

- Recurrence reuses the existing ICS RRULE engine: events now carry an opaque provider payload through expansion, so a TaskNotes task and a subscribed feed expand identically.
- The TaskNotes plugin helpers the tasks card already had (`openInTaskNotes`, the plugin-id constant, `TaskInfo` resolution) move into the shared module instead of being duplicated.
- Vault reads are cached per render and the card already redraws on vault changes, so month navigation costs nothing extra.

## Related issue

None — happy to open one if you'd prefer this discussed first.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (also `npm run lint` — 0 errors — and `npm run test`: 322 passing, including 39 new unit tests in `test/tasknotes.test.ts` covering settings parsing, task reading, date/recurrence handling, event expansion, timeblocks and the completion writes)
- [x] I've tested this in an actual vault — **not done**: this was written in a container with no Obsidian/TaskNotes install, so the pure logic is unit-tested but the rendering and write-back paths need a real vault check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULA42vj74VbVTduCwecemc)_