### PR TITLE
Remove issue-number reference from embed card's Open button description

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -846,7 +846,7 @@ export const en = {
 			secondViewClear: "Remove second view",
 			openButton: "Open button",
 			openButtonDesc:
-				"Show a button that opens the embedded file in its own tab (#144). Off by default.",
+				"Show a button that opens the embedded file in its own tab. Off by default.",
 		},
 		daily: {
 			editable: "Editable",


### PR DESCRIPTION
## What does this PR do?

Fixes a UI wording issue: the embed card's "Open button" setting description referenced an internal GitHub issue number (`#144`) instead of just describing what the toggle does.

Before: "Show a button that opens the embedded file in its own tab (#144). Off by default."
After: "Show a button that opens the embedded file in its own tab. Off by default."

I also scanned the rest of `src/locales/en.ts` (the full UI string catalogue) for similar dev-note leakage — leftover issue/PR references, TODO/FIXME markers — and found no other instances.

## Related issue

N/A — trivial one-line wording fix.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault (single-string text change; not manually verified in a live vault)
