### PR TITLE
Clear the actionable findings from the Obsidian review scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,19 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   saturated hover colour can't turn today into an unreadable slab, and hover no
   longer sticks after a tap on touch devices.
 
+### Removed
+
+- **The deprecated `commandId` field on mobile action buttons is gone.**
+  Scheduled for removal in 1.11.0 when the 1.9.0 migration landed, it is now
+  retired: the field no longer exists on a button, and `actionTarget()` no
+  longer falls back to reading it. **This changes nothing about how your buttons
+  behave.** The load-time migration that folds a legacy `commandId` into
+  `target` is deliberately kept, so a vault upgrading from before 1.9.0 — even
+  one that skipped every release since — still has its buttons migrated in place
+  exactly as before, as does an imported backup. The one-way caveat from 1.9.0
+  is unchanged: downgrading below 1.9.0 loses any button whose action was stored
+  *only* as `commandId`.
+
 ## [1.17.0]
 
 ### Added

--- a/src/cards/calendar.ts
+++ b/src/cards/calendar.ts
@@ -59,7 +59,6 @@ import {
 } from "../tasknotes";
 import {
 	calendarChips,
-	type CalendarChipConfig,
 	type CalendarConfig,
 	type DashboardCard,
 	type ResolvedChips,

--- a/src/mobileactions.ts
+++ b/src/mobileactions.ts
@@ -27,15 +27,12 @@ export function renderMobileActionBar(view: HomeView, parent: HTMLElement): void
 }
 
 /** The button's target. `migrateSettings` folds the legacy `commandId` into
- * `target` at load time, so this reads `target` alone; the `?? btn.commandId`
- * below is a transitional safety net for any button not yet migrated in memory.
- * Remove in 1.11.0 or later — two minor releases after 1.9.0, once the
- * migration has run for everyone — together with the `commandId` field. */
+ * `target` at load time — and `sanitizeMobileActionButton` does the same for an
+ * imported backup — so by the time a button reaches here its action always
+ * lives in `target`. The transitional `?? btn.commandId` fallback this used to
+ * carry was retired in 1.18.0 together with the field itself. */
 export function actionTarget(btn: MobileActionButton): string {
-	// The `?? btn.commandId` read intentionally trips no-deprecated (the repo
-	// forbids silencing that rule): the warning is the visible marker for this
-	// transitional fallback and disappears when the field is removed in 1.11.0.
-	return btn.target ?? btn.commandId ?? "";
+	return btn.target ?? "";
 }
 
 /** Run a mobile action button: execute its command, open its note/file, or

--- a/src/types.ts
+++ b/src/types.ts
@@ -655,17 +655,12 @@ export interface MobileActionButton {
 	id: string;
 	label: string;
 	icon: string;
-	/** What the button does. Defaults to "command" when absent (older buttons
-	 * stored only `commandId`). */
+	/** What the button does. Defaults to "command" when absent (buttons stored
+	 * before this field existed carried a bare command id, which
+	 * `migrateSettings` folds into `target` on load). */
 	type?: "command" | "note" | "url";
 	/** Command id, vault path, or URL depending on `type`. */
 	target?: string;
