### PR TITLE
Redesign the settings pane: category index with drill-down pages

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -238,6 +238,13 @@ export const en = {
 		resetField: "Reset to default",
 		collapseSection: "Collapse section",
 		expandSection: "Expand section",
+		/** Bulk fold control in a tab's header. Sections start folded, so this is
+		 * how a whole tab is surveyed at once. */
+		expandAll: "Expand all",
+		collapseAll: "Collapse all",
+		/** How many collapsible sections the open tab holds, shown beside its name.
+		 * Only ever rendered for two or more. */
+		sectionCount: (n: number) => `${n} sections`,
 		/** Shown in place of a settings section (or tab) whose render threw, so a
 		 * single failing section can no longer blank the whole settings pane. */
 		sectionError: (name: string) => `The "${name}" section couldn't be shown.`,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -236,15 +236,29 @@ export const en = {
 		resetSlider: "Reset to default",
 		/** Reset button next to text fields whose factory default is meaningful. */
 		resetField: "Reset to default",
-		collapseSection: "Collapse section",
-		expandSection: "Expand section",
-		/** Bulk fold control in a tab's header. Sections start folded, so this is
-		 * how a whole tab is surveyed at once. */
-		expandAll: "Expand all",
-		collapseAll: "Collapse all",
-		/** How many collapsible sections the open tab holds, shown beside its name.
-		 * Only ever rendered for two or more. */
-		sectionCount: (n: number) => `${n} sections`,
+		/** Strapline under the plugin name on the settings index. */
+		indexSub: "A home screen for your vault — search, dashboard, and launcher in one.",
+		/** Accessible name of the back link on a category page; the visible label is
+		 * the plugin's own name. */
+		backToIndex: "Back to all settings",
+		/** Headings that group the categories on the index. */
+		indexGroups: {
+			lookFeel: "Look & feel",
+			howItWorks: "How it works",
+			data: "Data & plugins",
+			etc: "Etc",
+		},
+		/** One line per category, shown on its index row and again at the top of
+		 * its page: what a reader will find if they open it. */
+		tabDescs: {
+			appearance: "Title, logo, background, and low power mode.",
+			search: "The search bar and which results it offers.",
+			dashboard: "Grid, card surface, and the controls around the board.",
+			behaviour: "Startup, how notes open, mobile, and privacy.",
+			integrations: "TaskNotes, file icons, and every plugin Hearth reads.",
+			backup: "Export and import your layout and settings.",
+			about: "Version, what's new, and where to report things.",
+		},
 		/** Shown in place of a settings section (or tab) whose render threw, so a
 		 * single failing section can no longer blank the whole settings pane. */
 		sectionError: (name: string) => `The "${name}" section couldn't be shown.`,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,7 +6,7 @@ import { FILE_TYPE_GROUPS, fileTypeLabel } from "./filetypes";
 import { CommandPickerModal } from "./pickers";
 import { type BackgroundKind, CARD_BORDER_WIDTH_MAX, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, LOW_POWER_BACKGROUND, type MobileActionButton, OPEN_IN_MODES, OPEN_SOURCES, type OpenIn, type OpenInRule, type OpenOutsideRule } from "./types";
 import { exportLayout, exportSettings, importLayout, importSettings } from "./layout";
-import { confirmAction, downloadTextFile, pickTextFile } from "./ui";
+import { confirmAction, downloadTextFile, makeClickable, pickTextFile } from "./ui";
 import { isOmnisearchAvailable, OMNISEARCH_PLUGIN_ID } from "./omnisearch";
 import {
 	type IntegrationEntry,
@@ -340,18 +340,24 @@ export class HomeSettingTab extends PluginSettingTab {
 		}
 	}
 
-	/** One index row: icon, category name, a line on what's inside, chevron. */
+	/** One index row: icon, category name, a line on what's inside, chevron.
+	 *
+	 * A div rather than a `<button>`, via the same `makeClickable` treatment the
+	 * rest of the plugin uses. Obsidian's base `button` style fixes the element's
+	 * height, which a two-line row overflows — its name and description spilled
+	 * straight out of the row's own box. */
 	private indexRow(rowsEl: HTMLElement, entry: { id: SettingsTabId; icon: string }): void {
 		const s = t().settings;
 		const label = s.tabs[entry.id];
-		const row = rowsEl.createEl("button", { cls: "hearth-settings-index-row" });
-		row.setAttribute("aria-label", label);
+		const row = rowsEl.createDiv("hearth-settings-index-row");
+		const open = () => this.navigate(entry.id);
+		makeClickable(row, open, label);
 		setIcon(row.createSpan("hearth-settings-index-glyph"), entry.icon);
 		const text = row.createDiv("hearth-settings-index-rowtext");
 		text.createDiv({ cls: "hearth-settings-index-rowname", text: label });
 		text.createDiv({ cls: "hearth-settings-index-rowdesc", text: s.tabDescs[entry.id] });
 		setIcon(row.createSpan("hearth-settings-index-go"), "chevron-right");
-		row.addEventListener("click", () => this.navigate(entry.id));
+		row.addEventListener("click", open);
 	}
 
 	/** A category page's header: the way back to the index, then the category's
@@ -359,11 +365,13 @@ export class HomeSettingTab extends PluginSettingTab {
 	 * away with the content, which is the whole point of dropping the ribbon. */
 	private renderCategoryHead(containerEl: HTMLElement, tab: SettingsTabId): void {
 		const s = t().settings;
-		const back = containerEl.createEl("button", { cls: "hearth-settings-back" });
+		// A div, for the same reason as an index row — see `indexRow`.
+		const back = containerEl.createDiv("hearth-settings-back");
+		const leave = () => this.navigate("index");
+		makeClickable(back, leave, s.backToIndex);
 		setIcon(back.createSpan("hearth-settings-back-icon"), "chevron-left");
 		back.createSpan({ text: this.plugin.manifest.name });
-		back.setAttribute("aria-label", s.backToIndex);
-		back.addEventListener("click", () => this.navigate("index"));
+		back.addEventListener("click", leave);
 
 		containerEl.createDiv({ cls: "hearth-settings-page-title", text: s.tabs[tab] });
 		containerEl.createDiv({ cls: "hearth-settings-page-desc", text: s.tabDescs[tab] });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -46,6 +46,13 @@ type StringSettingKey =
 	| "taskNotesDoneValue"
 	| "iconizeIconProperty";
 
+/** A handle on one collapsible section's fold state, collected per render so the
+ * tab header can open or close every section of the active tab at once. */
+type SectionToggle = {
+	isCollapsed: () => boolean;
+	setCollapsed: (collapsed: boolean) => void;
+};
+
 /** The GitHub repository and support links surfaced in the About tab. */
 const GITHUB_URL = "https://github.com/ondreu/hearth";
 const GITHUB_ISSUES_URL = "https://github.com/ondreu/hearth/issues/new";
@@ -152,6 +159,16 @@ export class HomeSettingTab extends PluginSettingTab {
 	 * render, set by a catalogue row's "Show" button. */
 	private revealSectionTitle: string | null = null;
 
+	/** Fold handles for the collapsible sections of the tab currently on screen,
+	 * in render order — rebuilt on every render and used by the tab header's
+	 * expand-all control to drive them together. */
+	private sectionToggles: SectionToggle[] = [];
+
+	/** Set by the tab header so a section folded on its own can refresh the
+	 * header's expand-all label, which otherwise goes stale until the next
+	 * render. Cleared on every render. */
+	private onSectionFoldChanged: (() => void) | null = null;
+
 	/**
 	 * Obsidian 1.13 reworked the settings modal around declarative setting
 	 * definitions; when a tab's definitions are non-empty, the legacy
@@ -242,6 +259,9 @@ export class HomeSettingTab extends PluginSettingTab {
 			const active = this.activeTab();
 			this.renderRibbon(containerEl, active);
 
+			// Named here but filled in after the sections below have rendered, so
+			// it can report how many the tab holds and drive them all at once.
+			const head = containerEl.createDiv("hearth-settings-tabhead");
 			const body = containerEl.createDiv("hearth-settings-tabbody");
 			// A tab-level backstop nested inside: individual sections already
 			// isolate their own failures (see `section`), but the About tab and a
@@ -249,12 +269,15 @@ export class HomeSettingTab extends PluginSettingTab {
 			// a throw in a tab shows an inline error rather than a blank pane —
 			// and, because the ribbon above is already drawn, the user can still
 			// switch to a working tab.
+			this.sectionToggles = [];
+			this.onSectionFoldChanged = null;
 			try {
 				this.renderTabSections(body, active);
 			} catch (err) {
 				body.empty();
 				this.renderError(body, t().settings.tabs[active], err);
 			}
+			this.renderTabHead(head, active);
 		} catch (err) {
 			// The ribbon/datalist itself failed to build. Append the error rather
 			// than empty()-ing, so any partially-drawn ribbon that survived still
@@ -290,11 +313,13 @@ export class HomeSettingTab extends PluginSettingTab {
 	private renderRibbon(containerEl: HTMLElement, active: SettingsTabId): void {
 		const ribbon = containerEl.createDiv("hearth-settings-ribbon");
 		ribbon.setAttribute("role", "tablist");
+		let activeEl: HTMLElement | null = null;
 		for (const tab of SETTINGS_TABS) {
 			const label = t().settings.tabs[tab.id];
 			const btn = ribbon.createEl("button", { cls: "hearth-ribbon-tab" });
 			btn.setAttribute("role", "tab");
 			btn.toggleClass("is-active", tab.id === active);
+			if (tab.id === active) activeEl = btn;
 			btn.setAttribute("aria-selected", String(tab.id === active));
 			btn.setAttribute("aria-label", label);
 			const icon = btn.createSpan("hearth-ribbon-tab-icon");
@@ -305,6 +330,54 @@ export class HomeSettingTab extends PluginSettingTab {
 				this.rerender();
 			});
 		}
+		// The row scrolls rather than wrapping, so on a pane too narrow for all
+		// seven tabs the active one can start out of sight. `block: "nearest"`
+		// keeps this from scrolling the pane itself.
+		const target = activeEl;
+		if (target) {
+			window.requestAnimationFrame(() =>
+				target.scrollIntoView({ block: "nearest", inline: "nearest" }),
+			);
+		}
+	}
+
+	/** The header above a tab's sections: names the active tab and, when it holds
+	 * more than one collapsible section, offers one control to open or close them
+	 * all. Sections start folded (see `section`), so without this every tab would
+	 * cost one click per section to survey.
+	 *
+	 * Called *after* the sections have rendered, since it reads
+	 * `this.sectionToggles` to know how many there are. */
+	private renderTabHead(headEl: HTMLElement, tab: SettingsTabId): void {
+		const s = t().settings;
+		const titles = headEl.createDiv("hearth-settings-tabhead-titles");
+		titles.createDiv({ cls: "hearth-settings-tabhead-title", text: s.tabs[tab] });
+
+		// One section (or none, as on the About tab) needs no bulk control, and
+		// naming a count of one adds nothing.
+		const toggles = this.sectionToggles;
+		if (toggles.length < 2) return;
+		titles.createDiv({
+			cls: "hearth-settings-tabhead-count",
+			text: s.sectionCount(toggles.length),
+		});
+
+		const btn = headEl.createEl("button", { cls: "hearth-settings-expand-all" });
+		// "Expand all" while anything is still folded, so the button always offers
+		// the action that changes the most; it flips to "Collapse all" once every
+		// section is open.
+		const relabel = () => {
+			btn.setText(toggles.some((sec) => sec.isCollapsed()) ? s.expandAll : s.collapseAll);
+		};
+		relabel();
+		btn.addEventListener("click", () => {
+			const expand = toggles.some((sec) => sec.isCollapsed());
+			for (const sec of toggles) sec.setCollapsed(!expand);
+			relabel();
+		});
+		// Folding a section by its own heading changes what this button should
+		// offer, so let `section` call back into it.
+		this.onSectionFoldChanged = relabel;
 	}
 
 	/** Render the sections that belong to a given ribbon tab. (Named
@@ -362,7 +435,9 @@ export class HomeSettingTab extends PluginSettingTab {
 				// in the catalogue link down to them.
 				// Folded to start with: it's a reference list, not a setting, and
 				// unfolded it would push the two sections that *are* settings off
-				// the screen.
+				// the screen. Every section now starts folded anyway, but this one
+				// is asked for explicitly so the intent survives a change of
+				// default.
 				this.section(
 					body,
 					s.integrations.heading,
@@ -400,10 +475,14 @@ export class HomeSettingTab extends PluginSettingTab {
 	 * the body; the collapsed state is persisted per-section in localStorage so
 	 * long settings panels can be tamed and stay tamed.
 	 *
-	 * `collapsedByDefault` only decides where a section starts before anyone has
-	 * ever folded it — for a long reference list that isn't a setting, starting
-	 * closed keeps the tab's actual settings in reach. Once the user folds or
-	 * unfolds it themselves, their choice is what persists. */
+	 * Sections start folded: a tab then opens as a short list of headings that
+	 * fits without scrolling, and the expand-all control in the tab header (see
+	 * `renderTabHead`) opens them in one go. `collapsedByDefault: false` opts a
+	 * section out and starts it open instead.
+	 *
+	 * Either way this only decides where a section starts before anyone has ever
+	 * folded it. Once the user folds or unfolds it themselves, their choice is
+	 * what persists. */
 	private section(
 		containerEl: HTMLElement,
 		title: string,
@@ -454,7 +533,7 @@ export class HomeSettingTab extends PluginSettingTab {
 		// open instead of folding itself again on the next visit.
 		const key = `hearth-section-${title}`;
 		const saved = this.app.loadLocalStorage(key) as string | null;
-		let collapsed = saved === null ? !!opts?.collapsedByDefault : saved === "1";
+		let collapsed = saved === null ? (opts?.collapsedByDefault ?? true) : saved === "1";
 
 		// A catalogue row asked for this section: unfold it (persisting that, so
 		// it doesn't snap shut on the next visit) and scroll it into view once the
@@ -479,12 +558,24 @@ export class HomeSettingTab extends PluginSettingTab {
 			collapsed = !collapsed;
 			this.app.saveLocalStorage(key, collapsed ? "1" : "0");
 			apply();
+			this.onSectionFoldChanged?.();
 		});
 		head.addEventListener("keydown", (e) => {
 			if (e.key === "Enter" || e.key === " ") {
 				e.preventDefault();
 				head.click();
 			}
+		});
+
+		// Hand the tab header a way to fold this section along with its siblings.
+		this.sectionToggles.push({
+			isCollapsed: () => collapsed,
+			setCollapsed: (next) => {
+				if (collapsed === next) return;
+				collapsed = next;
+				this.app.saveLocalStorage(key, collapsed ? "1" : "0");
+				apply();
+			},
 		});
 	}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -46,13 +46,6 @@ type StringSettingKey =
 	| "taskNotesDoneValue"
 	| "iconizeIconProperty";
 
-/** A handle on one collapsible section's fold state, collected per render so the
- * tab header can open or close every section of the active tab at once. */
-type SectionToggle = {
-	isCollapsed: () => boolean;
-	setCollapsed: (collapsed: boolean) => void;
-};
-
 /** The GitHub repository and support links surfaced in the About tab. */
 const GITHUB_URL = "https://github.com/ondreu/hearth";
 const GITHUB_ISSUES_URL = "https://github.com/ondreu/hearth/issues/new";
@@ -75,7 +68,24 @@ const SETTINGS_TABS: { id: SettingsTabId; icon: string }[] = [
 	{ id: "about", icon: "info" },
 ];
 
-/** localStorage key for the last-opened settings tab. */
+/** Where the settings pane currently is: the category index, or one category's
+ * own page. The pane is two levels deep — see `renderInto`. */
+type SettingsRoute = "index" | SettingsTabId;
+
+/** How the index groups the categories. Ids key `t().settings.indexGroups`, so a
+ * missing translation is a build error rather than an empty heading.
+ *
+ * The grouping is editorial, not structural: seven rows in one undivided list
+ * reads as a wall, and these four headings are how the categories actually
+ * cluster when you say out loud what each is for. */
+const SETTINGS_INDEX: { id: "lookFeel" | "howItWorks" | "data" | "etc"; tabs: SettingsTabId[] }[] = [
+	{ id: "lookFeel", tabs: ["appearance", "dashboard"] },
+	{ id: "howItWorks", tabs: ["search", "behaviour"] },
+	{ id: "data", tabs: ["integrations", "backup"] },
+	{ id: "etc", tabs: ["about"] },
+];
+
+/** localStorage key for where the pane was last left — a tab id, or "index". */
 const ACTIVE_TAB_KEY = "hearth-settings-tab";
 
 /**
@@ -155,19 +165,9 @@ export class HomeSettingTab extends PluginSettingTab {
 	/** Temporary #52 diagnostic state — see getSettingDefinitions. */
 	private loggedDefinitionsQuery = false;
 
-	/** Title of a collapsible section to unfold and scroll to on the next
-	 * render, set by a catalogue row's "Show" button. */
+	/** Title of a section to scroll to on the next render, set by a catalogue
+	 * row's "Show" button. */
 	private revealSectionTitle: string | null = null;
-
-	/** Fold handles for the collapsible sections of the tab currently on screen,
-	 * in render order — rebuilt on every render and used by the tab header's
-	 * expand-all control to drive them together. */
-	private sectionToggles: SectionToggle[] = [];
-
-	/** Set by the tab header so a section folded on its own can refresh the
-	 * header's expand-all label, which otherwise goes stale until the next
-	 * render. Cleared on every render. */
-	private onSectionFoldChanged: (() => void) | null = null;
 
 	/**
 	 * Obsidian 1.13 reworked the settings modal around declarative setting
@@ -243,45 +243,44 @@ export class HomeSettingTab extends PluginSettingTab {
 		containerEl.addClass("hearth-settings");
 
 		// Whole-pane backstop. #52 reports a completely blank settings pane — no
-		// ribbon, no error in the (main-window) console — for some users on
+		// content, no error in the (main-window) console — for some users on
 		// Obsidian 1.13, which renders settings in a *separate window*. A throw
-		// anywhere in the build (even before the ribbon, e.g. in `fileDatalist` or
-		// `activeTab`) would blank everything, and its error lands in that other
-		// window's console where it's easy to miss. Guard the entire build so the
-		// pane can never be silently blank: on failure, show an inline error and
-		// log the real stack (to whichever console this window uses).
+		// anywhere in the build (even before the first row, e.g. in `fileDatalist`
+		// or `activeRoute`) would blank everything, and its error lands in that
+		// other window's console where it's easy to miss. Guard the entire build so
+		// the pane can never be silently blank: on failure, show an inline error
+		// and log the real stack (to whichever console this window uses).
 		try {
+			// Two levels: an index of categories, and one category's page. Which
+			// one is showing persists per-vault in localStorage, so closing and
+			// reopening settings comes back to the same place.
+			const route = this.activeRoute();
+			if (route === "index") {
+				this.renderIndex(containerEl);
+				return;
+			}
+
+			// Only a category page has file-path inputs to complete, and building
+			// this walks the whole vault — so it stays out of the index.
 			this.fileDatalist(containerEl);
+			this.renderCategoryHead(containerEl, route);
 
-			// A ribbon of category tabs sits pinned at the top; only the active
-			// tab's sections render below it, keeping a long settings panel
-			// navigable. The active tab persists per-vault in localStorage.
-			const active = this.activeTab();
-			this.renderRibbon(containerEl, active);
-
-			// Named here but filled in after the sections below have rendered, so
-			// it can report how many the tab holds and drive them all at once.
-			const head = containerEl.createDiv("hearth-settings-tabhead");
 			const body = containerEl.createDiv("hearth-settings-tabbody");
-			// A tab-level backstop nested inside: individual sections already
-			// isolate their own failures (see `section`), but the About tab and a
+			// A page-level backstop nested inside: individual sections already
+			// isolate their own failures (see `section`), but the About page and a
 			// couple of bare rows render straight into the body. Guard here too so
-			// a throw in a tab shows an inline error rather than a blank pane —
-			// and, because the ribbon above is already drawn, the user can still
-			// switch to a working tab.
-			this.sectionToggles = [];
-			this.onSectionFoldChanged = null;
+			// a throw shows an inline error rather than a blank pane — and, because
+			// the back link above is already drawn, the user can still leave.
 			try {
-				this.renderTabSections(body, active);
+				this.renderTabSections(body, route);
 			} catch (err) {
 				body.empty();
-				this.renderError(body, t().settings.tabs[active], err);
+				this.renderError(body, t().settings.tabs[route], err);
 			}
-			this.renderTabHead(head, active);
 		} catch (err) {
-			// The ribbon/datalist itself failed to build. Append the error rather
-			// than empty()-ing, so any partially-drawn ribbon that survived still
-			// lets the user navigate.
+			// The datalist or the navigation itself failed to build. Append the
+			// error rather than empty()-ing, so anything that survived still lets
+			// the user navigate.
 			this.renderError(containerEl, "Hearth", err);
 		}
 	}
@@ -301,83 +300,73 @@ export class HomeSettingTab extends PluginSettingTab {
 		text.createDiv({ cls: "hearth-settings-error-hint", text: t().settings.sectionErrorHint });
 	}
 
-	/** The currently-selected ribbon tab, defaulting to the first. */
-	private activeTab(): SettingsTabId {
+	/** Where the pane was last left. Anything unrecognised — including the absent
+	 * key of a first visit — lands on the index. */
+	private activeRoute(): SettingsRoute {
 		const saved = this.app.loadLocalStorage(ACTIVE_TAB_KEY) as string | null;
-		return SETTINGS_TABS.some((tab) => tab.id === saved)
-			? (saved as SettingsTabId)
-			: SETTINGS_TABS[0].id;
+		return SETTINGS_TABS.some((tab) => tab.id === saved) ? (saved as SettingsTabId) : "index";
 	}
 
-	/** Draw the category ribbon. Clicking a tab persists the choice and redraws. */
-	private renderRibbon(containerEl: HTMLElement, active: SettingsTabId): void {
-		const ribbon = containerEl.createDiv("hearth-settings-ribbon");
-		ribbon.setAttribute("role", "tablist");
-		let activeEl: HTMLElement | null = null;
-		for (const tab of SETTINGS_TABS) {
-			const label = t().settings.tabs[tab.id];
-			const btn = ribbon.createEl("button", { cls: "hearth-ribbon-tab" });
-			btn.setAttribute("role", "tab");
-			btn.toggleClass("is-active", tab.id === active);
-			if (tab.id === active) activeEl = btn;
-			btn.setAttribute("aria-selected", String(tab.id === active));
-			btn.setAttribute("aria-label", label);
-			const icon = btn.createSpan("hearth-ribbon-tab-icon");
-			setIcon(icon, tab.icon);
-			btn.createSpan({ cls: "hearth-ribbon-tab-label", text: label });
-			btn.addEventListener("click", () => {
-				this.app.saveLocalStorage(ACTIVE_TAB_KEY, tab.id);
-				this.rerender();
-			});
-		}
-		// The row scrolls rather than wrapping, so on a pane too narrow for all
-		// seven tabs the active one can start out of sight. `block: "nearest"`
-		// keeps this from scrolling the pane itself.
-		const target = activeEl;
-		if (target) {
-			window.requestAnimationFrame(() =>
-				target.scrollIntoView({ block: "nearest", inline: "nearest" }),
-			);
-		}
+	/** Move to another level of the pane, remembering it for next time. */
+	private navigate(route: SettingsRoute): void {
+		this.app.saveLocalStorage(ACTIVE_TAB_KEY, route);
+		this.rerender();
 	}
 
-	/** The header above a tab's sections: names the active tab and, when it holds
-	 * more than one collapsible section, offers one control to open or close them
-	 * all. Sections start folded (see `section`), so without this every tab would
-	 * cost one click per section to survey.
+	/** The index: every category as a full-width row, grouped under headings.
 	 *
-	 * Called *after* the sections have rendered, since it reads
-	 * `this.sectionToggles` to know how many there are. */
-	private renderTabHead(headEl: HTMLElement, tab: SettingsTabId): void {
+	 * This replaced a ribbon of seven pinned tabs. Seven pills never fit a
+	 * stock-width settings pane, so they either wrapped onto a ragged second line
+	 * or — once made to scroll — clipped the last two out of sight; and pinning
+	 * the row left content sliced behind it. Rows have neither failure mode: they
+	 * are vertical, they are not pinned, and an eighth category costs nothing. */
+	private renderIndex(containerEl: HTMLElement): void {
 		const s = t().settings;
-		const titles = headEl.createDiv("hearth-settings-tabhead-titles");
-		titles.createDiv({ cls: "hearth-settings-tabhead-title", text: s.tabs[tab] });
+		const head = containerEl.createDiv("hearth-settings-index-head");
+		head.createDiv({ cls: "hearth-settings-index-title", text: this.plugin.manifest.name });
+		head.createDiv({ cls: "hearth-settings-index-sub", text: s.indexSub });
 
-		// One section (or none, as on the About tab) needs no bulk control, and
-		// naming a count of one adds nothing.
-		const toggles = this.sectionToggles;
-		if (toggles.length < 2) return;
-		titles.createDiv({
-			cls: "hearth-settings-tabhead-count",
-			text: s.sectionCount(toggles.length),
-		});
+		for (const group of SETTINGS_INDEX) {
+			containerEl.createDiv({
+				cls: "hearth-settings-index-grouplabel",
+				text: s.indexGroups[group.id],
+			});
+			const rows = containerEl.createDiv("hearth-settings-index-rows");
+			for (const id of group.tabs) {
+				const entry = SETTINGS_TABS.find((tab) => tab.id === id);
+				if (!entry) continue;
+				this.indexRow(rows, entry);
+			}
+		}
+	}
 
-		const btn = headEl.createEl("button", { cls: "hearth-settings-expand-all" });
-		// "Expand all" while anything is still folded, so the button always offers
-		// the action that changes the most; it flips to "Collapse all" once every
-		// section is open.
-		const relabel = () => {
-			btn.setText(toggles.some((sec) => sec.isCollapsed()) ? s.expandAll : s.collapseAll);
-		};
-		relabel();
-		btn.addEventListener("click", () => {
-			const expand = toggles.some((sec) => sec.isCollapsed());
-			for (const sec of toggles) sec.setCollapsed(!expand);
-			relabel();
-		});
-		// Folding a section by its own heading changes what this button should
-		// offer, so let `section` call back into it.
-		this.onSectionFoldChanged = relabel;
+	/** One index row: icon, category name, a line on what's inside, chevron. */
+	private indexRow(rowsEl: HTMLElement, entry: { id: SettingsTabId; icon: string }): void {
+		const s = t().settings;
+		const label = s.tabs[entry.id];
+		const row = rowsEl.createEl("button", { cls: "hearth-settings-index-row" });
+		row.setAttribute("aria-label", label);
+		setIcon(row.createSpan("hearth-settings-index-glyph"), entry.icon);
+		const text = row.createDiv("hearth-settings-index-rowtext");
+		text.createDiv({ cls: "hearth-settings-index-rowname", text: label });
+		text.createDiv({ cls: "hearth-settings-index-rowdesc", text: s.tabDescs[entry.id] });
+		setIcon(row.createSpan("hearth-settings-index-go"), "chevron-right");
+		row.addEventListener("click", () => this.navigate(entry.id));
+	}
+
+	/** A category page's header: the way back to the index, then the category's
+	 * name and a line on what it covers. Deliberately not pinned — it scrolls
+	 * away with the content, which is the whole point of dropping the ribbon. */
+	private renderCategoryHead(containerEl: HTMLElement, tab: SettingsTabId): void {
+		const s = t().settings;
+		const back = containerEl.createEl("button", { cls: "hearth-settings-back" });
+		setIcon(back.createSpan("hearth-settings-back-icon"), "chevron-left");
+		back.createSpan({ text: this.plugin.manifest.name });
+		back.setAttribute("aria-label", s.backToIndex);
+		back.addEventListener("click", () => this.navigate("index"));
+
+		containerEl.createDiv({ cls: "hearth-settings-page-title", text: s.tabs[tab] });
+		containerEl.createDiv({ cls: "hearth-settings-page-desc", text: s.tabDescs[tab] });
 	}
 
 	/** Render the sections that belong to a given ribbon tab. (Named
@@ -433,17 +422,8 @@ export class HomeSettingTab extends PluginSettingTab {
 				// or not it is installed and whether or not it has a setting. The two
 				// sections below are the only ones that *do* have settings, and rows
 				// in the catalogue link down to them.
-				// Folded to start with: it's a reference list, not a setting, and
-				// unfolded it would push the two sections that *are* settings off
-				// the screen. Every section now starts folded anyway, but this one
-				// is asked for explicitly so the intent survives a change of
-				// default.
-				this.section(
-					body,
-					s.integrations.heading,
-					s.integrations.headingDesc,
-					(b) => this.integrationsCatalogue(b),
-					{ collapsedByDefault: true },
+				this.section(body, s.integrations.heading, s.integrations.headingDesc, (b) =>
+					this.integrationsCatalogue(b),
 				);
 				this.section(body, s.tasks.heading, s.tasks.headingDesc, (b) => this.tasksSection(b));
 				this.section(body, s.fileIcons.heading, s.fileIcons.headingDesc, (b) =>
@@ -469,26 +449,21 @@ export class HomeSettingTab extends PluginSettingTab {
 		}
 	}
 
-	// ---- Foldable section wrapper --------------------------------------
+	// ---- Section wrapper -----------------------------------------------
 
-	/** Wrap a section in a collapsible block. The heading toggles visibility of
-	 * the body; the collapsed state is persisted per-section in localStorage so
-	 * long settings panels can be tamed and stay tamed.
+	/** Wrap a section in a labelled group: a heading, and a bordered box holding
+	 * its rows.
 	 *
-	 * Sections start folded: a tab then opens as a short list of headings that
-	 * fits without scrolling, and the expand-all control in the tab header (see
-	 * `renderTabHead`) opens them in one go. `collapsedByDefault: false` opts a
-	 * section out and starts it open instead.
-	 *
-	 * Either way this only decides where a section starts before anyone has ever
-	 * folded it. Once the user folds or unfolds it themselves, their choice is
-	 * what persists. */
+	 * Sections used to be collapsible, with the fold state persisted per section,
+	 * because a tab held every section of its category in one long scroll. Now
+	 * that each category is its own page holding two to five groups, there is
+	 * nothing left to tame — so nothing folds, and every setting on a page is
+	 * visible the moment it opens. */
 	private section(
 		containerEl: HTMLElement,
 		title: string,
 		desc: string | undefined,
 		render: (body: HTMLElement) => void,
-		opts?: { collapsedByDefault?: boolean },
 	): void;
 	private section(
 		containerEl: HTMLElement,
@@ -500,25 +475,19 @@ export class HomeSettingTab extends PluginSettingTab {
 		title: string,
 		descOrRender: string | undefined | ((body: HTMLElement) => void),
 		maybeRender?: (body: HTMLElement) => void,
-		opts?: { collapsedByDefault?: boolean },
 	): void {
 		const desc = typeof descOrRender === "string" ? descOrRender : undefined;
 		const render = typeof descOrRender === "function" ? descOrRender : maybeRender!;
 
 		const wrap = containerEl.createDiv("hearth-section");
 		const head = wrap.createDiv("hearth-section-head");
-		head.setAttribute("role", "button");
-		head.setAttribute("tabindex", "0");
-		const titles = head.createDiv("hearth-section-titles");
-		titles.createDiv({ cls: "hearth-section-title", text: title });
-		if (desc) titles.createDiv({ cls: "hearth-section-desc", text: desc });
-		const chevron = head.createDiv("hearth-section-chevron");
-		setIcon(chevron, "chevron-down");
+		head.createDiv({ cls: "hearth-section-title", text: title });
+		if (desc) head.createDiv({ cls: "hearth-section-desc", text: desc });
 
 		const body = wrap.createDiv("hearth-section-body");
 		// Isolate each section: a throw while rendering one section shows an inline
-		// error there instead of blanking the whole tab, so its siblings still
-		// render. The heading/fold behaviour below stays intact regardless.
+		// error there instead of blanking the whole page, so its siblings still
+		// render.
 		try {
 			render(body);
 		} catch (err) {
@@ -526,57 +495,14 @@ export class HomeSettingTab extends PluginSettingTab {
 			this.renderError(body, title, err);
 		}
 
-		// Persist the collapsed state per-section and per-vault via Obsidian's
-		// vault-scoped local storage. Both states are stored explicitly ("1"/"0")
-		// rather than clearing the key when open: absent has to keep meaning
-		// "never touched", so a default-collapsed section the user opened stays
-		// open instead of folding itself again on the next visit.
-		const key = `hearth-section-${title}`;
-		const saved = this.app.loadLocalStorage(key) as string | null;
-		let collapsed = saved === null ? (opts?.collapsedByDefault ?? true) : saved === "1";
-
-		// A catalogue row asked for this section: unfold it (persisting that, so
-		// it doesn't snap shut on the next visit) and scroll it into view once the
-		// pane has been laid out.
+		// A catalogue row asked for this section — it lives further down the same
+		// page, so scroll it into view once the pane has been laid out.
 		if (this.revealSectionTitle === title) {
 			this.revealSectionTitle = null;
-			collapsed = false;
-			this.app.saveLocalStorage(key, "0");
 			window.requestAnimationFrame(() =>
 				wrap.scrollIntoView({ block: "start", behavior: "smooth" }),
 			);
 		}
-		const apply = () => {
-			wrap.toggleClass("is-collapsed", collapsed);
-			body.style.display = collapsed ? "none" : "";
-			chevron.toggleClass("is-rotated", collapsed);
-			head.setAttribute("aria-expanded", String(!collapsed));
-			head.setAttribute("aria-label", collapsed ? t().settings.expandSection : t().settings.collapseSection);
-		};
-		apply();
-		head.addEventListener("click", () => {
-			collapsed = !collapsed;
-			this.app.saveLocalStorage(key, collapsed ? "1" : "0");
-			apply();
-			this.onSectionFoldChanged?.();
-		});
-		head.addEventListener("keydown", (e) => {
-			if (e.key === "Enter" || e.key === " ") {
-				e.preventDefault();
-				head.click();
-			}
-		});
-
-		// Hand the tab header a way to fold this section along with its siblings.
-		this.sectionToggles.push({
-			isCollapsed: () => collapsed,
-			setCollapsed: (next) => {
-				if (collapsed === next) return;
-				collapsed = next;
-				this.app.saveLocalStorage(key, collapsed ? "1" : "0");
-				apply();
-			},
-		});
 	}
 
 	// ---- Slider reset helper -------------------------------------------
@@ -1283,12 +1209,7 @@ export class HomeSettingTab extends PluginSettingTab {
 
 		if (entry.where.kind === "tab") {
 			const tab = entry.where.tab;
-			row.addButton((b) =>
-				b.setButtonText(strings.goToTab).onClick(() => {
-					this.app.saveLocalStorage(ACTIVE_TAB_KEY, tab);
-					this.rerender();
-				}),
-			);
+			row.addButton((b) => b.setButtonText(strings.goToTab).onClick(() => this.navigate(tab)));
 		}
 	}
 
@@ -1710,41 +1631,42 @@ export class HomeSettingTab extends PluginSettingTab {
 	private aboutSection(containerEl: HTMLElement): void {
 		const about = t().settings.about;
 
-		new Setting(containerEl)
-			.setName(about.heading)
-			.setDesc(about.headingDesc)
-			.setHeading();
+		// Grouped like every other page, rather than as bare rows: the section
+		// heading replaces what used to be a `setHeading()` row of its own.
+		this.section(containerEl, about.heading, about.headingDesc, (body) => {
+			new Setting(body)
+				.setName(about.whatsNew)
+				.setDesc(about.whatsNewDesc)
+				.addButton((b) =>
+					this.aboutButton(b, "sparkles", about.whatsNewButton, () =>
+						new WhatsNewModal(this.app, CHANGELOG).open(),
+					),
+				);
 
-		new Setting(containerEl)
-			.setName(about.whatsNew)
-			.setDesc(about.whatsNewDesc)
-			.addButton((b) =>
-				this.aboutButton(b, "sparkles", about.whatsNewButton, () =>
-					new WhatsNewModal(this.app, CHANGELOG).open(),
-				),
-			);
+			new Setting(body)
+				.setName(about.github)
+				.setDesc(about.githubDesc)
+				.addButton((b) => this.linkButton(b, "github", about.githubButton, GITHUB_URL));
 
-		new Setting(containerEl)
-			.setName(about.github)
-			.setDesc(about.githubDesc)
-			.addButton((b) => this.linkButton(b, "github", about.githubButton, GITHUB_URL));
+			new Setting(body)
+				.setName(about.reportIssue)
+				.setDesc(about.reportIssueDesc)
+				.addButton((b) =>
+					this.linkButton(b, "bug", about.reportIssueButton, GITHUB_ISSUES_URL),
+				);
 
-		new Setting(containerEl)
-			.setName(about.reportIssue)
-			.setDesc(about.reportIssueDesc)
-			.addButton((b) => this.linkButton(b, "bug", about.reportIssueButton, GITHUB_ISSUES_URL));
+			new Setting(body)
+				.setName(about.kofi)
+				.setDesc(about.kofiDesc)
+				.addButton((b) => {
+					this.linkButton(b, "coffee", about.kofiButton, KOFI_URL);
+					b.buttonEl.addClass("hearth-kofi-btn");
+				});
 
-		new Setting(containerEl)
-			.setName(about.kofi)
-			.setDesc(about.kofiDesc)
-			.addButton((b) => {
-				this.linkButton(b, "coffee", about.kofiButton, KOFI_URL);
-				b.buttonEl.addClass("hearth-kofi-btn");
-			});
-
-		new Setting(containerEl)
-			.setName(about.version(this.plugin.manifest.version))
-			.setDesc(about.versionDesc);
+			new Setting(body)
+				.setName(about.version(this.plugin.manifest.version))
+				.setDesc(about.versionDesc);
+		});
 	}
 
 	/** A button that shows an icon *and* a label (Obsidian's setButtonText wipes a

--- a/styles.css
+++ b/styles.css
@@ -1254,19 +1254,21 @@
 	overflow: hidden;
 }
 
+/* A div with role="button" (see HomeSettingTab.indexRow), so none of Obsidian's
+   base button styling applies — in particular its fixed height, which a
+   two-line row overflows. */
 .hearth-settings-index-row {
 	display: flex;
 	align-items: center;
 	gap: 14px;
-	width: 100%;
 	padding: 14px 16px;
-	border: none;
-	border-radius: 0;
-	background: transparent;
-	box-shadow: none;
-	text-align: left;
 	cursor: pointer;
 	transition: background 110ms ease;
+}
+
+.hearth-settings-index-row:focus-visible {
+	outline: 2px solid var(--interactive-accent);
+	outline-offset: -2px;
 }
 
 .hearth-settings-index-row + .hearth-settings-index-row {
@@ -1320,16 +1322,14 @@
 /* ---- Settings tab: a category page ----------------------------------
    The second level: one category's groups, with the way back at the top. */
 
+/* Also a div rather than a button — see .hearth-settings-index-row. */
 .hearth-settings-back {
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
 	margin: 14px 0 0;
 	padding: 5px 10px 5px 6px;
-	border: none;
 	border-radius: 7px;
-	background: transparent;
-	box-shadow: none;
 	color: var(--text-muted);
 	font-size: var(--font-ui-small);
 	cursor: pointer;
@@ -1338,6 +1338,11 @@
 .hearth-settings-back:hover {
 	background: var(--background-modifier-hover);
 	color: var(--text-normal);
+}
+
+.hearth-settings-back:focus-visible {
+	outline: 2px solid var(--interactive-accent);
+	outline-offset: 2px;
 }
 
 .hearth-settings-back-icon {

--- a/styles.css
+++ b/styles.css
@@ -1153,98 +1153,49 @@
 	resize: vertical;
 }
 
-/* ---- Settings tab: foldable sections --------------------------------
+/* ---- Settings tab: section groups -----------------------------------
    These styles apply in Obsidian's settings UI (not the home view), so they're
-   not scoped under .hearth-view. Each section is a .hearth-section with a
-   clickable heading (.hearth-section-head) that toggles the body below it. */
+   not scoped under .hearth-view. Each section is a .hearth-section: a heading
+   (.hearth-section-head) above a bordered box of rows (.hearth-section-body).
 
-/* Sections are cards, spaced by the flex gap on .hearth-settings-tabbody rather
-   than their own margins. Before this they were flat blocks separated by a
-   single hairline under each heading, which read as one continuous list — the
-   boundary between two sections was indistinguishable from the boundary between
-   two settings rows. An open section is filled; a folded one stays flat, so
-   what's open reads at a glance. */
+   Sections were collapsible cards when a tab held a whole category in one
+   scroll. Each category now has its own page holding a handful of groups, so
+   there's nothing to fold — the heading sits outside the box, labelling it. */
+
 .hearth-section {
-	background: var(--background-secondary);
-	border: 1px solid var(--background-modifier-border);
-	border-radius: 10px;
-	transition: background 120ms ease;
-}
-
-.hearth-section.is-collapsed {
-	background: transparent;
-}
-
-.hearth-section.is-collapsed:hover {
-	background: var(--background-modifier-hover);
-}
-
-/* The heading row mirrors Obsidian's own .setting-item-heading look but is
-   interactive (click to fold). */
-.hearth-section-head {
 	display: flex;
-	align-items: center;
-	gap: 10px;
-	padding: 14px 16px;
-	cursor: pointer;
-	user-select: none;
+	flex-direction: column;
 }
 
-/* Only an open section rules off its heading — on a folded one that hairline
-   would sit under nothing. */
-.hearth-section:not(.is-collapsed) > .hearth-section-head {
-	border-bottom: 1px solid var(--background-modifier-border);
-}
-
-.hearth-section-head:hover .hearth-section-title {
-	color: var(--interactive-accent);
-}
-
-.hearth-section-titles {
-	flex: 1;
-	min-width: 0;
+.hearth-section-head {
+	padding: 0 4px 8px;
 }
 
 .hearth-section-title {
-	font-size: var(--font-ui-medium);
+	font-size: var(--font-ui-small);
 	font-weight: 600;
 	color: var(--text-normal);
-	transition: color 120ms ease;
 }
 
 .hearth-section-desc {
-	margin-top: 4px;
+	margin-top: 3px;
 	font-size: var(--font-ui-smaller);
 	color: var(--text-muted);
-	line-height: 1.4;
-}
-
-/* The chevron rotates to indicate collapsed state. */
-.hearth-section-chevron {
-	display: flex;
-	color: var(--text-muted);
-	transition: transform 180ms ease;
-}
-
-.hearth-section-chevron.is-rotated {
-	transform: rotate(-90deg);
+	line-height: 1.45;
+	max-width: 60ch;
 }
 
 .hearth-section-body {
-	/* Smooth collapse/expand. Only height animates; display:none is the real
-	   toggle (so inputs don't remain focusable when hidden). */
-	transition: opacity 150ms ease;
-	padding: 0 16px;
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 10px;
+	padding: 2px 16px;
 }
 
-/* Obsidian rules off every .setting-item with a top border; inside a card the
-   first one would double up with the heading's own rule. */
+/* Obsidian rules off every .setting-item with a top border; the first row in a
+   box has the box's own edge above it already. */
 .hearth-section-body > .setting-item:first-child {
 	border-top: none;
-}
-
-.hearth-section-body > .setting-item:last-child {
-	padding-bottom: 6px;
 }
 
 /* On Obsidian 1.13+ the whole pane is hosted inside a single declarative
@@ -1257,37 +1208,161 @@
 	padding: 0;
 }
 
-/* ---- Settings tab: category ribbon ----------------------------------
-   A row of tabs pinned to the top of the settings pane; clicking one shows
-   only that category's sections in the body below. */
+/* ---- Settings tab: the category index -------------------------------
+   The pane's first level: every category as a full-width row that opens its
+   own page. This replaced a ribbon of seven tabs pinned to the top of the
+   pane. Seven pills never fit a stock-width pane — they wrapped onto a ragged
+   second line, and clipped the last two once made to scroll — and pinning the
+   row left content sliced behind it. Rows are vertical and nothing here is
+   pinned, so neither failure mode exists.
 
-.hearth-settings-ribbon {
-	/* One row, always. With flex-wrap seven tabs overflowed a stock-width
-	   settings pane and broke onto a second, ragged line; a pane too narrow for
-	   all seven now scrolls horizontally instead (scrollbar hidden — the active
-	   tab is scrolled into view on render). */
-	display: flex;
-	flex-wrap: nowrap;
-	overflow-x: auto;
-	scrollbar-width: none;
-	gap: 3px;
-	position: sticky;
-	top: 0;
-	z-index: 5;
-	padding: 8px 0 10px;
-	margin-bottom: 4px;
-	background: var(--background-primary);
-	border-bottom: 1px solid var(--background-modifier-border);
-	/* The pinned bar's background only paints its own box, so content scrolling
-	   through the band between the pane's top edge and the bar stayed visible
-	   above it: a section heading sliced in half sitting above the tabs. Extend
-	   the same fill upwards, which covers that band without having to hardcode
-	   the host pane's padding. */
-	box-shadow: 0 -16px 0 var(--background-primary);
+   Note the ribbon *tab* styles below survive: the card- and dashboard-settings
+   modals reuse .hearth-ribbon-tab for their own tab strips. */
+
+.hearth-settings-index-head {
+	padding: 18px 4px 4px;
 }
 
-.hearth-settings-ribbon::-webkit-scrollbar {
-	display: none;
+.hearth-settings-index-title {
+	font-size: var(--font-ui-larger);
+	font-weight: 600;
+	color: var(--text-normal);
+	letter-spacing: -0.01em;
+}
+
+.hearth-settings-index-sub {
+	margin-top: 4px;
+	font-size: var(--font-ui-small);
+	color: var(--text-muted);
+	line-height: 1.5;
+	max-width: 56ch;
+}
+
+.hearth-settings-index-grouplabel {
+	padding: 22px 4px 8px;
+	font-size: var(--font-ui-smaller);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--text-faint);
+}
+
+.hearth-settings-index-rows {
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 10px;
+	overflow: hidden;
+}
+
+.hearth-settings-index-row {
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	width: 100%;
+	padding: 14px 16px;
+	border: none;
+	border-radius: 0;
+	background: transparent;
+	box-shadow: none;
+	text-align: left;
+	cursor: pointer;
+	transition: background 110ms ease;
+}
+
+.hearth-settings-index-row + .hearth-settings-index-row {
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.hearth-settings-index-row:hover {
+	background: var(--background-modifier-hover);
+}
+
+.hearth-settings-index-glyph {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 30px;
+	height: 30px;
+	border-radius: 8px;
+	background: var(--background-modifier-border);
+	color: var(--text-normal);
+}
+
+.hearth-settings-index-glyph .svg-icon {
+	width: 16px;
+	height: 16px;
+}
+
+.hearth-settings-index-rowtext {
+	flex: 1;
+	min-width: 0;
+}
+
+.hearth-settings-index-rowname {
+	font-size: var(--font-ui-medium);
+	color: var(--text-normal);
+}
+
+.hearth-settings-index-rowdesc {
+	margin-top: 2px;
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+	line-height: 1.45;
+}
+
+.hearth-settings-index-go {
+	display: inline-flex;
+	flex-shrink: 0;
+	color: var(--text-faint);
+}
+
+/* ---- Settings tab: a category page ----------------------------------
+   The second level: one category's groups, with the way back at the top. */
+
+.hearth-settings-back {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	margin: 14px 0 0;
+	padding: 5px 10px 5px 6px;
+	border: none;
+	border-radius: 7px;
+	background: transparent;
+	box-shadow: none;
+	color: var(--text-muted);
+	font-size: var(--font-ui-small);
+	cursor: pointer;
+}
+
+.hearth-settings-back:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.hearth-settings-back-icon {
+	display: inline-flex;
+}
+
+.hearth-settings-back-icon .svg-icon {
+	width: 15px;
+	height: 15px;
+}
+
+.hearth-settings-page-title {
+	padding: 10px 4px 0;
+	font-size: var(--font-ui-larger);
+	font-weight: 600;
+	color: var(--text-normal);
+	letter-spacing: -0.01em;
+}
+
+.hearth-settings-page-desc {
+	padding: 4px 4px 0;
+	font-size: var(--font-ui-small);
+	color: var(--text-muted);
+	line-height: 1.5;
+	max-width: 58ch;
 }
 
 .hearth-ribbon-tab {
@@ -1337,59 +1412,26 @@
 	}
 }
 
-/* ---- Settings tab: tab header ---------------------------------------
-   Names the open tab above its sections and, since every section starts
-   folded, carries the control that opens them all at once. */
-
-.hearth-settings-tabhead {
-	display: flex;
-	align-items: baseline;
-	gap: 10px;
-	padding: 14px 2px 10px;
-}
-
-.hearth-settings-tabhead-titles {
-	flex: 1;
-	min-width: 0;
-	display: flex;
-	align-items: baseline;
-	gap: 8px;
-}
-
-.hearth-settings-tabhead-title {
-	font-size: var(--font-ui-large);
-	font-weight: 600;
-	color: var(--text-normal);
-}
-
-.hearth-settings-tabhead-count {
-	font-size: var(--font-ui-smaller);
-	color: var(--text-faint);
-}
-
-.hearth-settings-expand-all {
-	flex-shrink: 0;
-	padding: 4px 10px;
-	border: none;
-	border-radius: 6px;
-	background: transparent;
-	box-shadow: none;
-	color: var(--text-muted);
-	font-size: var(--font-ui-small);
-	cursor: pointer;
-}
-
-.hearth-settings-expand-all:hover {
-	background: var(--background-modifier-hover);
-	color: var(--text-normal);
-}
-
 .hearth-settings-tabbody {
-	/* Sections space themselves with this gap; see .hearth-section. */
-	display: flex;
-	flex-direction: column;
-	gap: 10px;
+	padding-top: 20px;
 	animation: hearth-tab-fade 140ms ease;
+}
+
+/* Margin rather than a flex gap on the parent: a page is mostly .hearth-section
+   groups, but a couple of pages drop a bare .setting-item straight into the
+   body, and those must not be spaced as if they were groups. */
+.hearth-section,
+.hearth-settings-tabbody > .setting-item {
+	margin-bottom: 22px;
+}
+
+/* A stray row that belongs to no group still gets the group's box, so it reads
+   as deliberate rather than unfinished. */
+.hearth-settings-tabbody > .setting-item {
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 10px;
+	padding: 14px 16px;
 }
 
 /* Inline error shown when a section (or tab) fails to render, so one broken

--- a/styles.css
+++ b/styles.css
@@ -1158,8 +1158,25 @@
    not scoped under .hearth-view. Each section is a .hearth-section with a
    clickable heading (.hearth-section-head) that toggles the body below it. */
 
+/* Sections are cards, spaced by the flex gap on .hearth-settings-tabbody rather
+   than their own margins. Before this they were flat blocks separated by a
+   single hairline under each heading, which read as one continuous list — the
+   boundary between two sections was indistinguishable from the boundary between
+   two settings rows. An open section is filled; a folded one stays flat, so
+   what's open reads at a glance. */
 .hearth-section {
-	margin-bottom: 8px;
+	background: var(--background-secondary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 10px;
+	transition: background 120ms ease;
+}
+
+.hearth-section.is-collapsed {
+	background: transparent;
+}
+
+.hearth-section.is-collapsed:hover {
+	background: var(--background-modifier-hover);
 }
 
 /* The heading row mirrors Obsidian's own .setting-item-heading look but is
@@ -1168,9 +1185,14 @@
 	display: flex;
 	align-items: center;
 	gap: 10px;
-	padding: 14px 0 10px;
+	padding: 14px 16px;
 	cursor: pointer;
 	user-select: none;
+}
+
+/* Only an open section rules off its heading — on a folded one that hairline
+   would sit under nothing. */
+.hearth-section:not(.is-collapsed) > .hearth-section-head {
 	border-bottom: 1px solid var(--background-modifier-border);
 }
 
@@ -1212,10 +1234,17 @@
 	/* Smooth collapse/expand. Only height animates; display:none is the real
 	   toggle (so inputs don't remain focusable when hidden). */
 	transition: opacity 150ms ease;
+	padding: 0 16px;
 }
 
-.hearth-section.is-collapsed .hearth-section-head {
-	border-bottom-color: transparent;
+/* Obsidian rules off every .setting-item with a top border; inside a card the
+   first one would double up with the heading's own rule. */
+.hearth-section-body > .setting-item:first-child {
+	border-top: none;
+}
+
+.hearth-section-body > .setting-item:last-child {
+	padding-bottom: 6px;
 }
 
 /* On Obsidian 1.13+ the whole pane is hosted inside a single declarative
@@ -1233,23 +1262,39 @@
    only that category's sections in the body below. */
 
 .hearth-settings-ribbon {
+	/* One row, always. With flex-wrap seven tabs overflowed a stock-width
+	   settings pane and broke onto a second, ragged line; a pane too narrow for
+	   all seven now scrolls horizontally instead (scrollbar hidden — the active
+	   tab is scrolled into view on render). */
 	display: flex;
-	flex-wrap: wrap;
-	gap: 4px;
+	flex-wrap: nowrap;
+	overflow-x: auto;
+	scrollbar-width: none;
+	gap: 3px;
 	position: sticky;
 	top: 0;
 	z-index: 5;
-	padding: 4px 0 10px;
-	margin-bottom: 8px;
+	padding: 8px 0 10px;
+	margin-bottom: 4px;
 	background: var(--background-primary);
 	border-bottom: 1px solid var(--background-modifier-border);
+	/* The pinned bar's background only paints its own box, so content scrolling
+	   through the band between the pane's top edge and the bar stayed visible
+	   above it: a section heading sliced in half sitting above the tabs. Extend
+	   the same fill upwards, which covers that band without having to hardcode
+	   the host pane's padding. */
+	box-shadow: 0 -16px 0 var(--background-primary);
+}
+
+.hearth-settings-ribbon::-webkit-scrollbar {
+	display: none;
 }
 
 .hearth-ribbon-tab {
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
-	padding: 6px 12px;
+	padding: 6px 10px;
 	border-radius: 8px;
 	border: 1px solid transparent;
 	background: transparent;
@@ -1258,6 +1303,7 @@
 	font-weight: 500;
 	cursor: pointer;
 	white-space: nowrap;
+	flex-shrink: 0;
 	box-shadow: none;
 	transition:
 		background 120ms ease,
@@ -1291,7 +1337,58 @@
 	}
 }
 
+/* ---- Settings tab: tab header ---------------------------------------
+   Names the open tab above its sections and, since every section starts
+   folded, carries the control that opens them all at once. */
+
+.hearth-settings-tabhead {
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
+	padding: 14px 2px 10px;
+}
+
+.hearth-settings-tabhead-titles {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+}
+
+.hearth-settings-tabhead-title {
+	font-size: var(--font-ui-large);
+	font-weight: 600;
+	color: var(--text-normal);
+}
+
+.hearth-settings-tabhead-count {
+	font-size: var(--font-ui-smaller);
+	color: var(--text-faint);
+}
+
+.hearth-settings-expand-all {
+	flex-shrink: 0;
+	padding: 4px 10px;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	box-shadow: none;
+	color: var(--text-muted);
+	font-size: var(--font-ui-small);
+	cursor: pointer;
+}
+
+.hearth-settings-expand-all:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
 .hearth-settings-tabbody {
+	/* Sections space themselves with this gap; see .hearth-section. */
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 	animation: hearth-tab-fade 140ms ease;
 }
 


### PR DESCRIPTION
## What does this PR do?

Replaces the settings pane's pinned horizontal tab row with a two-level structure: an index of categories, each opening its own page.

The pane had grown to seven tabs, seventeen sections and sixty rows inside a shell built for something smaller. Two problems came out of the tab row specifically, and the first commit here tried to fix them in place and made one of them worse — that attempt is superseded by the second commit, and the branch should be read as a whole.

**Seven tabs never fit a stock-width pane.** With `flex-wrap: wrap` they broke onto a ragged second line (4 + 3). Switching to `overflow-x: auto` with a hidden scrollbar traded that for something worse: "Backup" clipped mid-word, "About" gone entirely, and no cue that either existed.

**Pinning the row left sliced text behind it.** A `position: sticky` bar's background paints only its own box, so content scrolling through the band beside it stays visible — a section heading cut in half above the pills.

So the row is gone rather than patched again:

- **The index** lists every category as a full-width row — icon, name, one line on what's inside, chevron — grouped under four headings. Rows are vertical, so there is no width at which they wrap or clip, and an eighth category costs nothing.
- **A category page** holds that category's groups with a back link at the top. Nothing on either level is pinned, so the sliced-text bug cannot recur: the element that caused it no longer exists.
- **Sections stop folding.** The fold state, chevrons, persisted per-section localStorage keys and the expand-all control all existed to tame a tab holding a whole category in one scroll. A page holds two to five groups, so everything is visible the moment it opens. A section is now a heading above a bordered box of rows.
- The About page's five bare rows move into a group so they read like every other page, and the one stray ungrouped row (Dashboard's "Cards" note) picks up the same box from CSS.

Compatibility: the localStorage key is unchanged and old values are still valid tab ids, so an upgrading user lands on the page they last had open rather than the index. The catalogue's cross-links still work — "Show" scrolls to a section on the same page, "Go to" navigates to another category. `.hearth-ribbon-tab` and its icon/label styles stay, because `src/tabbedmodal.ts` reuses them for the card- and dashboard-settings modals.

The final commit fixes a bug in the first version of the index: the rows were `<button>` elements, and Obsidian's base `button` style fixes their height, so each row's two lines of text overflowed its own box and collided with its neighbours. They are now divs given the `makeClickable` treatment from `src/ui.ts` (`role="button"`, tabindex, Enter/Space) — the pattern the rest of the plugin already uses so Obsidian's button styling never has to be overridden.

Two things worth a reviewer's eye:

- **It costs a click** each way to reach any setting — the real trade for never scrolling past irrelevant categories. The back link sits in normal flow and scrolls away on the longest page (Behaviour), which I'd accept over reintroducing anything pinned.
- The index grouping (Look & feel / How it works / Data & plugins / Etc) is editorial, not structural. Rename or reshuffle freely; it's one array in `settings.ts` plus four strings.

**On Operon**, which was the reference for this direction: it's GPL-3.0 and Hearth is MIT, so I took the pattern from a screenshot and wrote this independently rather than copying their implementation, which would have forced a licence change on Hearth. The pattern itself is generic — it's also how Obsidian's own plugin list and iOS Settings work.

**Not in scope: settings search.** Worth recording why, since it came up. Obsidian 1.13 indexes declarative settings for its own search (`SettingDefinition.name`/`desc`/`aliases`), and `SettingDefinitionPage` is a first-class version of the drill-down this PR hand-rolls. Adopting it is blocked on two things today: `minAppVersion` is 1.8.7 while those APIs are `@since 1.13.0`, and the typings expose no programmatic navigation between definition pages — which the catalogue's "Go to" buttons need. Revisit once 1.13 is the floor.

## Related issue

None — raised directly as UX feedback on the global settings pane.

## Type of change

- [x] ✨ Feature / behaviour change (discussed in an issue first) — no issue was opened first; happy to split or park this if you'd rather align on the direction than on the diff

## Checklist

- [x] `npm run build` passes locally — the esbuild bundle builds clean; `npm run build`'s `tsc` step also reports two pre-existing `tsconfig.json` deprecation errors (`baseUrl`, `moduleResolution=node10`) under the TypeScript 5.9.3 a fresh `npm install` resolves. Unrelated to this diff and present on `main`. `npm run lint` is 0 errors / 28 pre-existing warnings, `npm test` is 358 passing.
- [x] I've tested this in an actual vault — by the maintainer, not by me: this branch was written in a container with no Obsidian, so every visual claim in it came from reading code. That is how the overflowing index rows shipped in the first place. The pane has since been run in a vault and confirmed working as of the final commit.