### PR TITLE
fix(calendar): soften today's highlight in the agenda list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,14 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   they did, set **Links** under Settings → Hearth → Behaviour → Opening notes to
   *The current tab* (#106).
 
+- **Today is marked more quietly in the calendar's agenda.** The current day's
+  row no longer takes a heavy accent fill that made its text hard to read.
+  Today is now carried by an accent ring around the date badge plus a faint tint
+  on the row, with the stronger accent wash kept for hover — so pointing at the
+  row is what lights it up. The row sets both states itself, so a theme's own
+  saturated hover colour can't turn today into an unreadable slab, and hover no
+  longer sticks after a tap on touch devices.
+
 ## [1.17.0]
 
 ### Added

--- a/styles.css
+++ b/styles.css
@@ -2447,8 +2447,12 @@
 	cursor: pointer;
 }
 
-.hearth-agenda-row:hover {
-	background: var(--background-modifier-hover);
+/* Hover is guarded to pointers that can actually hover: on touch the state
+   sticks after a tap, leaving a row looking permanently selected. */
+@media (hover: hover) {
+	.hearth-agenda-row:hover {
+		background: var(--background-modifier-hover);
+	}
 }
 
 .hearth-agenda-date {
@@ -2473,9 +2477,12 @@
 	color: var(--text-normal);
 }
 
+/* Today is marked on the date badge, not by flooding the row: an accent ring
+   around the day number reads at a glance without fighting the row's text. */
 .hearth-agenda-row.is-today .hearth-agenda-daynum {
 	color: var(--interactive-accent);
-	background: color-mix(in srgb, var(--interactive-accent) 16%, transparent);
+	background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+	box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--interactive-accent) 55%, transparent);
 	border-radius: 999px;
 	width: 24px;
 	height: 24px;
@@ -2483,6 +2490,10 @@
 	align-items: center;
 	justify-content: center;
 	font-weight: 700;
+}
+
+.hearth-agenda-row.is-today .hearth-agenda-dow {
+	color: color-mix(in srgb, var(--interactive-accent) 70%, var(--text-muted));
 }
 
 .hearth-agenda-main {
@@ -2515,11 +2526,11 @@
 	margin-left: auto;
 }
 
-.hearth-agenda-row.is-today {
-	outline: 1px solid color-mix(in srgb, var(--interactive-accent) 45%, transparent);
-	outline-offset: -1px;
-}
-
+/* At rest today's row is only faintly tinted — the accent badge above carries
+   the marking. The stronger accent wash is kept for hover, so pointing at the
+   row is what lights it up rather than it shouting all the time. The row owns
+   both states explicitly so a theme's own (sometimes very saturated) hover
+   colour can't turn it into an unreadable slab. */
 /* Heatmap tint for agenda rows, mirroring the grid's per-day tint. Built from
  * the stable --accent-h/s/l vars for the same reason (see the grid rule). */
 .hearth-agenda-row.has-heat {
@@ -2531,8 +2542,10 @@
 	);
 }
 
-.hearth-agenda-row.has-heat:hover {
-	background-color: var(--background-modifier-hover);
+@media (hover: hover) {
+	.hearth-agenda-row.has-heat:hover {
+		background-color: var(--background-modifier-hover);
+	}
 }
 
 .hearth-agenda-row.is-static {
@@ -2541,6 +2554,20 @@
 
 .hearth-agenda-row.is-static:hover {
 	background: transparent;
+}
+
+/* Today's row, last so it wins over the heat tint and the static reset. */
+.hearth-agenda-row.is-today,
+.hearth-agenda-row.is-today.has-heat,
+.hearth-agenda-row.is-today.is-static:hover {
+	background-color: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
+}
+
+@media (hover: hover) {
+	.hearth-agenda-row.is-today:hover,
+	.hearth-agenda-row.is-today.has-heat:hover {
+		background-color: color-mix(in srgb, var(--interactive-accent) 20%, transparent);
+	}
 }
 
 /* External calendar events listed under an agenda day. The left inset lines


### PR DESCRIPTION
## What does this PR do?

Today's row in the calendar card's agenda list read as a solid, saturated accent slab, which made its label and sub-text hard to read.

The plugin's own rule for `.hearth-agenda-row.is-today` was only a 1px accent outline — the heavy fill comes from the row picking up the theme's `--background-modifier-hover`, which in some themes is a strongly saturated accent. So this swaps the two states and makes the row own its colours:

- **Rest state:** a faint accent tint (8%) instead of the outline. Today is carried by the date badge — the day number gets an accent ring (inset 1px at 55%) around its soft pill, and the weekday abbreviation is accent-tinted.
- **Hover:** the stronger accent wash (20%), so pointing at the row is what lights it up.
- Both states are set explicitly on `.is-today`, so a theme's own hover colour no longer applies to it.
- Agenda-row hover rules are wrapped in `@media (hover: hover)` — on touch the hover state stuck after a tap, leaving a row looking permanently selected.
- Today's rules are ordered last so they win over the heatmap tint and the `is-static` reset (an agenda on a card with no daily notes stays inert and doesn't light up).

CSS only; the month-grid view's today marker (solid accent badge + 2px ring) is unchanged.

## Related issue

None — small visual fix reported directly.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault

Notes on the checklist: `npm run build` fails in this environment before reaching the change — `tsc` errors on two pre-existing `tsconfig.json` deprecations (`baseUrl`, `moduleResolution=node10`) under the TypeScript version installed here, and it fails identically on an unmodified `main`. The change is CSS only, so nothing in the build is affected by it, but it hasn't been verified green. It also hasn't been rendered in a real vault — worth a look before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NU5o6fZPoF6u7MLohFkLyd)_