-	/** @deprecated Legacy command id from before `type`/`target` existed.
-	 * `migrateSettings` folds it into `target` on load (one-way); the fallback
-	 * read in `actionTarget` is a transitional safety net.
-	 * Remove in 1.11.0 or later — two minor releases after 1.9.0, once the
-	 * migration has run for everyone — together with that fallback. */
-	commandId?: string;
 }
 
 /** A secondary embed a card can switch to. Only `target` is required; `scale`
@@ -1579,17 +1574,18 @@ export function migrateSettings(s: HomeSettings, raw: Record<string, unknown>): 
 	// This does NOT round-trip — a user who upgrades and then downgrades below
 	// 1.9.0 loses any button whose action was stored only as `commandId`. See
 	// CHANGELOG.
-	// Remove in 1.11.0 or later — two minor releases after 1.9.0, once the
-	// migration has run for everyone — together with the `commandId` field on
-	// MobileActionButton and the fallback read in actionTarget().
+	// The `commandId` field itself was removed from MobileActionButton in
+	// 1.18.0, along with the fallback read that used to back it up in
+	// actionTarget(). This fold is deliberately kept: stored settings can still
+	// carry the legacy key, and it is now the only thing standing between a
+	// vault that skipped 1.9.0–1.17.0 and a row of dead buttons. It reads the
+	// key through an untyped view of the button, since the type no longer
+	// admits it, and it self-converges — once folded, it stops re-firing.
 	let migratedCommandId = false;
 	if (Array.isArray(s.mobileActionButtons)) {
 		for (const btn of s.mobileActionButtons) {
-			// Reading (and below, deleting) `commandId` intentionally trips
-			// no-deprecated — the repo forbids silencing that rule, so the
-			// warnings stay visible until the field is removed in 1.11.0. That is
-			// expected: a migration must touch the field it is retiring.
-			const legacy = btn.commandId;
+			const legacyBtn = btn as MobileActionButton & { commandId?: string };
+			const legacy = legacyBtn.commandId;
 			if (legacy === undefined) continue;
 			// Only lift the value into `target` when `target` is unset: a button
 			// that already carries a `target` (a newer version or a manual edit)
@@ -1607,7 +1603,7 @@ export function migrateSettings(s: HomeSettings, raw: Record<string, unknown>): 
 			// so there is nothing to preserve. This also lets the migration fully
 			// converge, so it stops re-firing (and re-saving) on later loads.
 			if ((btn.target !== undefined && btn.target !== "") || legacy === "") {
-				delete btn.commandId;
+				delete legacyBtn.commandId;
 				migratedCommandId = true;
 			}
 		}

--- a/test/mobileactionsmigration.test.ts
+++ b/test/mobileactionsmigration.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { actionTarget } from "../src/mobileactions";
+import { DEFAULT_SETTINGS, migrateSettings, type HomeSettings } from "../src/types";
+
+/**
+ * The legacy `commandId` → `target` fold.
+ *
+ * The deprecated `commandId` field was removed from `MobileActionButton` in
+ * 1.18.0, together with the `?? btn.commandId` fallback that `actionTarget()`
+ * used to carry. This migration is what replaced them: it is now the *only*
+ * thing that keeps a vault whose settings still store `commandId` — one that
+ * skipped 1.9.0–1.17.0 — from coming back with a row of dead buttons. It is
+ * also the reason the fallback could be dropped safely, so the rules it
+ * guarantees are worth pinning down.
+ */
+
+/** Load settings the way `main.ts` does, then migrate. Returns the migrated
+ * buttons alongside the flag that tells the caller to flush to storage. */
+function load(buttons: unknown[]): { buttons: Record<string, unknown>[]; flushed: boolean } {
+	const raw = { mobileActionButtons: buttons } as Record<string, unknown>;
+	const s = Object.assign({}, DEFAULT_SETTINGS, raw) as HomeSettings;
+	const flushed = migrateSettings(s, raw);
+	return { buttons: s.mobileActionButtons as unknown as Record<string, unknown>[], flushed };
+}
+
+const legacy = (extra: Record<string, unknown>) => ({
+	id: "b1",
+	label: "Daily",
+	icon: "calendar",
+	...extra,
+});
+
+describe("commandId → target migration", () => {
+	it("lifts a legacy commandId into target and drops the old field", () => {
+		const { buttons, flushed } = load([legacy({ commandId: "daily-notes" })]);
+		expect(buttons[0].target).toBe("daily-notes");
+		expect(buttons[0]).not.toHaveProperty("commandId");
+		// The fold is one-way, so the caller must persist it.
+		expect(flushed).toBe(true);
+	});
+
+	it("keeps an existing target authoritative and discards the stale commandId", () => {
+		const { buttons } = load([legacy({ target: "new-note", commandId: "daily-notes" })]);
+		expect(buttons[0].target).toBe("new-note");
+		expect(buttons[0]).not.toHaveProperty("commandId");
+	});
+
+	it("preserves a command that does not resolve yet", () => {
+		// At load time another plugin's commands may not be registered, so a
+		// "missing" command is only not-yet-loaded — dropping it would be data loss.
+		const { buttons } = load([legacy({ commandId: "some-other-plugin:thing" })]);
+		expect(buttons[0].target).toBe("some-other-plugin:thing");
+	});
+
+	it("drops an empty commandId without inventing a target", () => {
+		const { buttons } = load([legacy({ commandId: "" })]);
+		expect(buttons[0]).not.toHaveProperty("commandId");
+		expect(buttons[0].target).toBeUndefined();
+	});
+
+	it("leaves an already-migrated button completely alone", () => {
+		const { buttons, flushed } = load([legacy({ type: "command", target: "new-note" })]);
+		expect(buttons[0].target).toBe("new-note");
+		// Nothing was folded, so there is nothing to flush.
+		expect(flushed).toBe(false);
+	});
+
+	it("converges — a second load has nothing left to migrate", () => {
+		const raw = { mobileActionButtons: [legacy({ commandId: "daily-notes" })] } as Record<
+			string,
+			unknown
+		>;
+		const s = Object.assign({}, DEFAULT_SETTINGS, raw) as HomeSettings;
+		expect(migrateSettings(s, raw)).toBe(true);
+		// Re-running over the already-folded settings must not re-fire, or the
+		// plugin would save on every single start.
+		expect(migrateSettings(s, s as unknown as Record<string, unknown>)).toBe(false);
+	});
+
+	it("hands actionTarget a button it can resolve without the removed fallback", () => {
+		const { buttons } = load([legacy({ commandId: "daily-notes" })]);
+		expect(actionTarget(buttons[0] as never)).toBe("daily-notes");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Works through the latest Obsidian review scan and lands the two findings that were actually actionable.

**1. Drop an unused import.** `src/cards/calendar.ts` imported `CalendarChipConfig` but only ever used `calendarChips()` and `ResolvedChips` — the type itself is never referenced in the file.

**2. Retire the deprecated `commandId` field on mobile action buttons.** The scan flagged it, and the field's own comment scheduled it for removal *"in 1.11.0 or later"* when the migration landed in 1.9.0. We're on 1.17.0, so it is six minor versions overdue. This removes the field from `MobileActionButton` and the `?? btn.commandId` fallback in `actionTarget()`.

The load-time fold in `migrateSettings` is **deliberately kept** rather than retired alongside them, which is a small deviation from "remove all three". It's what allows the fallback to go away safely, and with the field gone it is now the only thing standing between a vault that skipped 1.9.0–1.17.0 and a row of dead buttons — while costing nothing, since it self-converges and stops re-firing once folded. It now reads the legacy key through an untyped view of the button, since the type no longer admits it. `sanitizeMobileActionButton` in `layout.ts` already did the same untyped fold for imported backups, so this keeps the two paths consistent.

That migration turned out to have **no test coverage at all**, which is hard to justify now that it carries the compatibility guarantee by itself, so this adds `test/mobileactionsmigration.test.ts` pinning the rules it has to hold: the fold, an existing `target` staying authoritative, an unresolved command being preserved rather than dropped (at load time another plugin's commands may not be registered yet), an empty value not inventing a target, convergence across two loads, and `actionTarget()` resolving a migrated button without the removed fallback.

No user-visible behaviour change. Lint warnings go 27 → 24, with all three `commandId` ones cleared.

### Scan findings deliberately left alone

- **`setWarning` / `setDynamicTooltip`** — minAppVersion constraints, not oversights. Both replacements (`setDestructive`, the inline slider value) are `@since 1.13.0`, and our declared `minAppVersion` is `1.8.7`; switching would break these controls on 1.8.7–1.12.x, and for the slider would leave no value readout at all. `src/ui.ts` already documents this. These clear themselves when minAppVersion rises to 1.13.0+.
- **`use24Hour`** — our own deprecation, intentionally kept for migration.
- **All 7 `!important` warnings** — each is a documented theme-override defense (plugin/theme CSS load order isn't guaranteed) or a focus-ring reset. Specificity can't reliably beat a theme hard-coding a literal colour.
- **`multicolumn` at `styles.css:367`** — false positive; that's `column-gap` on a *flex* container, not multi-column layout.
- **`display: contents` at `styles.css:4471`** — flagged as partially supported, but Obsidian is Electron/Chromium where it's fully supported.

## Related issue

None — cleanup of an overdue deprecation surfaced by the review scan.

## Type of change

- [x] 🐛 Bug fix — dead import plus an overdue deprecation removal; no behaviour change
- [ ] 🌍 Translation
- [x] 📝 Docs — CHANGELOG entry under 1.18.0
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (typecheck clean, 342 tests pass, 0 lint errors)
- [ ] I've tested this in an actual vault — not possible from this environment; the migration path is covered by the new unit tests instead, and worth a spot-check on a vault with pre-1.9.0 mobile action buttons before release

---
_Generated by [Claude Code](https://claude.ai/code/session_011zPEb9V5LhtvyFUKTmkGck)_