### PR TITLE
feat(settings): list every integration on the Integrations tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   a complete catalogue of everything Hearth works with — community plugins
   (Omnisearch, TaskNotes, Dataview, Iconic, Iconize, Excalidraw), Obsidian's own
   core plugins (Bases, Canvas, Daily notes, Bookmarks, Search, File explorer,
-  Workspaces, Audio recorder, plus any plugin whose side panel a Leaf card can
-  host) and the external services some cards fetch from (Jira, RSS and Atom
+  Workspaces, Audio recorder, plus any plugin whose side panel a Plugin view
+  card can host) and the external services some cards fetch from (Jira, RSS and Atom
   feeds, iCalendar subscriptions, exchange rates, web search). Every one is
   listed whether or not it's installed, so the tab answers "what does Hearth
   work with?" and not just "what did I already set up". Each row says what the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
+- **Every integration in one place.** **Settings → Integrations** now opens with
+  a complete catalogue of everything Hearth works with — community plugins
+  (Omnisearch, TaskNotes, Dataview, Iconic, Iconize, Excalidraw), Obsidian's own
+  core plugins (Bases, Canvas, Daily notes, Bookmarks, Search, File explorer,
+  Workspaces, Audio recorder, plus any plugin whose side panel a Leaf card can
+  host) and the external services some cards fetch from (Jira, RSS and Atom
+  feeds, iCalendar subscriptions, exchange rates, web search). Every one is
+  listed whether or not it's installed, so the tab answers "what does Hearth
+  work with?" and not just "what did I already set up". Each row says what the
+  integration does, carries a live status (enabled, disabled, not installed),
+  and points at where its settings actually live — the section below on that
+  tab, another tab (Omnisearch is a choice in the search-engine dropdown), the
+  card itself, the other plugin's own settings, or nowhere at all. Rows link
+  straight there, and anything not installed gets a one-click Install button.
 - **Low power mode.** One switch at the top of **Settings → Appearance** trades
   Hearth's visual effects for battery life and smoothness on slower hardware.
   While it is on the background becomes a flat colour (a muted grey-purple by

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -1,0 +1,240 @@
+/**
+ * The catalogue of everything Hearth talks to: community plugins, Obsidian's
+ * own core plugins, and the external services a few cards fetch from.
+ *
+ * Why a catalogue at all — Hearth's integrations are, by nature, scattered.
+ * Some carry global settings (TaskNotes' field names, the Iconic/Iconize
+ * switch), some are a single option on a different tab (Omnisearch is a choice
+ * in the search-engine dropdown), and most are configured per-card on the board
+ * or need no configuration whatsoever. Before this, that meant the Integrations
+ * tab showed only the two integrations that happened to have settings, and
+ * there was nowhere to answer "what does Hearth work with, and is it working
+ * right now?".
+ *
+ * So the catalogue is deliberately *complete and static*: every entry is listed
+ * whether or not the plugin is installed and whether or not Hearth has a
+ * setting for it. Status is resolved live at render time; the row says where
+ * the setting lives (or that there isn't one) either way.
+ *
+ * Everything here is pure data plus one resolver, so it is unit-testable and
+ * carries no rendering concerns — {@link HomeSettingTab} renders it.
+ */
+import type { App } from "obsidian";
+import { DATAVIEW_PLUGIN_ID } from "./dataview";
+import { ICONIC_PLUGIN_ID, ICONIZE_PLUGIN_ID } from "./fileicons";
+import { EXCALIDRAW_PLUGIN_ID } from "./filetypes";
+import { OMNISEARCH_PLUGIN_ID } from "./omnisearch";
+import { TASKNOTES_PLUGIN_ID } from "./tasknotes";
+
+/**
+ * Ids of the settings ribbon tabs.
+ *
+ * Declared here rather than in `settings.ts` so a catalogue entry can point at
+ * the tab that holds its setting without `integrations.ts` and `settings.ts`
+ * importing each other.
+ */
+export type SettingsTabId =
+	| "appearance"
+	| "search"
+	| "dashboard"
+	| "behaviour"
+	| "integrations"
+	| "backup"
+	| "about";
+
+/** The collapsible sections of the Integrations tab that hold real settings.
+ * A catalogue entry names one so its row can expand and scroll to it. */
+export type IntegrationSectionId = "tasks" | "fileIcons";
+
+/** How an integration is grouped in the list. */
+export type IntegrationGroup = "plugin" | "core" | "service";
+
+/** Where an integration's settings live — which is often nowhere, and that is
+ * worth saying out loud rather than leaving the row looking unfinished. */
+export type IntegrationWhere =
+	/** A settings section further down the Integrations tab. */
+	| { kind: "section"; section: IntegrationSectionId }
+	/** A setting on another tab of Hearth's settings. */
+	| { kind: "tab"; tab: SettingsTabId }
+	/** Configured per-card, in that card's own settings on the board. */
+	| { kind: "card" }
+	/** Hearth reads the other plugin's own settings; nothing to set here. */
+	| { kind: "pluginSettings" }
+	/** Nothing to configure anywhere. */
+	| { kind: "none" };
+
+/** Ids of the catalogue entries; also the keys of
+ * `t().settings.integrations.items`, so a missing translation is a build
+ * error rather than an empty row. */
+export type IntegrationId =
+	| "omnisearch"
+	| "tasknotes"
+	| "dataview"
+	| "iconic"
+	| "iconize"
+	| "excalidraw"
+	| "bases"
+	| "canvas"
+	| "dailyNotes"
+	| "bookmarks"
+	| "globalSearch"
+	| "fileExplorer"
+	| "workspaces"
+	| "audioRecorder"
+	| "leafViews"
+	| "jira"
+	| "rss"
+	| "ics"
+	| "currency"
+	| "webSearch";
+
+export interface IntegrationEntry {
+	id: IntegrationId;
+	group: IntegrationGroup;
+	/** The community-plugin id whose presence decides this row's status. */
+	pluginId?: string;
+	/** The core (internal) plugin id whose presence decides this row's status. */
+	corePluginId?: string;
+	where: IntegrationWhere;
+}
+
+/**
+ * Every integration Hearth has, in the order they're listed.
+ *
+ * Adding one here is all it takes to have it appear — add the matching strings
+ * under `settings.integrations.items` and TypeScript will point at the gap if
+ * you forget.
+ */
+export const INTEGRATIONS: readonly IntegrationEntry[] = [
+	// ---- Community plugins ------------------------------------------------
+	{
+		id: "omnisearch",
+		group: "plugin",
+		pluginId: OMNISEARCH_PLUGIN_ID,
+		where: { kind: "tab", tab: "search" },
+	},
+	{
+		id: "tasknotes",
+		group: "plugin",
+		pluginId: TASKNOTES_PLUGIN_ID,
+		where: { kind: "section", section: "tasks" },
+	},
+	{
+		id: "dataview",
+		group: "plugin",
+		pluginId: DATAVIEW_PLUGIN_ID,
+		where: { kind: "card" },
+	},
+	{
+		id: "iconic",
+		group: "plugin",
+		pluginId: ICONIC_PLUGIN_ID,
+		where: { kind: "section", section: "fileIcons" },
+	},
+	{
+		id: "iconize",
+		group: "plugin",
+		pluginId: ICONIZE_PLUGIN_ID,
+		where: { kind: "section", section: "fileIcons" },
+	},
+	{
+		id: "excalidraw",
+		group: "plugin",
+		pluginId: EXCALIDRAW_PLUGIN_ID,
+		where: { kind: "card" },
+	},
+
+	// ---- Obsidian core plugins --------------------------------------------
+	{ id: "bases", group: "core", corePluginId: "bases", where: { kind: "card" } },
+	{ id: "canvas", group: "core", corePluginId: "canvas", where: { kind: "card" } },
+	{
+		id: "dailyNotes",
+		group: "core",
+		corePluginId: "daily-notes",
+		where: { kind: "pluginSettings" },
+	},
+	{ id: "bookmarks", group: "core", corePluginId: "bookmarks", where: { kind: "card" } },
+	{
+		id: "globalSearch",
+		group: "core",
+		corePluginId: "global-search",
+		where: { kind: "none" },
+	},
+	{
+		id: "fileExplorer",
+		group: "core",
+		corePluginId: "file-explorer",
+		where: { kind: "none" },
+	},
+	{ id: "workspaces", group: "core", corePluginId: "workspaces", where: { kind: "card" } },
+	{
+		id: "audioRecorder",
+		group: "core",
+		corePluginId: "audio-recorder",
+		where: { kind: "tab", tab: "behaviour" },
+	},
+	// Not tied to any one plugin: the Leaf card hosts whichever side-panel
+	// views happen to be registered, core or community.
+	{ id: "leafViews", group: "core", where: { kind: "card" } },
+
+	// ---- External services -------------------------------------------------
+	{ id: "jira", group: "service", where: { kind: "card" } },
+	{ id: "rss", group: "service", where: { kind: "card" } },
+	{ id: "ics", group: "service", where: { kind: "card" } },
+	{ id: "currency", group: "service", where: { kind: "none" } },
+	{ id: "webSearch", group: "service", where: { kind: "tab", tab: "search" } },
+];
+
+/** The live state of an integration.
+ *
+ * - `enabled`  — the plugin is on right now and Hearth can use it.
+ * - `disabled` — installed (or, for a core plugin, always present) but off.
+ * - `missing`  — not installed at all.
+ * - `external` — an outbound service rather than a plugin.
+ * - `always`   — nothing to install; it works with whatever is there.
+ */
+export type IntegrationStatus =
+	| "enabled"
+	| "disabled"
+	| "missing"
+	| "external"
+	| "always";
+
+/**
+ * Resolve an entry's status against the running app.
+ *
+ * Every read is defensive: `plugins.manifests` is an Obsidian internal (it's
+ * how "installed but disabled" is told apart from "never installed") and
+ * `internalPlugins.getPluginById` returns null for an id a given Obsidian
+ * version doesn't know — Bases, for instance, only exists in 1.9+. Neither may
+ * throw here: this runs while the settings pane is being built.
+ */
+export function integrationStatus(app: App, entry: IntegrationEntry): IntegrationStatus {
+	if (entry.group === "service") return "external";
+
+	if (entry.pluginId) {
+		try {
+			if (app.plugins?.enabledPlugins?.has(entry.pluginId)) return "enabled";
+			return app.plugins?.manifests?.[entry.pluginId] ? "disabled" : "missing";
+		} catch {
+			return "missing";
+		}
+	}
+
+	if (entry.corePluginId) {
+		try {
+			const plugin = app.internalPlugins?.getPluginById(entry.corePluginId);
+			if (!plugin) return "missing";
+			return plugin.enabled ? "enabled" : "disabled";
+		} catch {
+			return "missing";
+		}
+	}
+
+	return "always";
+}
+
+/** Entries of one group, in catalogue order. */
+export function integrationsInGroup(group: IntegrationGroup): IntegrationEntry[] {
+	return INTEGRATIONS.filter((entry) => entry.group === group);
+}

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -173,8 +173,8 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
 		corePluginId: "audio-recorder",
 		where: { kind: "tab", tab: "behaviour" },
 	},
-	// Not tied to any one plugin: the Leaf card hosts whichever side-panel
-	// views happen to be registered, core or community.
+	// Not tied to any one plugin: the Plugin view card (`leaf` internally) hosts
+	// whichever side-panel views happen to be registered, core or community.
 	{ id: "leafViews", group: "core", where: { kind: "card" } },
 
 	// ---- External services -------------------------------------------------

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -473,6 +473,169 @@ export const en = {
 			addButton: "Add button",
 			resetDefaults: "Reset to defaults",
 		},
+		/** The full catalogue shown at the top of the Integrations tab. Every
+		 * integration is listed here whether or not it has a setting and whether
+		 * or not the plugin is installed — see `src/integrations.ts`. */
+		integrations: {
+			heading: "All integrations",
+			headingDesc:
+				"Everything Hearth can work with, listed whether or not it's installed. " +
+				"Most integrations need no setup — the ones that do say where their " +
+				"settings live.",
+			groups: {
+				plugin: "Community plugins",
+				pluginDesc: "Hearth picks these up automatically once they're enabled.",
+				core: "Obsidian core plugins",
+				coreDesc:
+					"Built into Obsidian. Enable them in Settings → Core plugins if a " +
+					"card says one is missing.",
+				service: "External services",
+				serviceDesc:
+					"Cards that fetch over the network. All of them are silenced at once " +
+					"by “Disable external calls” under Behaviour → Privacy & network.",
+			},
+			status: {
+				enabled: "Enabled",
+				disabled: "Disabled",
+				missing: "Not installed",
+				external: "Network",
+				always: "Always available",
+			},
+			/** Tooltip on the status pill, spelling out what it means for Hearth. */
+			statusTooltip: {
+				enabled: "Installed and enabled — Hearth is using it.",
+				disabled: "Installed but turned off, so Hearth can't use it right now.",
+				missing: "Not installed. Everything else in Hearth works without it.",
+				external: "An outbound request, not a plugin.",
+				always: "Nothing to install.",
+			},
+			/** Where this integration's settings live, shown under the description. */
+			where: {
+				section: "Settings below on this tab.",
+				tab: (tab: string) => `Settings under ${tab}.`,
+				card: "Configured on the card itself, on your dashboard.",
+				pluginSettings: "Uses that plugin's own settings — nothing to set in Hearth.",
+				none: "Nothing to configure.",
+			},
+			/** Row buttons. */
+			install: "Install",
+			installTooltip: "Open this plugin in Obsidian's community plugin browser.",
+			goToSection: "Show",
+			goToTab: "Open",
+			/** One entry per id in `INTEGRATIONS`. */
+			items: {
+				omnisearch: {
+					name: "Omnisearch",
+					desc:
+						"Swaps the search bar over to Omnisearch's fuzzy, full-text index " +
+						"instead of Hearth's built-in engine. Pick the engine under " +
+						"Search → Search bar; the choice only sticks while Omnisearch is enabled.",
+				},
+				tasknotes: {
+					name: "TaskNotes",
+					desc:
+						"Lets Tasks cards read TaskNotes' one-note-per-task vaults — status, " +
+						"due date and priority straight from frontmatter.",
+				},
+				dataview: {
+					name: "Dataview",
+					desc:
+						"The Dataview card runs DQL queries and DataviewJS blocks and renders " +
+						"them with Dataview's own renderers, refreshing as its index changes.",
+				},
+				iconic: {
+					name: "Iconic",
+					desc:
+						"Per-file icons set with Iconic show up wherever Hearth lists a file — " +
+						"Recent, Favorites, saved searches and search results.",
+				},
+				iconize: {
+					name: "Iconize",
+					desc:
+						"The same for Iconize (formerly Obsidian Icon Folder), including icons " +
+						"set through a frontmatter property.",
+				},
+				excalidraw: {
+					name: "Excalidraw",
+					desc:
+						"Embed cards render Excalidraw drawings live, and the “New drawing” " +
+						"action creates one through Excalidraw's own command.",
+				},
+				bases: {
+					name: "Bases",
+					desc: "Embed cards can show a Bases (.base) view on the dashboard.",
+				},
+				canvas: {
+					name: "Canvas",
+					desc: "Embed cards can show a canvas, interactive and edge to edge.",
+				},
+				dailyNotes: {
+					name: "Daily notes",
+					desc:
+						"The Daily note, Mini calendar and Vault statistics cards resolve today's " +
+						"note from Daily notes' own folder, date format and template.",
+				},
+				bookmarks: {
+					name: "Bookmarks",
+					desc: "The Bookmarks card lists your Obsidian bookmarks, groups and all.",
+				},
+				globalSearch: {
+					name: "Search",
+					desc:
+						"Hands a query over to Obsidian's own search pane when you ask for the " +
+						"full results.",
+				},
+				fileExplorer: {
+					name: "File explorer",
+					desc: "Powers “Reveal in file explorer” on Hearth's search results.",
+				},
+				workspaces: {
+					name: "Workspaces",
+					desc: "A dashboard can switch to a saved workspace when you open it.",
+				},
+				audioRecorder: {
+					name: "Audio recorder",
+					desc:
+						"The “Record voice” mobile action button starts and stops Obsidian's " +
+						"own recorder.",
+				},
+				leafViews: {
+					name: "Any plugin with a side panel",
+					desc:
+						"The Leaf card hosts another plugin's registered view — calendars, " +
+						"kanban boards, outlines, tag panes — right inside a card. Whatever " +
+						"is installed shows up in the card's view picker.",
+				},
+				jira: {
+					name: "Jira",
+					desc:
+						"Jira cards fetch issues from your Jira Cloud or Server instance over " +
+						"its REST API, using credentials you enter on the card.",
+				},
+				rss: {
+					name: "RSS & Atom feeds",
+					desc: "RSS cards fetch and parse any RSS 2.0 or Atom feed you point them at.",
+				},
+				ics: {
+					name: "iCalendar feeds",
+					desc:
+						"Mini calendar cards can subscribe to external ICS/webcal calendars — " +
+						"Google, iCloud, Fastmail, Nextcloud and friends.",
+				},
+				currency: {
+					name: "Exchange rates",
+					desc:
+						"The Calculator card converts currencies using ECB rates from the free, " +
+						"key-less Frankfurter API.",
+				},
+				webSearch: {
+					name: "Web search",
+					desc:
+						"The search bar's button can send your query to DuckDuckGo instead of " +
+						"creating a note. Switch it under Search → Search bar.",
+				},
+			},
+		},
 		tasks: {
 			heading: "Tasks / TaskNotes",
 			headingDesc:

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -602,9 +602,9 @@ export const en = {
 				leafViews: {
 					name: "Any plugin with a side panel",
 					desc:
-						"The Leaf card hosts another plugin's registered view — calendars, " +
-						"kanban boards, outlines, tag panes — right inside a card. Whatever " +
-						"is installed shows up in the card's view picker.",
+						"The Plugin view card hosts another plugin's registered view — " +
+						"calendars, kanban boards, outlines, tag panes — right inside a card. " +
+						"Whatever is installed shows up in the card's view picker.",
 				},
 				jira: {
 					name: "Jira",

--- a/src/obsidian-ext.d.ts
+++ b/src/obsidian-ext.d.ts
@@ -20,6 +20,11 @@ declare module "obsidian" {
 			enabledPlugins: Set<string>;
 			/** The loaded community plugin instances, keyed by id. */
 			plugins: Record<string, unknown>;
+			/** Manifests of every *installed* community plugin, keyed by id —
+			 * present whether or not the plugin is enabled, which is how the
+			 * integrations catalogue tells "installed but off" from "not
+			 * installed". Optional: it's an internal, so treat it as absent. */
+			manifests?: Record<string, unknown>;
 		};
 		/** Registry of every view type registered via `registerView` (core and
 		 * community). `viewByType` is keyed by the view-type id. Used by the

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -360,8 +360,15 @@ export class HomeSettingTab extends PluginSettingTab {
 				// or not it is installed and whether or not it has a setting. The two
 				// sections below are the only ones that *do* have settings, and rows
 				// in the catalogue link down to them.
-				this.section(body, s.integrations.heading, s.integrations.headingDesc, (b) =>
-					this.integrationsCatalogue(b),
+				// Folded to start with: it's a reference list, not a setting, and
+				// unfolded it would push the two sections that *are* settings off
+				// the screen.
+				this.section(
+					body,
+					s.integrations.heading,
+					s.integrations.headingDesc,
+					(b) => this.integrationsCatalogue(b),
+					{ collapsedByDefault: true },
 				);
 				this.section(body, s.tasks.heading, s.tasks.headingDesc, (b) => this.tasksSection(b));
 				this.section(body, s.fileIcons.heading, s.fileIcons.headingDesc, (b) =>
@@ -391,12 +398,18 @@ export class HomeSettingTab extends PluginSettingTab {
 
 	/** Wrap a section in a collapsible block. The heading toggles visibility of
 	 * the body; the collapsed state is persisted per-section in localStorage so
-	 * long settings panels can be tamed and stay tamed. */
+	 * long settings panels can be tamed and stay tamed.
+	 *
+	 * `collapsedByDefault` only decides where a section starts before anyone has
+	 * ever folded it — for a long reference list that isn't a setting, starting
+	 * closed keeps the tab's actual settings in reach. Once the user folds or
+	 * unfolds it themselves, their choice is what persists. */
 	private section(
 		containerEl: HTMLElement,
 		title: string,
 		desc: string | undefined,
 		render: (body: HTMLElement) => void,
+		opts?: { collapsedByDefault?: boolean },
 	): void;
 	private section(
 		containerEl: HTMLElement,
@@ -408,6 +421,7 @@ export class HomeSettingTab extends PluginSettingTab {
 		title: string,
 		descOrRender: string | undefined | ((body: HTMLElement) => void),
 		maybeRender?: (body: HTMLElement) => void,
+		opts?: { collapsedByDefault?: boolean },
 	): void {
 		const desc = typeof descOrRender === "string" ? descOrRender : undefined;
 		const render = typeof descOrRender === "function" ? descOrRender : maybeRender!;
@@ -434,9 +448,13 @@ export class HomeSettingTab extends PluginSettingTab {
 		}
 
 		// Persist the collapsed state per-section and per-vault via Obsidian's
-		// vault-scoped local storage.
+		// vault-scoped local storage. Both states are stored explicitly ("1"/"0")
+		// rather than clearing the key when open: absent has to keep meaning
+		// "never touched", so a default-collapsed section the user opened stays
+		// open instead of folding itself again on the next visit.
 		const key = `hearth-section-${title}`;
-		let collapsed = this.app.loadLocalStorage(key) === "1";
+		const saved = this.app.loadLocalStorage(key) as string | null;
+		let collapsed = saved === null ? !!opts?.collapsedByDefault : saved === "1";
 
 		// A catalogue row asked for this section: unfold it (persisting that, so
 		// it doesn't snap shut on the next visit) and scroll it into view once the
@@ -444,7 +462,7 @@ export class HomeSettingTab extends PluginSettingTab {
 		if (this.revealSectionTitle === title) {
 			this.revealSectionTitle = null;
 			collapsed = false;
-			this.app.saveLocalStorage(key, null);
+			this.app.saveLocalStorage(key, "0");
 			window.requestAnimationFrame(() =>
 				wrap.scrollIntoView({ block: "start", behavior: "smooth" }),
 			);
@@ -459,7 +477,7 @@ export class HomeSettingTab extends PluginSettingTab {
 		apply();
 		head.addEventListener("click", () => {
 			collapsed = !collapsed;
-			this.app.saveLocalStorage(key, collapsed ? "1" : null);
+			this.app.saveLocalStorage(key, collapsed ? "1" : "0");
 			apply();
 		});
 		head.addEventListener("keydown", (e) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,6 +8,14 @@ import { type BackgroundKind, CARD_BORDER_WIDTH_MAX, DEFAULT_SETTINGS, defaultMo
 import { exportLayout, exportSettings, importLayout, importSettings } from "./layout";
 import { confirmAction, downloadTextFile, pickTextFile } from "./ui";
 import { isOmnisearchAvailable, OMNISEARCH_PLUGIN_ID } from "./omnisearch";
+import {
+	type IntegrationEntry,
+	type IntegrationGroup,
+	type IntegrationSectionId,
+	integrationsInGroup,
+	integrationStatus,
+	type SettingsTabId,
+} from "./integrations";
 import { CHANGELOG, WhatsNewModal } from "./whatsnew";
 import { t } from "./i18n";
 
@@ -47,17 +55,9 @@ const KOFI_URL = "https://ko-fi.com/ondru";
 const LAYOUT_FILE = "hearth-layout.json";
 const SETTINGS_FILE = "hearth-settings.json";
 
-/** A tab in the settings ribbon: an id (keys `t().settings.tabs`) and a Lucide
- * icon shown beside the label. */
-type SettingsTabId =
-	| "appearance"
-	| "search"
-	| "dashboard"
-	| "behaviour"
-	| "integrations"
-	| "backup"
-	| "about";
-
+/** A tab in the settings ribbon: an id (keys `t().settings.tabs`, declared in
+ * `integrations.ts` so the catalogue can point at one) and a Lucide icon shown
+ * beside the label. */
 const SETTINGS_TABS: { id: SettingsTabId; icon: string }[] = [
 	{ id: "appearance", icon: "palette" },
 	{ id: "search", icon: "search" },
@@ -147,6 +147,10 @@ export class HomeSettingTab extends PluginSettingTab {
 
 	/** Temporary #52 diagnostic state — see getSettingDefinitions. */
 	private loggedDefinitionsQuery = false;
+
+	/** Title of a collapsible section to unfold and scroll to on the next
+	 * render, set by a catalogue row's "Show" button. */
+	private revealSectionTitle: string | null = null;
 
 	/**
 	 * Obsidian 1.13 reworked the settings modal around declarative setting
@@ -352,6 +356,13 @@ export class HomeSettingTab extends PluginSettingTab {
 				);
 				break;
 			case "integrations":
+				// The catalogue first: every integration Hearth has, listed whether
+				// or not it is installed and whether or not it has a setting. The two
+				// sections below are the only ones that *do* have settings, and rows
+				// in the catalogue link down to them.
+				this.section(body, s.integrations.heading, s.integrations.headingDesc, (b) =>
+					this.integrationsCatalogue(b),
+				);
 				this.section(body, s.tasks.heading, s.tasks.headingDesc, (b) => this.tasksSection(b));
 				this.section(body, s.fileIcons.heading, s.fileIcons.headingDesc, (b) =>
 					this.fileIconsSection(b),
@@ -426,6 +437,18 @@ export class HomeSettingTab extends PluginSettingTab {
 		// vault-scoped local storage.
 		const key = `hearth-section-${title}`;
 		let collapsed = this.app.loadLocalStorage(key) === "1";
+
+		// A catalogue row asked for this section: unfold it (persisting that, so
+		// it doesn't snap shut on the next visit) and scroll it into view once the
+		// pane has been laid out.
+		if (this.revealSectionTitle === title) {
+			this.revealSectionTitle = null;
+			collapsed = false;
+			this.app.saveLocalStorage(key, null);
+			window.requestAnimationFrame(() =>
+				wrap.scrollIntoView({ block: "start", behavior: "smooth" }),
+			);
+		}
 		const apply = () => {
 			wrap.toggleClass("is-collapsed", collapsed);
 			body.style.display = collapsed ? "none" : "";
@@ -1069,6 +1092,119 @@ export class HomeSettingTab extends PluginSettingTab {
 		arr.splice(to, 0, item);
 		void this.save();
 		this.rerender();
+	}
+
+	// ---- Integrations catalogue -------------------------------------------
+
+	/**
+	 * The full list of everything Hearth works with.
+	 *
+	 * Deliberately not filtered by what's installed: the point of the list is to
+	 * answer "what does Hearth work with?" as much as "is it working?", so every
+	 * entry in {@link INTEGRATIONS} renders, with a live status pill and a line
+	 * saying where its settings are — including when the honest answer is "there
+	 * aren't any" or "on the card". Integrations whose settings sit elsewhere
+	 * (Omnisearch on the Search tab) get a button that jumps straight there.
+	 */
+	private integrationsCatalogue(containerEl: HTMLElement): void {
+		const strings = t().settings.integrations;
+		const groups: IntegrationGroup[] = ["plugin", "core", "service"];
+		const groupDescKey = { plugin: "pluginDesc", core: "coreDesc", service: "serviceDesc" } as const;
+
+		for (const group of groups) {
+			const head = new Setting(containerEl)
+				.setName(strings.groups[group])
+				.setDesc(strings.groups[groupDescKey[group]])
+				.setHeading();
+			head.settingEl.addClass("hearth-integration-group");
+			for (const entry of integrationsInGroup(group)) {
+				this.integrationRow(containerEl, entry);
+			}
+		}
+	}
+
+	/** One catalogue row: name, status pill, what it does, where its settings
+	 * are, and (where there is somewhere to go) a button that goes there. */
+	private integrationRow(containerEl: HTMLElement, entry: IntegrationEntry): void {
+		const strings = t().settings.integrations;
+		const item = strings.items[entry.id];
+		const status = integrationStatus(this.plugin.app, entry);
+
+		const row = new Setting(containerEl).setName(item.name).setDesc(item.desc);
+		row.settingEl.addClass("hearth-integration-row");
+
+		// The pill sits with the name rather than in the control column, so the
+		// row still reads as a sentence at narrow widths (and on mobile, where
+		// Obsidian stacks name and control).
+		const pill = row.nameEl.createSpan({
+			cls: `hearth-integration-status is-${status}`,
+			text: strings.status[status],
+		});
+		pill.setAttribute("aria-label", strings.statusTooltip[status]);
+		pill.setAttribute("title", strings.statusTooltip[status]);
+
+		row.descEl.createDiv({
+			cls: "hearth-integration-where",
+			text: this.integrationWhereText(entry),
+		});
+
+		// Not installed and installable — offer the community plugin browser.
+		// Core plugins have no such URI, and their "where" line already says to
+		// enable them in Obsidian's settings.
+		if (entry.pluginId && status === "missing") {
+			row.addButton((b) =>
+				b
+					.setButtonText(strings.install)
+					.setTooltip(strings.installTooltip)
+					.onClick(() => window.open(`obsidian://show-plugin?id=${entry.pluginId}`)),
+			);
+			return;
+		}
+
+		if (entry.where.kind === "section") {
+			const section = entry.where.section;
+			row.addButton((b) =>
+				b.setButtonText(strings.goToSection).onClick(() => {
+					this.revealSectionTitle = this.integrationSectionTitle(section);
+					this.rerender();
+				}),
+			);
+			return;
+		}
+
+		if (entry.where.kind === "tab") {
+			const tab = entry.where.tab;
+			row.addButton((b) =>
+				b.setButtonText(strings.goToTab).onClick(() => {
+					this.app.saveLocalStorage(ACTIVE_TAB_KEY, tab);
+					this.rerender();
+				}),
+			);
+		}
+	}
+
+	/** The "where are its settings" line for a catalogue row. */
+	private integrationWhereText(entry: IntegrationEntry): string {
+		const where = t().settings.integrations.where;
+		switch (entry.where.kind) {
+			case "section":
+				return where.section;
+			case "tab":
+				return where.tab(t().settings.tabs[entry.where.tab]);
+			case "card":
+				return where.card;
+			case "pluginSettings":
+				return where.pluginSettings;
+			case "none":
+				return where.none;
+		}
+	}
+
+	/** The heading of the collapsible section a catalogue row links down to —
+	 * the same string `renderTabSections` passes to `section()`, which is what
+	 * keys its collapsed state. */
+	private integrationSectionTitle(section: IntegrationSectionId): string {
+		return section === "tasks" ? t().settings.tasks.heading : t().settings.fileIcons.heading;
 	}
 
 	// ---- Tasks / TaskNotes ------------------------------------------------

--- a/styles.css
+++ b/styles.css
@@ -955,6 +955,56 @@
 	color: var(--text-muted);
 }
 
+/* The integrations catalogue: every plugin and service Hearth works with,
+ * listed whether or not it's installed. Rows are informational first — a status
+ * pill beside the name, and a line under the description saying where the
+ * settings are — so they read tighter than a normal settings row. */
+.hearth-integration-group:not(:first-child) {
+	margin-top: 18px;
+}
+
+.hearth-integration-row .setting-item-name {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+/* The status pill. Sized down to a badge and colour-coded by state: green when
+ * Hearth is actually using it, muted for everything that just isn't on. */
+.hearth-integration-status {
+	flex: 0 0 auto;
+	padding: 1px 7px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 999px;
+	background: var(--background-modifier-hover);
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+	font-weight: var(--font-normal);
+	line-height: 1.5;
+	white-space: nowrap;
+}
+
+.hearth-integration-status.is-enabled {
+	border-color: var(--color-green, var(--interactive-accent));
+	color: var(--color-green, var(--interactive-accent));
+	background: transparent;
+}
+
+.hearth-integration-status.is-disabled {
+	border-color: var(--color-orange, var(--background-modifier-border));
+	color: var(--color-orange, var(--text-muted));
+	background: transparent;
+}
+
+/* Where this integration's settings live (or that it has none). Quieter than
+ * the description above it — it's a signpost, not the point of the row. */
+.hearth-integration-where {
+	margin-top: 3px;
+	color: var(--text-faint);
+	font-size: var(--font-ui-smaller);
+}
+
 /* Settings whose value low power mode is currently overriding. Still live and
  * editable — they simply aren't what's on screen right now — so this dims them
  * rather than disabling them. */

--- a/test/integrations.test.ts
+++ b/test/integrations.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import type { App } from "obsidian";
+import {
+	INTEGRATIONS,
+	type IntegrationEntry,
+	integrationsInGroup,
+	integrationStatus,
+} from "../src/integrations";
+import { en } from "../src/locales/en";
+
+/**
+ * The integrations catalogue. The rendering is Obsidian API and stays untested
+ * (per the no-mocks rule), but the catalogue itself is data — so what's covered
+ * here is that it stays complete and internally consistent, and that the status
+ * resolver survives every shape of app object Obsidian can hand it.
+ */
+
+/** A stand-in `App` exposing only the two registries the resolver reads. */
+function fakeApp(opts: {
+	enabled?: string[];
+	installed?: string[];
+	core?: Record<string, boolean>;
+}): App {
+	return {
+		plugins: {
+			enabledPlugins: new Set(opts.enabled ?? []),
+			manifests: Object.fromEntries((opts.installed ?? []).map((id) => [id, {}])),
+		},
+		internalPlugins: {
+			getPluginById: (id: string) =>
+				id in (opts.core ?? {}) ? { instance: {}, enabled: opts.core![id] } : null,
+		},
+	} as unknown as App;
+}
+
+const entry = (id: string): IntegrationEntry => {
+	const found = INTEGRATIONS.find((e) => e.id === id);
+	if (!found) throw new Error(`no such integration: ${id}`);
+	return found;
+};
+
+describe("the catalogue", () => {
+	it("has a unique id per entry", () => {
+		const ids = INTEGRATIONS.map((e) => e.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it("has strings for every entry", () => {
+		for (const e of INTEGRATIONS) {
+			const item = en.settings.integrations.items[e.id];
+			expect(item?.name, e.id).toBeTruthy();
+			expect(item?.desc, e.id).toBeTruthy();
+		}
+	});
+
+	it("lists no entry the strings don't cover, and none the catalogue doesn't", () => {
+		const listed = new Set(INTEGRATIONS.map((e) => e.id));
+		for (const id of Object.keys(en.settings.integrations.items)) {
+			expect(listed.has(id as (typeof INTEGRATIONS)[number]["id"]), id).toBe(true);
+		}
+	});
+
+	it("binds each plugin entry to exactly one plugin id", () => {
+		for (const e of INTEGRATIONS) {
+			if (e.group === "service") {
+				expect(e.pluginId ?? e.corePluginId, e.id).toBeUndefined();
+			} else {
+				// A row is either community, core, or bound to nothing at all (the
+				// Leaf card, which works with whatever is installed) — never both.
+				expect(!!e.pluginId && !!e.corePluginId, e.id).toBe(false);
+			}
+		}
+	});
+
+	it("groups every entry", () => {
+		const grouped = [
+			...integrationsInGroup("plugin"),
+			...integrationsInGroup("core"),
+			...integrationsInGroup("service"),
+		];
+		expect(grouped).toHaveLength(INTEGRATIONS.length);
+	});
+});
+
+describe("integrationStatus", () => {
+	it("reports an enabled community plugin", () => {
+		const app = fakeApp({ enabled: ["omnisearch"], installed: ["omnisearch"] });
+		expect(integrationStatus(app, entry("omnisearch"))).toBe("enabled");
+	});
+
+	it("tells an installed-but-off plugin from one that was never installed", () => {
+		const app = fakeApp({ installed: ["omnisearch"] });
+		expect(integrationStatus(app, entry("omnisearch"))).toBe("disabled");
+		expect(integrationStatus(app, entry("dataview"))).toBe("missing");
+	});
+
+	it("falls back to 'missing' when the manifests internal isn't there", () => {
+		const app = { plugins: { enabledPlugins: new Set<string>() } } as unknown as App;
+		expect(integrationStatus(app, entry("dataview"))).toBe("missing");
+	});
+
+	it("reads core plugins from the internal registry", () => {
+		const app = fakeApp({ core: { bookmarks: true, canvas: false } });
+		expect(integrationStatus(app, entry("bookmarks"))).toBe("enabled");
+		expect(integrationStatus(app, entry("canvas"))).toBe("disabled");
+	});
+
+	it("reports a core plugin this Obsidian version doesn't have as missing", () => {
+		// Bases only exists from Obsidian 1.9 on.
+		expect(integrationStatus(fakeApp({}), entry("bases"))).toBe("missing");
+	});
+
+	it("marks services external and unbound entries always-available", () => {
+		const app = fakeApp({});
+		expect(integrationStatus(app, entry("jira"))).toBe("external");
+		expect(integrationStatus(app, entry("leafViews"))).toBe("always");
+	});
+
+	it("never throws on an app missing the registries entirely", () => {
+		const bare = {} as App;
+		for (const e of INTEGRATIONS) {
+			expect(() => integrationStatus(bare, e), e.id).not.toThrow();
+		}
+	});
+
+	it("resolves a status the strings have a label for", () => {
+		const app = fakeApp({ enabled: ["dataview"], core: { canvas: true } });
+		for (const e of INTEGRATIONS) {
+			const status = integrationStatus(app, e);
+			expect(en.settings.integrations.status[status], e.id).toBeTruthy();
+			expect(en.settings.integrations.statusTooltip[status], e.id).toBeTruthy();
+		}
+	});
+});


### PR DESCRIPTION
## What does this PR do?

The Integrations tab only ever showed the two integrations that happen to have global settings (TaskNotes field names, Iconic/Iconize). Everything else was invisible: Omnisearch is a choice in the search-engine dropdown on another tab, Dataview/Excalidraw/Jira/RSS are configured per-card, and the core-plugin integrations surface only as an empty-state message once a card can't find them.

This adds a catalogue at the top of the tab that lists **all** of them regardless — whether or not the plugin is installed, and whether or not Hearth has a setting for it — in three groups:

- **Community plugins** — Omnisearch, TaskNotes, Dataview, Iconic, Iconize, Excalidraw
- **Obsidian core plugins** — Bases, Canvas, Daily notes, Bookmarks, Search, File explorer, Workspaces, Audio recorder, plus a row for "any plugin with a side panel" (what the Leaf card hosts)
- **External services** — Jira, RSS/Atom feeds, iCalendar subscriptions, exchange rates, web search, with a group note that "Disable external calls" silences them all at once

Each row carries a live status pill (Enabled / Disabled / Not installed / Network / Always available), says what the integration does in Hearth, and points at where its settings actually live — the section below on that tab, another tab, the card itself, the other plugin's own settings, or nowhere at all. Omnisearch, for instance, reads "Settings under Search" with an **Open** button that jumps there. Rows pointing at the Tasks or File icons sections get a **Show** button that unfolds and scrolls to them; an uninstalled community plugin gets an **Install** button into Obsidian's plugin browser.

The catalogue is pure data plus one defensive status resolver in the new `src/integrations.ts`, so it's unit-tested and adding an integration is a one-entry change; the settings tab only renders it. `SettingsTabId` moves there too so an entry can name the tab holding its setting without a circular import. Status reads `plugins.manifests` to tell "installed but off" from "never installed", and every registry read is guarded — `internalPlugins.getPluginById("bases")` returns null before Obsidian 1.9, and nothing here may throw while the settings pane is being built.

## Related issue

None — raised directly.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (typecheck + esbuild; `npm run lint` clean, 0 errors)
- [x] I've tested this in an actual vault — not possible from this environment; covered by 13 new unit tests in `test/integrations.test.ts` (full suite: 358 passed, 1 skipped)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMj1yPNVBA7c1GkJRPdgeJ)_