### PR TITLE
Make body-search results readable and stop stale vault scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,9 +188,37 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   rule outranked the transparent background Hearth asks for. The raw editor
   now keeps the card's surface in every state, so switching between the
   rendered note and its source no longer changes the card's background (#160).
+- **Note-content search results are readable.** A hit inside a note's body
+  showed the raw slice of file it was cut from, so results imported from HTML
+  or carrying frontmatter came out as a wall of `&quot;`, `&#039;` and `<br>`
+  with `["Novák Jan", "Šikl Tomáš"]` quoting in the middle of it — and the whole
+  line was accent-coloured, so it shouted as loudly as the file name above it.
+  Excerpts are now cleaned before they're shown (HTML and entities decoded,
+  frontmatter fences, heading, quote and bullet markers dropped, links reduced
+  to their text, inline YAML lists unquoted), narrowed to the text around the
+  match, and rendered as muted context with only the matched words highlighted.
+  Omnisearch results go through the same treatment and highlight the words it
+  reports matching, so both engines read the same way.
+- **Searching with the folders filter no longer comes up empty on Omnisearch.**
+  Omnisearch indexes notes only, so with it selected as the search engine the
+  folders chip could never match anything and every query answered "no matches".
+  Folder searches now go to the built-in engine whichever engine is selected.
+- **A saved-search card no longer lists folders you can't open.** The Query
+  card's rows open a note when clicked, but folder hits were listed too and did
+  nothing. It now searches files only.
+- **Omnisearch failing is no longer shown as "no matches".** If Omnisearch was
+  disabled mid-query or its API threw, the dropdown emptied as though the note
+  didn't exist. Hearth now quietly answers with its own engine instead.
 
 ### Changed
 
+- **Searching note contents costs a lot less on a large vault.** A body search
+  walked every note and built a lower-cased copy of it to match against, and the
+  walk kept going after you'd typed the next character — so a few keystrokes
+  left several full-vault reads racing each other, each allocating a second copy
+  of the vault. A stale scan is now abandoned as soon as the query moves on, and
+  lower-cased bodies are cached (bounded, and re-read when a note changes), so
+  refining a query re-uses the work the last one did.
 - **The Plugin view card now says plainly how expensive it is.** Its performance
   hint was a line of muted grey text under the type dropdown, easy to skim past
   when it is the one card that can genuinely slow a dashboard down. It is now a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,25 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   match, and rendered as muted context with only the matched words highlighted.
   Omnisearch results go through the same treatment and highlight the words it
   reports matching, so both engines read the same way.
+- **Search results are ranked by how well they actually match.** A query's
+  letters were fuzzy-matched against each file's whole path, and a long path
+  gives them plenty of room to scatter — searching `banán` returned
+  *Library/Recipes/Polévka z pečených **b**atátů s cizr**n**ou **a** kukuřicí*
+  ranked among the notes genuinely called *Banánové…*. Matches are now banded:
+  a name starting with what you typed comes first, then a match at a word
+  boundary in the name, then anywhere in the name, then a fuzzy name match, and
+  last a match in the folder path. Paths are matched literally and never
+  fuzzily, so a folder search still works but can no longer conjure hits out of
+  scattered letters.
+- **Accents no longer have to be typed exactly.** `banan` now finds *Banánové
+  Snickersky* and highlights `Banán` in it, in file names, note bodies and
+  Omnisearch results alike — matching ignores case and diacritics throughout.
+- **Omnisearch results highlight the matched words again.** Omnisearch reports
+  the words it matched stemmed and stripped of their accents (`banan` for a note
+  that says *Banánové*), so looking for them literally found nothing and both
+  the title and the excerpt came back unhighlighted. Hearth now also reads the
+  spans Omnisearch itself marked in the excerpt — which carry the words exactly
+  as the note spells them — and matches without accents on top of that.
 - **Searching with the folders filter no longer comes up empty on Omnisearch.**
   Omnisearch indexes notes only, so with it selected as the search engine the
   folders chip could never match anything and every query answered "no matches".
@@ -217,7 +236,7 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   walk kept going after you'd typed the next character — so a few keystrokes
   left several full-vault reads racing each other, each allocating a second copy
   of the vault. A stale scan is now abandoned as soon as the query moves on, and
-  lower-cased bodies are cached (bounded, and re-read when a note changes), so
+  folded bodies are cached (bounded, and re-read when a note changes), so
   refining a query re-uses the work the last one did.
 - **The Plugin view card now says plainly how expensive it is.** Its performance
   hint was a line of muted grey text under the type dropdown, easy to skim past

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,16 +199,23 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   match, and rendered as muted context with only the matched words highlighted.
   Omnisearch results go through the same treatment and highlight the words it
   reports matching, so both engines read the same way.
-- **Search results are ranked by how well they actually match.** A query's
-  letters were fuzzy-matched against each file's whole path, and a long path
-  gives them plenty of room to scatter — searching `banán` returned
-  *Library/Recipes/Polévka z pečených **b**atátů s cizr**n**ou **a** kukuřicí*
-  ranked among the notes genuinely called *Banánové…*. Matches are now banded:
-  a name starting with what you typed comes first, then a match at a word
-  boundary in the name, then anywhere in the name, then a fuzzy name match, and
-  last a match in the folder path. Paths are matched literally and never
-  fuzzily, so a folder search still works but can no longer conjure hits out of
-  scattered letters.
+- **Search results are ranked by how well they actually match.** Obsidian's
+  fuzzy matcher will scatter a query's letters across a long string and score
+  the result respectably, so searching `banán` returned
+  *Pohan**á**kový chlé**b** s **a**vokádovo-vaječ**n**ou pom**a**zá**n**kou* and
+  *Library/Recipes/Polévka z pečených **b**atátů s cizr**n**ou **a** kukuřicí* —
+  ranked above notes that plainly contain the word *banánu*. Results are now
+  banded, and **every literal match outranks every fuzzy one**: a name starting
+  with what you typed, then the query at a word start in the name, then anywhere
+  in the name, then in the folder path, then in the note's body, and only then a
+  fuzzy name match. Paths are matched literally and never fuzzily, so a folder
+  search still works but can no longer conjure hits out of scattered letters.
+- **Note-content matches take their place in the list.** They were appended
+  after every name match, so a note whose body plainly contained the word ranked
+  below every note whose title merely fuzzy-matched it — and when scattered
+  titles filled the page, content search was given no room to run at all and the
+  real matches never appeared. Body hits are now merged into the ranking, and
+  only results that genuinely outrank them reserve a slot.
 - **Accents no longer have to be typed exactly.** `banan` now finds *Banánové
   Snickersky* and highlights `Banán` in it, in file names, note bodies and
   Omnisearch results alike — matching ignores case and diacritics throughout.

--- a/src/cards/search.ts
+++ b/src/cards/search.ts
@@ -6,7 +6,7 @@ import { t } from "../i18n";
 import { openFile } from "../opener";
 import { runQuery, searchFileContents, type QueryHit } from "../query";
 import { type DashboardCard } from "../types";
-import { makeClickable } from "../ui";
+import { makeClickable, renderHighlighted } from "../ui";
 import { type HomeView } from "../view";
 import { type CardDefinition, type CardEditorContext } from "./definition";
 
@@ -25,7 +25,12 @@ export function renderSavedSearch(view: HomeView, card: DashboardCard, body: HTM
 	const limit = cfg.count && cfg.count > 0 ? cfg.count : 12;
 	const useTiles = (cfg.view ?? "list") === "tiles";
 
-	const hits = runQuery(view.app, query, { limit });
+	// Files only: the card's rows open a note on click, so a folder hit would
+	// render as a row that looks clickable and then does nothing.
+	const hits = runQuery(view.app, query, {
+		limit,
+		filter: { includeFolders: false, includeFiles: true, groupId: null },
+	});
 
 	const render = (all: QueryHit[]) => {
 		const list = all.slice(0, limit);
@@ -45,7 +50,12 @@ export function renderSavedSearch(view: HomeView, card: DashboardCard, body: HTM
 	// Append full-text body matches when enabled (self-guards to name queries).
 	if (view.plugin.settings.searchContents) {
 		const exclude = new Set(hits.map((h) => h.file.path));
-		void searchFileContents(view.app, query, { exclude, limit }).then((extra) => {
+		// Only top up to the card's limit — asking for `limit` more would keep
+		// reading notes whose hits `render` is just going to slice off anyway.
+		void searchFileContents(view.app, query, {
+			exclude,
+			limit: Math.max(0, limit - hits.length),
+		}).then((extra) => {
 			if (extra.length) render([...hits, ...extra]);
 		});
 	}
@@ -64,8 +74,21 @@ function renderQueryList(view: HomeView, body: HTMLElement, list: QueryHit[]): v
 			hit.badge?.icon ?? resolveFileIcon(view.app, hit.file, icons),
 		);
 		const name = hit.file instanceof TFile ? hit.file.basename : hit.file.name;
-		row.createDiv({ cls: "hearth-list-label", text: name });
-		if (hit.badge) row.createDiv({ cls: "hearth-task-status", text: hit.badge.label });
+		if (hit.badge?.excerpt) {
+			// A body excerpt is a sentence, not a chip: it goes on its own line
+			// under the file name, muted, with the matched words picked out.
+			row.addClass("has-excerpt");
+			const text = row.createDiv("hearth-list-text");
+			text.createDiv({ cls: "hearth-list-label", text: name });
+			renderHighlighted(
+				text.createDiv("hearth-list-excerpt"),
+				hit.badge.label,
+				hit.badge.matches,
+			);
+		} else {
+			row.createDiv({ cls: "hearth-list-label", text: name });
+			if (hit.badge) row.createDiv({ cls: "hearth-task-status", text: hit.badge.label });
+		}
 		const open = () => {
 			if (hit.file instanceof TFile) void openFile(view, hit.file, "search");
 		};

--- a/src/cards/search.ts
+++ b/src/cards/search.ts
@@ -4,7 +4,13 @@ import { addResetButton } from "../editors";
 import { applyFileIcon, fileIconOptions, resolveFileIcon } from "../fileicons";
 import { t } from "../i18n";
 import { openFile } from "../opener";
-import { runQuery, searchFileContents, type QueryHit } from "../query";
+import {
+	mergeRanked,
+	runQuery,
+	searchFileContents,
+	slotsAboveBody,
+	type QueryHit,
+} from "../query";
 import { type DashboardCard } from "../types";
 import { makeClickable, renderHighlighted } from "../ui";
 import { type HomeView } from "../view";
@@ -50,13 +56,13 @@ export function renderSavedSearch(view: HomeView, card: DashboardCard, body: HTM
 	// Append full-text body matches when enabled (self-guards to name queries).
 	if (view.plugin.settings.searchContents) {
 		const exclude = new Set(hits.map((h) => h.file.path));
-		// Only top up to the card's limit — asking for `limit` more would keep
-		// reading notes whose hits `render` is just going to slice off anyway.
+		// Budget against the hits that outrank a body match, so fuzzy name hits
+		// (which sort below body ones) don't reserve slots they won't keep.
 		void searchFileContents(view.app, query, {
 			exclude,
-			limit: Math.max(0, limit - hits.length),
+			limit: Math.max(0, limit - slotsAboveBody(hits)),
 		}).then((extra) => {
-			if (extra.length) render([...hits, ...extra]);
+			if (extra.length) render(mergeRanked(hits, extra, limit));
 		});
 	}
 }

--- a/src/excerpt.ts
+++ b/src/excerpt.ts
@@ -100,17 +100,69 @@ export function cleanExcerptText(raw: string): string {
 	);
 }
 
-/** Char ranges in `haystack` covering any of `needles` (case-insensitive),
- * sorted and with overlaps merged so highlight spans never cross. Returns
- * undefined when nothing matched. */
+/**
+ * Fold one character for matching: lower-cased and stripped of its accent, so
+ * "Á" and "á" both compare equal to "a".
+ *
+ * Every step is reverted unless it leaves the character the same length in
+ * UTF-16 units. That's the whole trick: the folded string stays index-aligned
+ * with the original, so a range found in the folded text can be applied to the
+ * original text unchanged. The handful of characters that don't fold cleanly
+ * (ß → ss, a combining mark on its own) are simply left as they are.
+ */
+function foldChar(ch: string): string {
+	const lower = ch.toLowerCase();
+	const base = lower.length === ch.length ? lower : ch;
+	const stripped = base.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+	return stripped.length === base.length ? stripped : base;
+}
+
+// Everything above ASCII, written as a positive range so the linter does not
+// see control characters in a character class.
+const HAS_NON_ASCII = /[\u0080-\uffff]/;
+const NON_ASCII_G = /[\u0080-\uffff]/g;
+const HAS_UPPER = /[A-Z]/;
+
+/** Fold every character. Only used when the bulk path can't preserve length. */
+function perCharFold(s: string): string {
+	let out = "";
+	for (const ch of s) out += foldChar(ch);
+	return out;
+}
+
+/**
+ * A lower-cased, accent-stripped copy of `s` that is index-aligned with it, for
+ * matching a query against text that may not carry the same diacritics — "banan"
+ * has to find "Banánové", and Omnisearch reports its matched words folded even
+ * when the note spells them with accents.
+ *
+ * This runs over whole note bodies, so it leans on the native bulk operations
+ * and only touches individual characters where it has to: an already-folded
+ * string is returned as-is, and accents are fixed with one regex pass that skips
+ * every ASCII character.
+ */
+export function foldForMatch(s: string): string {
+	const nonAscii = HAS_NON_ASCII.test(s);
+	if (!nonAscii && !HAS_UPPER.test(s)) return s;
+	const lower = s.toLowerCase();
+	// Lower-casing can change a string's length (ß, İ), which would break the
+	// index alignment the ranges depend on. Fall back to the per-character fold,
+	// which reverts any step that doesn't preserve it.
+	const base = lower.length === s.length ? lower : perCharFold(s);
+	return nonAscii ? base.replace(NON_ASCII_G, foldChar) : base;
+}
+
+/** Char ranges in `haystack` covering any of `needles`, ignoring case and
+ * accents, sorted and with overlaps merged so highlight spans never cross.
+ * Returns undefined when nothing matched. */
 export function highlightRanges(
 	haystack: string,
 	needles: readonly string[],
 ): [number, number][] | undefined {
-	const lower = haystack.toLowerCase();
+	const lower = foldForMatch(haystack);
 	const ranges: [number, number][] = [];
 	for (const needle of needles) {
-		const n = needle.toLowerCase();
+		const n = foldForMatch(needle);
 		if (!n) continue;
 		let from = 0;
 		for (;;) {
@@ -170,7 +222,7 @@ export function windowExcerpt(
 	cutBefore = false,
 	cutAfter = false,
 ): Excerpt {
-	const at = needle ? cleaned.toLowerCase().indexOf(needle.toLowerCase()) : -1;
+	const at = needle ? foldForMatch(cleaned).indexOf(foldForMatch(needle)) : -1;
 	// Markup stripping can swallow the match (it straddled a tag, say). Fall
 	// back to the head of the line: still readable, just not centred.
 	const anchor = at < 0 ? 0 : at;

--- a/src/excerpt.ts
+++ b/src/excerpt.ts
@@ -1,0 +1,199 @@
+/**
+ * Turning raw note text into the one readable line a search result shows under
+ * its title.
+ *
+ * Body hits are cut straight out of the file, so the raw slice is whatever
+ * happened to surround the match: YAML frontmatter, HTML entities from an
+ * imported note (`&quot;`, `&#039;`), `<br>` tags, markdown emphasis markers.
+ * Dropped into a result row verbatim that reads as noise. Everything here
+ * exists to make that slice legible: decode it, strip the markup, keep a window
+ * of context around the match, and report where the match landed so the row can
+ * highlight it.
+ */
+
+/** Context kept on each side of the match in the finished line. */
+const CONTEXT_BEFORE = 36;
+const CONTEXT_AFTER = 110;
+/** How much raw text to pull in before cleaning. Generous, because stripping
+ * markup shrinks the slice and we'd rather trim than come up short. */
+const RAW_BEFORE = 220;
+const RAW_AFTER = 460;
+/** Don't hunt further than this for a word boundary to cut on. */
+const SNAP_WINDOW = 14;
+
+/** The handful of named HTML entities that actually show up in notes imported
+ * from HTML or exported by other tools. Anything else is left alone. */
+const NAMED_ENTITIES: Record<string, string> = {
+	amp: "&",
+	lt: "<",
+	gt: ">",
+	quot: '"',
+	apos: "'",
+	nbsp: " ",
+	hellip: "…",
+	mdash: "—",
+	ndash: "–",
+	lsquo: "‘",
+	rsquo: "’",
+	ldquo: "“",
+	rdquo: "”",
+};
+
+function decodeEntities(s: string): string {
+	return s.replace(/&(#\d{1,7}|#x[0-9a-fA-F]{1,6}|[a-zA-Z]{2,8});/g, (whole, body: string) => {
+		if (body.startsWith("#")) {
+			const code = body[1] === "x" || body[1] === "X"
+				? parseInt(body.slice(2), 16)
+				: parseInt(body.slice(1), 10);
+			// Skip anything that isn't a plain printable character — a lone
+			// surrogate or a control code would be worse than the entity text.
+			if (!Number.isFinite(code) || code < 32 || code > 0x10ffff) return whole;
+			try {
+				return String.fromCodePoint(code);
+			} catch {
+				return whole;
+			}
+		}
+		return NAMED_ENTITIES[body.toLowerCase()] ?? whole;
+	});
+}
+
+/**
+ * Flatten a chunk of note text to plain readable prose on one line: HTML out,
+ * entities decoded, markdown markers dropped, whitespace collapsed.
+ *
+ * Tags are stripped *before* entities are decoded, so an escaped `&lt;div&gt;`
+ * in the note survives as visible text instead of being decoded into a tag and
+ * then eaten.
+ */
+export function cleanExcerptText(raw: string): string {
+	let s = raw
+		// A newline, not a space: notes exported from HTML put `<br>` where the
+		// line break was, so the heading and bullet rules below (which anchor to
+		// a line start) need to see one. The final collapse flattens it again.
+		.replace(/<br\s*\/?>/gi, "\n")
+		.replace(/<\/?[a-zA-Z][^>]{0,300}>/g, " ");
+	s = decodeEntities(s);
+	return (
+		s
+			// Inline YAML/JSON string lists (`participants: ["A", "B"]`) are a very
+			// common frontmatter hit. Drop the quoting so they read as a plain list.
+			.replace(/\[\s*"/g, "")
+			.replace(/"\s*\]/g, "")
+			.replace(/"\s*,\s*"/g, ", ")
+			// Frontmatter fences and heading/quote/bullet markers carry no meaning
+			// once the text is a single line.
+			.replace(/^\s*-{3,}\s*$/gm, " ")
+			.replace(/^\s{0,3}#{1,6}\s+/gm, "")
+			.replace(/^\s{0,3}>+\s?/gm, "")
+			.replace(/^\s{0,8}[-*+]\s+/gm, "")
+			// Links: keep the text a human would read, drop the target.
+			.replace(/!?\[\[([^\]|]*)(?:\|([^\]]*))?\]\]/g, (_, target: string, alias: string) =>
+				alias || target,
+			)
+			.replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+			// Emphasis and code markers. `_` is deliberately left alone: it shows up
+			// far more often inside identifiers and filenames than as italics.
+			.replace(/[*`~]/g, "")
+			.replace(/\s+/g, " ")
+			.trim()
+	);
+}
+
+/** Char ranges in `haystack` covering any of `needles` (case-insensitive),
+ * sorted and with overlaps merged so highlight spans never cross. Returns
+ * undefined when nothing matched. */
+export function highlightRanges(
+	haystack: string,
+	needles: readonly string[],
+): [number, number][] | undefined {
+	const lower = haystack.toLowerCase();
+	const ranges: [number, number][] = [];
+	for (const needle of needles) {
+		const n = needle.toLowerCase();
+		if (!n) continue;
+		let from = 0;
+		for (;;) {
+			const idx = lower.indexOf(n, from);
+			if (idx < 0) break;
+			ranges.push([idx, idx + n.length]);
+			from = idx + n.length;
+		}
+	}
+	if (ranges.length === 0) return undefined;
+	ranges.sort((a, b) => a[0] - b[0]);
+	const merged: [number, number][] = [[ranges[0][0], ranges[0][1]]];
+	for (const [start, end] of ranges) {
+		const last = merged[merged.length - 1];
+		if (start <= last[1]) last[1] = Math.max(last[1], end);
+		else merged.push([start, end]);
+	}
+	return merged;
+}
+
+/** Move `i` forward to just past the next space, so a cut lands between words
+ * rather than mid-word. Never moves past `limit`, and gives up if the nearest
+ * boundary is too far to be worth the characters. */
+function snapForward(s: string, i: number, limit: number): number {
+	if (i <= 0) return 0;
+	const space = s.indexOf(" ", i);
+	if (space < 0 || space - i > SNAP_WINDOW) return i;
+	return Math.min(space + 1, limit);
+}
+
+/** Move `i` back to the preceding space, on the same terms as snapForward. */
+function snapBack(s: string, i: number, limit: number): number {
+	if (i >= s.length) return s.length;
+	const space = s.lastIndexOf(" ", i);
+	if (space < 0 || i - space > SNAP_WINDOW) return i;
+	return Math.max(space, limit);
+}
+
+/** A cleaned excerpt: the line to display, plus where in it the query matched. */
+export interface Excerpt {
+	label: string;
+	matches?: [number, number][];
+}
+
+/**
+ * Trim an already-cleaned line down to a window around the first occurrence of
+ * `needle`, adding an ellipsis on whichever side was cut. `cutBefore`/`cutAfter`
+ * say whether the caller had already sliced text off that end.
+ *
+ * The match is located in the *cleaned* text rather than mapped over from the
+ * raw offsets — cleaning shifts every position, and re-finding the needle is
+ * both simpler and exactly what the highlight needs anyway.
+ */
+export function windowExcerpt(
+	cleaned: string,
+	needle: string,
+	cutBefore = false,
+	cutAfter = false,
+): Excerpt {
+	const at = needle ? cleaned.toLowerCase().indexOf(needle.toLowerCase()) : -1;
+	// Markup stripping can swallow the match (it straddled a tag, say). Fall
+	// back to the head of the line: still readable, just not centred.
+	const anchor = at < 0 ? 0 : at;
+	const anchorEnd = at < 0 ? 0 : at + needle.length;
+
+	let start = snapForward(cleaned, Math.max(0, anchor - CONTEXT_BEFORE), anchor);
+	let end = snapBack(cleaned, Math.min(cleaned.length, anchorEnd + CONTEXT_AFTER), anchorEnd);
+	if (end < start) end = start;
+
+	let label = cleaned.slice(start, end).trim();
+	if (start > 0 || cutBefore) label = `…${label}`;
+	if (end < cleaned.length || cutAfter) label = `${label}…`;
+	return { label, matches: needle ? highlightRanges(label, [needle]) : undefined };
+}
+
+/**
+ * Build the display line for a body-content hit at [idx, idx+len) in `text`.
+ * Pulls a generous raw window, cleans it, then narrows to the match.
+ */
+export function buildExcerpt(text: string, idx: number, len: number): Excerpt {
+	const needle = text.slice(idx, idx + len);
+	const rawStart = Math.max(0, idx - RAW_BEFORE);
+	const rawEnd = Math.min(text.length, idx + len + RAW_AFTER);
+	const cleaned = cleanExcerptText(text.slice(rawStart, rawEnd));
+	return windowExcerpt(cleaned, needle, rawStart > 0, rawEnd < text.length);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { openFile } from "./opener";
 import { EXCALIDRAW_PLUGIN_ID } from "./filetypes";
 import { setLanguage, t } from "./i18n";
 import { maybeShowWhatsNew } from "./whatsnew";
+import { clearContentSearchCache } from "./query";
 
 /** Core "Audio recorder" plugin id, used by the "Record voice" mobile action. */
 const AUDIO_RECORDER_PLUGIN_ID = "audio-recorder";
@@ -149,6 +150,9 @@ export default class HearthPlugin extends Plugin {
 
 	onunload() {
 		// Views are detached automatically by Obsidian on plugin unload.
+		// The content-search cache holds lower-cased note bodies, though, so
+		// drop it rather than leave a copy of the vault behind after unload.
+		clearContentSearchCache();
 	}
 
 	private maybeReplaceNewTab(leaf: WorkspaceLeaf | null) {

--- a/src/omnisearch.ts
+++ b/src/omnisearch.ts
@@ -1,5 +1,5 @@
 import { App, TFile } from "obsidian";
-import { cleanExcerptText, highlightRanges, windowExcerpt } from "./excerpt";
+import { cleanExcerptText, foldForMatch, highlightRanges, windowExcerpt } from "./excerpt";
 import { groupForFile } from "./filetypes";
 import { QueryFilter, QueryHit } from "./query";
 
@@ -59,13 +59,31 @@ export function cleanExcerpt(
 	excerpt: string,
 	foundWords: readonly string[] = [],
 ): { label: string; matches?: [number, number][] } {
+	// Omnisearch already marked the hits, and those spans hold the words as the
+	// note actually spells them — `foundWords` comes back stemmed and stripped of
+	// diacritics ("banan" for a note that says "Banánové"), so on its own it
+	// often finds nothing to highlight. Take both.
+	const words = [...markedWords(excerpt), ...foundWords].filter((w) => w.length > 1);
 	const cleaned = cleanExcerptText(excerpt.replace(/<\/?mark>/g, ""));
 	if (!cleaned) return { label: "" };
 	// Narrow around the first word that's actually present, so the visible part
 	// of a long excerpt is the part that explains the hit.
-	const anchor = foundWords.find((w) => w && cleaned.toLowerCase().includes(w.toLowerCase()));
+	const folded = foldForMatch(cleaned);
+	const anchor = words.find((w) => folded.includes(foldForMatch(w)));
 	const { label } = windowExcerpt(cleaned, anchor ?? "");
-	return { label, matches: highlightRanges(label, foundWords) };
+	return { label, matches: highlightRanges(label, words) };
+}
+
+/** The literal text Omnisearch wrapped in `<mark>` — the matched words exactly
+ * as the note spells them, accents and inflection included. */
+function markedWords(excerpt: string): string[] {
+	const words = new Set<string>();
+	const re = /<mark>([\s\S]*?)<\/mark>/g;
+	for (let m = re.exec(excerpt); m; m = re.exec(excerpt)) {
+		const word = m[1].trim();
+		if (word) words.add(word);
+	}
+	return [...words];
 }
 
 /**
@@ -111,8 +129,9 @@ export async function searchWithOmnisearch(
 		const excerpt = cleanExcerpt(result.excerpt, words);
 		hits.push({
 			file,
-			score: result.score,
+			// Folded, so a stemmed "banan" still lights up "Banánové" in the title.
 			matches: highlightRanges(file.basename, words),
+			score: result.score,
 			badge: excerpt.label
 				? { icon: "file-search", label: excerpt.label, matches: excerpt.matches, excerpt: true }
 				: undefined,

--- a/src/omnisearch.ts
+++ b/src/omnisearch.ts
@@ -1,4 +1,5 @@
 import { App, TFile } from "obsidian";
+import { cleanExcerptText, highlightRanges, windowExcerpt } from "./excerpt";
 import { groupForFile } from "./filetypes";
 import { QueryFilter, QueryHit } from "./query";
 
@@ -42,16 +43,40 @@ export function isOmnisearchAvailable(app: App): boolean {
 	return getOmnisearchApi(app) !== null;
 }
 
-/** Strip Omnisearch's `<mark>` markup out of an excerpt so it renders as plain
- * text (Hearth does its own highlighting) and collapse whitespace to one line. */
-function cleanExcerpt(excerpt: string): string {
-	return excerpt.replace(/<\/?mark>/g, "").replace(/\s+/g, " ").trim();
+/**
+ * Turn an Omnisearch excerpt into the same readable one-liner a built-in body
+ * hit produces: its own `<mark>` markup comes out (Hearth highlights the result
+ * row itself), then the shared cleaner deals with everything else the raw note
+ * text dragged along — HTML, entities, frontmatter, markdown markers.
+ *
+ * `foundWords` is what Omnisearch actually matched, so the excerpt is narrowed
+ * around the first of those words and they're highlighted in place. Without
+ * that the row shows a wall of context with no visible reason it matched.
+ *
+ * Exported for tests.
+ */
+export function cleanExcerpt(
+	excerpt: string,
+	foundWords: readonly string[] = [],
+): { label: string; matches?: [number, number][] } {
+	const cleaned = cleanExcerptText(excerpt.replace(/<\/?mark>/g, ""));
+	if (!cleaned) return { label: "" };
+	// Narrow around the first word that's actually present, so the visible part
+	// of a long excerpt is the part that explains the hit.
+	const anchor = foundWords.find((w) => w && cleaned.toLowerCase().includes(w.toLowerCase()));
+	const { label } = windowExcerpt(cleaned, anchor ?? "");
+	return { label, matches: highlightRanges(label, foundWords) };
 }
 
 /**
  * Run a vault search through Omnisearch and adapt its results to Hearth's
- * {@link QueryHit} shape. Resolves to an empty list when Omnisearch is
- * unavailable so the caller can fall back to the built-in engine.
+ * {@link QueryHit} shape.
+ *
+ * Resolves to `null` — not an empty list — when Omnisearch can't answer at all
+ * (plugin gone, or its API threw). The two cases need to look different to the
+ * caller: "Omnisearch found nothing" is a real answer worth showing, while
+ * "Omnisearch is broken" should fall back to the built-in engine instead of
+ * rendering a misleading empty state.
  *
  * The active file-type filter (and folder/file toggles) is applied to the
  * returned notes so the filter chips keep working; Omnisearch only indexes
@@ -61,61 +86,38 @@ export async function searchWithOmnisearch(
 	app: App,
 	query: string,
 	opts: { filter: QueryFilter; limit: number },
-): Promise<QueryHit[]> {
+): Promise<QueryHit[] | null> {
 	const api = getOmnisearchApi(app);
-	if (!api) return [];
+	if (!api) return null;
 
 	let results: OmnisearchResult[];
 	try {
 		results = await api.search(query);
 	} catch {
-		return [];
+		return null;
 	}
 
 	const { filter } = opts;
+	// Omnisearch indexes notes only, so a folders-only filter can never match.
+	if (!filter.includeFiles) return [];
 	const hits: QueryHit[] = [];
 	for (const result of results) {
-		if (!filter.includeFiles) break;
 		const file = app.vault.getAbstractFileByPath(result.path);
 		if (!(file instanceof TFile)) continue;
 		if (filter.groupId && groupForFile(file)?.id !== filter.groupId) continue;
-		const excerpt = cleanExcerpt(result.excerpt);
+		// Single characters match almost everywhere; highlighting them speckles
+		// the row without saying anything about why it matched.
+		const words = result.foundWords.filter((w) => w.length > 1);
+		const excerpt = cleanExcerpt(result.excerpt, words);
 		hits.push({
 			file,
 			score: result.score,
-			matches: matchRanges(file.basename, result.foundWords),
-			badge: excerpt ? { icon: "file-search", label: excerpt } : undefined,
+			matches: highlightRanges(file.basename, words),
+			badge: excerpt.label
+				? { icon: "file-search", label: excerpt.label, matches: excerpt.matches, excerpt: true }
+				: undefined,
 		});
 		if (hits.length >= opts.limit) break;
 	}
 	return hits;
-}
-
-/** Character ranges in `name` covering any of Omnisearch's matched words, so the
- * built-in result row can highlight the note title the same way name search
- * does. Returns undefined when nothing in the name matched. */
-function matchRanges(name: string, foundWords: string[]): [number, number][] | undefined {
-	const lower = name.toLowerCase();
-	const ranges: [number, number][] = [];
-	for (const word of foundWords) {
-		const w = word.toLowerCase();
-		if (!w) continue;
-		let from = 0;
-		for (;;) {
-			const idx = lower.indexOf(w, from);
-			if (idx < 0) break;
-			ranges.push([idx, idx + w.length]);
-			from = idx + w.length;
-		}
-	}
-	if (ranges.length === 0) return undefined;
-	// Sort and merge overlaps so <mark> spans never cross.
-	ranges.sort((a, b) => a[0] - b[0]);
-	const merged: [number, number][] = [ranges[0]];
-	for (const [start, end] of ranges.slice(1)) {
-		const last = merged[merged.length - 1];
-		if (start <= last[1]) last[1] = Math.max(last[1], end);
-		else merged.push([start, end]);
-	}
-	return merged;
 }

--- a/src/query.ts
+++ b/src/query.ts
@@ -21,6 +21,10 @@ export interface QueryBadge {
 export interface QueryHit {
 	file: TAbstractFile;
 	score: number;
+	/** Ranking band (see {@link RANK}). Compared before `score`, so a literal
+	 * match can never be displaced by a well-scored fuzzy one. Absent on tag and
+	 * property hits, which are their own mode and never mixed with these. */
+	rank?: number;
 	badge?: QueryBadge;
 	matches?: [number, number][];
 }
@@ -57,17 +61,29 @@ export function formatPropertyValue(v: unknown): string {
 const NO_FILTER: QueryFilter = { includeFolders: true, includeFiles: true, groupId: null };
 
 /**
- * Ranking bands for a name query, applied before any score. The point is that a
- * literal hit in the file's own name always beats a fuzzy one, and a fuzzy hit
- * always beats one that only landed somewhere in the folder path — the fuzzy
- * matcher happily scatters a query's letters across a long string, so without
- * bands its scores put near-random matches among the obvious ones.
+ * Ranking bands for a name query, applied before any score.
+ *
+ * The ordering principle is that **every literal match beats every fuzzy one**.
+ * Obsidian's fuzzy matcher will scatter a query's letters across a long string
+ * and score the result respectably, so a query for "banán" pulls in
+ * "Pohanákový chlé*b* s *a*vokádovo-vaječ*n*ou pom*a*zá*n*kou" — a hit no reader
+ * would call a hit. Left to compete on score alone, those crowd out the notes
+ * that plainly contain the word. Bands stop that: fuzzy is the last resort, not
+ * a peer.
+ *
+ * Among literal matches, specificity decides: the file's own name first, then
+ * its folder path, then its body. `BODY` is used by {@link searchFileContents},
+ * whose hits the search bar merges into this same order rather than tacking
+ * them on the end.
  */
-const TIER_PREFIX = 4;
-const TIER_WORD = 3;
-const TIER_SUBSTRING = 2;
-const TIER_FUZZY = 1;
-const TIER_PATH = 0;
+export const RANK = {
+	NAME_PREFIX: 5,
+	NAME_WORD: 4,
+	NAME_SUBSTRING: 3,
+	PATH: 2,
+	BODY: 1,
+	FUZZY_NAME: 0,
+} as const;
 
 /**
  * Run a synchronous vault query (tag / property / name+path). Content search is
@@ -173,7 +189,7 @@ function searchByName(app: App, query: string, filter: QueryFilter, limit: numbe
 
 	const fuzzy = prepareFuzzySearch(query);
 	const q = foldForMatch(query);
-	const ranked: { hit: QueryHit; tier: number }[] = [];
+	const hits: QueryHit[] = [];
 
 	for (const file of candidates) {
 		const displayName = file instanceof TFile ? file.basename : file.name;
@@ -181,48 +197,79 @@ function searchByName(app: App, query: string, filter: QueryFilter, limit: numbe
 		const at = folded.indexOf(q);
 
 		if (at >= 0) {
-			// The query appears in the name as typed. That's what the user meant
-			// almost every time, so it outranks anything fuzzy regardless of what
-			// score the fuzzy matcher would have given it.
-			const tier = at === 0 ? TIER_PREFIX : isWordStart(folded, at) ? TIER_WORD : TIER_SUBSTRING;
-			// Within a tier: an earlier match, then a shorter name, wins.
-			ranked.push({
-				tier,
-				hit: { file, score: -at - displayName.length / 1000, matches: highlightRanges(displayName, [query]) },
+			// The query appears in the name as typed — what the user meant almost
+			// every time, whatever score the fuzzy matcher would have given it.
+			const rank =
+				at === 0
+					? RANK.NAME_PREFIX
+					: isWordStart(folded, at)
+						? RANK.NAME_WORD
+						: RANK.NAME_SUBSTRING;
+			hits.push({
+				file,
+				rank,
+				// Within a band: an earlier match, then a shorter name, wins.
+				score: -at - displayName.length / 1000,
+				matches: highlightRanges(displayName, [query]),
 			});
-			continue;
-		}
-
-		const onName = fuzzy(displayName);
-		if (onName) {
-			ranked.push({ tier: TIER_FUZZY, hit: { file, score: onName.score, matches: onName.matches } });
 			continue;
 		}
 
 		// Path matching is literal, never fuzzy. Fuzzy-matching a whole path lets
 		// the query's letters scatter across folder names and match nearly
 		// everything: searching "banán" turned up "Library/Recipes/Polévka z
-		// pečených batátů s cizrnou a kukuřicí" on b-a-n-a-n, ranked alongside
-		// the notes actually called "Banánové…". Inside a folder name the query
-		// still has to appear as typed.
+		// pečených batátů s cizrnou a kukuřicí" on b-a-n-a-n. Inside a folder name
+		// the query still has to appear as typed.
 		if (foldForMatch(file.path).includes(q)) {
-			ranked.push({ tier: TIER_PATH, hit: { file, score: 0 } });
+			hits.push({ file, rank: RANK.PATH, score: 0 });
+			continue;
+		}
+
+		const onName = fuzzy(displayName);
+		if (onName) {
+			hits.push({ file, rank: RANK.FUZZY_NAME, score: onName.score, matches: onName.matches });
 		}
 	}
 
-	ranked.sort(
-		(a, b) =>
-			b.tier - a.tier ||
-			b.hit.score - a.hit.score ||
-			a.hit.file.name.localeCompare(b.hit.file.name),
-	);
-	return ranked.slice(0, limit).map((r) => r.hit);
+	return sortByRank(hits).slice(0, limit);
 }
 
 /** Whether the match at `at` starts a word, so "nut" ranks higher in
  * "Coco nut" than in "Doughnut". */
 function isWordStart(folded: string, at: number): boolean {
 	return !/[a-z0-9]/.test(folded[at - 1] ?? "");
+}
+
+/** Order hits by rank band, then by score within the band, then by name so the
+ * list is stable between renders. Sorts in place and returns the same array. */
+export function sortByRank(hits: QueryHit[]): QueryHit[] {
+	return hits.sort(
+		(a, b) =>
+			(b.rank ?? 0) - (a.rank ?? 0) ||
+			b.score - a.score ||
+			a.file.name.localeCompare(b.file.name),
+	);
+}
+
+/**
+ * Fold body-content hits into the same order as the name/path hits they arrive
+ * after, instead of appending them below everything.
+ *
+ * Body search is async, so its results land after the instant name results are
+ * already on screen. Tacking them on the end put a note that plainly contains
+ * the word you typed below every note whose title the fuzzy matcher had merely
+ * scattered it across — the exact complaint that motivated the rank bands.
+ */
+export function mergeRanked(hits: QueryHit[], extra: QueryHit[], limit: number): QueryHit[] {
+	return sortByRank([...hits, ...extra]).slice(0, limit);
+}
+
+/** How many hits outrank a body match, and so genuinely occupy a result slot
+ * ahead of one. Fuzzy name hits sort *below* body hits, so they must not be
+ * counted — reserving slots for them is what starved body search of its budget
+ * and kept the good matches off the list entirely. */
+export function slotsAboveBody(hits: readonly QueryHit[]): number {
+	return hits.filter((h) => (h.rank ?? 0) > RANK.BODY).length;
 }
 
 function searchByTag(app: App, raw: string, limit: number): QueryHit[] {
@@ -346,6 +393,7 @@ export async function searchFileContents(
 		const { label, matches } = buildExcerpt(text, idx, needle.length);
 		hits.push({
 			file,
+			rank: RANK.BODY,
 			score: 0,
 			badge: { icon: "file-search", label, matches, excerpt: true },
 		});

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,5 +1,19 @@
 import { App, getAllTags, prepareFuzzySearch, TAbstractFile, TFile, TFolder } from "obsidian";
+import { buildExcerpt } from "./excerpt";
 import { groupForFile } from "./filetypes";
+
+/** Shown instead of the folder path to say *why* a file matched. */
+export interface QueryBadge {
+	icon: string;
+	label: string;
+	/** Char ranges into `label` to highlight — the part that actually matched. */
+	matches?: [number, number][];
+	/** True for a note-body excerpt. Excerpts are prose, so they're rendered as
+	 * muted context with the match picked out, not as a short accent-coloured
+	 * chip the way a tag or property badge is — a whole sentence in accent
+	 * colour competes with the file name it sits under. */
+	excerpt?: boolean;
+}
 
 /** A single query result. `matches` holds char ranges into the display name for
  * highlighting (name/path matches only). `badge` is shown instead of the folder
@@ -7,7 +21,7 @@ import { groupForFile } from "./filetypes";
 export interface QueryHit {
 	file: TAbstractFile;
 	score: number;
-	badge?: { icon: string; label: string };
+	badge?: QueryBadge;
 	matches?: [number, number][];
 }
 
@@ -32,8 +46,8 @@ export function queryMode(query: string): QueryMode {
 	return "name";
 }
 
-/** Stringify a frontmatter value for display/matching. */
-function formatPropertyValue(v: unknown): string {
+/** Stringify a frontmatter value for display/matching. Exported for tests. */
+export function formatPropertyValue(v: unknown): string {
 	if (v == null) return "";
 	if (typeof v === "string") return v;
 	if (typeof v === "number" || typeof v === "boolean" || typeof v === "bigint") return String(v);
@@ -194,21 +208,72 @@ function searchByProperty(app: App, key: string, rawValue: string, limit: number
 }
 
 /**
+ * Lower-cased note bodies, keyed by path. Re-lower-casing every note on every
+ * keystroke was by far the biggest cost of a content search — it allocates a
+ * second copy of the whole vault per query — so the result is kept around and
+ * a refined query ("meet" → "meeting") re-uses it. Bounded by total characters
+ * so a large vault can't grow it without limit, and keyed by mtime so an edited
+ * note is re-lowered instead of matched against stale text.
+ */
+const LOWER_CACHE_MAX_CHARS = 4_000_000;
+const lowerCache = new Map<string, { mtime: number; lower: string }>();
+let lowerCacheChars = 0;
+
+/** The lower-cased body of `path`, from the cache when it's still current for
+ * `mtime`, otherwise lowered now and cached (evicting the coldest entries when
+ * that pushes the cache over budget). Exported for tests. */
+export function lowerBody(path: string, mtime: number, text: string): string {
+	const cached = lowerCache.get(path);
+	if (cached && cached.mtime === mtime) {
+		// Re-insert so Map's insertion order stays least-recently-used first.
+		lowerCache.delete(path);
+		lowerCache.set(path, cached);
+		return cached.lower;
+	}
+	const lower = text.toLowerCase();
+	if (cached) lowerCacheChars -= cached.lower.length;
+	lowerCache.set(path, { mtime, lower });
+	lowerCacheChars += lower.length;
+	while (lowerCacheChars > LOWER_CACHE_MAX_CHARS) {
+		const oldest = lowerCache.keys().next();
+		// Never evict the entry we're about to return, even if it alone is over
+		// budget — otherwise a single huge note would loop forever.
+		if (oldest.done || oldest.value === path) break;
+		lowerCacheChars -= lowerCache.get(oldest.value)?.lower.length ?? 0;
+		lowerCache.delete(oldest.value);
+	}
+	return lower;
+}
+
+/** Drop every cached body. Called on plugin unload so the plugin doesn't leave
+ * a copy of the vault behind; also used to isolate tests. */
+export function clearContentSearchCache(): void {
+	lowerCache.clear();
+	lowerCacheChars = 0;
+}
+
+/**
  * Full-text search over note bodies. Only runs for plain (name) queries, reads
  * lazily via cachedRead, skips files already matched by name (`exclude`), and
  * stops once `limit` hits are found so a big vault isn't fully read. Each hit's
  * badge is a short snippet around the first match.
+ *
+ * `shouldStop` is polled once per file: a scan of a large vault outlives the
+ * keystroke that started it, so the caller uses this to abandon the walk as
+ * soon as the query it belongs to is stale — without it, every keystroke piles
+ * another full-vault read onto the ones already running.
  */
 export async function searchFileContents(
 	app: App,
 	query: string,
-	opts: { exclude: Set<string>; limit: number },
+	opts: { exclude: Set<string>; limit: number; shouldStop?: () => boolean },
 ): Promise<QueryHit[]> {
 	const needle = query.trim().toLowerCase();
-	if (!needle || queryMode(query) !== "name") return [];
+	if (!needle || opts.limit <= 0 || queryMode(query) !== "name") return [];
 
 	const hits: QueryHit[] = [];
 	for (const file of app.vault.getMarkdownFiles()) {
+		if (opts.shouldStop?.()) break;
 		if (opts.exclude.has(file.path)) continue;
 		let text: string;
 		try {
@@ -216,20 +281,15 @@ export async function searchFileContents(
 		} catch {
 			continue;
 		}
-		const idx = text.toLowerCase().indexOf(needle);
+		const idx = lowerBody(file.path, file.stat.mtime, text).indexOf(needle);
 		if (idx < 0) continue;
-		hits.push({ file, score: 0, badge: { icon: "file-search", label: snippet(text, idx, needle.length) } });
+		const { label, matches } = buildExcerpt(text, idx, needle.length);
+		hits.push({
+			file,
+			score: 0,
+			badge: { icon: "file-search", label, matches, excerpt: true },
+		});
 		if (hits.length >= opts.limit) break;
 	}
 	return hits;
-}
-
-/** A one-line snippet of `text` around [idx, idx+len], collapsed to single spaces. */
-function snippet(text: string, idx: number, len: number): string {
-	const start = Math.max(0, idx - 30);
-	const end = Math.min(text.length, idx + len + 40);
-	let s = text.slice(start, end).replace(/\s+/g, " ").trim();
-	if (start > 0) s = `…${s}`;
-	if (end < text.length) s = `${s}…`;
-	return s;
 }

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,5 +1,5 @@
 import { App, getAllTags, prepareFuzzySearch, TAbstractFile, TFile, TFolder } from "obsidian";
-import { buildExcerpt } from "./excerpt";
+import { buildExcerpt, foldForMatch, highlightRanges } from "./excerpt";
 import { groupForFile } from "./filetypes";
 
 /** Shown instead of the folder path to say *why* a file matched. */
@@ -57,6 +57,19 @@ export function formatPropertyValue(v: unknown): string {
 const NO_FILTER: QueryFilter = { includeFolders: true, includeFiles: true, groupId: null };
 
 /**
+ * Ranking bands for a name query, applied before any score. The point is that a
+ * literal hit in the file's own name always beats a fuzzy one, and a fuzzy hit
+ * always beats one that only landed somewhere in the folder path — the fuzzy
+ * matcher happily scatters a query's letters across a long string, so without
+ * bands its scores put near-random matches among the obvious ones.
+ */
+const TIER_PREFIX = 4;
+const TIER_WORD = 3;
+const TIER_SUBSTRING = 2;
+const TIER_FUZZY = 1;
+const TIER_PATH = 0;
+
+/**
  * Run a synchronous vault query (tag / property / name+path). Content search is
  * separate (see searchFileContents) because it needs async file reads.
  */
@@ -90,11 +103,20 @@ export function countQuery(app: App, query: string): number {
 
 function countByName(app: App, query: string): number {
 	const fuzzy = prepareFuzzySearch(query);
+	const q = foldForMatch(query);
 	let n = 0;
 	for (const f of app.vault.getAllLoadedFiles()) {
 		if (f instanceof TFolder && f.path === "/") continue;
 		const displayName = f instanceof TFile ? f.basename : f.name;
-		if (fuzzy(displayName) ?? fuzzy(f.path)) n++;
+		// Same predicate as searchByName, so a stat tile counts exactly what the
+		// search bar would list: name literal or fuzzy, path literal only.
+		if (
+			foldForMatch(displayName).includes(q) ||
+			fuzzy(displayName) ||
+			foldForMatch(f.path).includes(q)
+		) {
+			n++;
+		}
 	}
 	return n;
 }
@@ -150,22 +172,57 @@ function searchByName(app: App, query: string, filter: QueryFilter, limit: numbe
 	}
 
 	const fuzzy = prepareFuzzySearch(query);
-	const hits: QueryHit[] = [];
+	const q = foldForMatch(query);
+	const ranked: { hit: QueryHit; tier: number }[] = [];
+
 	for (const file of candidates) {
 		const displayName = file instanceof TFile ? file.basename : file.name;
-		const onName = fuzzy(displayName);
-		const match = onName ?? fuzzy(file.path);
-		if (match) {
-			hits.push({
-				file,
-				score: match.score,
-				// Highlight ranges only apply when the name itself matched.
-				matches: onName ? match.matches : undefined,
+		const folded = foldForMatch(displayName);
+		const at = folded.indexOf(q);
+
+		if (at >= 0) {
+			// The query appears in the name as typed. That's what the user meant
+			// almost every time, so it outranks anything fuzzy regardless of what
+			// score the fuzzy matcher would have given it.
+			const tier = at === 0 ? TIER_PREFIX : isWordStart(folded, at) ? TIER_WORD : TIER_SUBSTRING;
+			// Within a tier: an earlier match, then a shorter name, wins.
+			ranked.push({
+				tier,
+				hit: { file, score: -at - displayName.length / 1000, matches: highlightRanges(displayName, [query]) },
 			});
+			continue;
+		}
+
+		const onName = fuzzy(displayName);
+		if (onName) {
+			ranked.push({ tier: TIER_FUZZY, hit: { file, score: onName.score, matches: onName.matches } });
+			continue;
+		}
+
+		// Path matching is literal, never fuzzy. Fuzzy-matching a whole path lets
+		// the query's letters scatter across folder names and match nearly
+		// everything: searching "banán" turned up "Library/Recipes/Polévka z
+		// pečených batátů s cizrnou a kukuřicí" on b-a-n-a-n, ranked alongside
+		// the notes actually called "Banánové…". Inside a folder name the query
+		// still has to appear as typed.
+		if (foldForMatch(file.path).includes(q)) {
+			ranked.push({ tier: TIER_PATH, hit: { file, score: 0 } });
 		}
 	}
-	hits.sort((a, b) => b.score - a.score);
-	return hits.slice(0, limit);
+
+	ranked.sort(
+		(a, b) =>
+			b.tier - a.tier ||
+			b.hit.score - a.hit.score ||
+			a.hit.file.name.localeCompare(b.hit.file.name),
+	);
+	return ranked.slice(0, limit).map((r) => r.hit);
+}
+
+/** Whether the match at `at` starts a word, so "nut" ranks higher in
+ * "Coco nut" than in "Doughnut". */
+function isWordStart(folded: string, at: number): boolean {
+	return !/[a-z0-9]/.test(folded[at - 1] ?? "");
 }
 
 function searchByTag(app: App, raw: string, limit: number): QueryHit[] {
@@ -208,48 +265,49 @@ function searchByProperty(app: App, key: string, rawValue: string, limit: number
 }
 
 /**
- * Lower-cased note bodies, keyed by path. Re-lower-casing every note on every
- * keystroke was by far the biggest cost of a content search — it allocates a
- * second copy of the whole vault per query — so the result is kept around and
- * a refined query ("meet" → "meeting") re-uses it. Bounded by total characters
- * so a large vault can't grow it without limit, and keyed by mtime so an edited
- * note is re-lowered instead of matched against stale text.
+ * Folded note bodies (lower-cased, accents stripped, index-aligned with the
+ * original), keyed by path. Folding every note on every keystroke was by far the
+ * biggest cost of a content search — it allocates a second copy of the whole
+ * vault per query — so the result is kept around and a refined query ("meet" →
+ * "meeting") re-uses it. Bounded by total characters so a large vault can't grow
+ * it without limit, and keyed by mtime so an edited note is re-folded instead of
+ * matched against stale text.
  */
-const LOWER_CACHE_MAX_CHARS = 4_000_000;
-const lowerCache = new Map<string, { mtime: number; lower: string }>();
-let lowerCacheChars = 0;
+const BODY_CACHE_MAX_CHARS = 4_000_000;
+const bodyCache = new Map<string, { mtime: number; folded: string }>();
+let bodyCacheChars = 0;
 
-/** The lower-cased body of `path`, from the cache when it's still current for
- * `mtime`, otherwise lowered now and cached (evicting the coldest entries when
+/** The folded body of `path`, from the cache when it's still current for
+ * `mtime`, otherwise folded now and cached (evicting the coldest entries when
  * that pushes the cache over budget). Exported for tests. */
-export function lowerBody(path: string, mtime: number, text: string): string {
-	const cached = lowerCache.get(path);
+export function foldedBody(path: string, mtime: number, text: string): string {
+	const cached = bodyCache.get(path);
 	if (cached && cached.mtime === mtime) {
 		// Re-insert so Map's insertion order stays least-recently-used first.
-		lowerCache.delete(path);
-		lowerCache.set(path, cached);
-		return cached.lower;
+		bodyCache.delete(path);
+		bodyCache.set(path, cached);
+		return cached.folded;
 	}
-	const lower = text.toLowerCase();
-	if (cached) lowerCacheChars -= cached.lower.length;
-	lowerCache.set(path, { mtime, lower });
-	lowerCacheChars += lower.length;
-	while (lowerCacheChars > LOWER_CACHE_MAX_CHARS) {
-		const oldest = lowerCache.keys().next();
+	const folded = foldForMatch(text);
+	if (cached) bodyCacheChars -= cached.folded.length;
+	bodyCache.set(path, { mtime, folded });
+	bodyCacheChars += folded.length;
+	while (bodyCacheChars > BODY_CACHE_MAX_CHARS) {
+		const oldest = bodyCache.keys().next();
 		// Never evict the entry we're about to return, even if it alone is over
 		// budget — otherwise a single huge note would loop forever.
 		if (oldest.done || oldest.value === path) break;
-		lowerCacheChars -= lowerCache.get(oldest.value)?.lower.length ?? 0;
-		lowerCache.delete(oldest.value);
+		bodyCacheChars -= bodyCache.get(oldest.value)?.folded.length ?? 0;
+		bodyCache.delete(oldest.value);
 	}
-	return lower;
+	return folded;
 }
 
 /** Drop every cached body. Called on plugin unload so the plugin doesn't leave
  * a copy of the vault behind; also used to isolate tests. */
 export function clearContentSearchCache(): void {
-	lowerCache.clear();
-	lowerCacheChars = 0;
+	bodyCache.clear();
+	bodyCacheChars = 0;
 }
 
 /**
@@ -268,7 +326,9 @@ export async function searchFileContents(
 	query: string,
 	opts: { exclude: Set<string>; limit: number; shouldStop?: () => boolean },
 ): Promise<QueryHit[]> {
-	const needle = query.trim().toLowerCase();
+	// Folded, so a query typed without diacritics still finds the accented
+	// spelling — the same way name matching and Omnisearch behave.
+	const needle = foldForMatch(query.trim());
 	if (!needle || opts.limit <= 0 || queryMode(query) !== "name") return [];
 
 	const hits: QueryHit[] = [];
@@ -281,7 +341,7 @@ export async function searchFileContents(
 		} catch {
 			continue;
 		}
-		const idx = lowerBody(file.path, file.stat.mtime, text).indexOf(needle);
+		const idx = foldedBody(file.path, file.stat.mtime, text).indexOf(needle);
 		if (idx < 0) continue;
 		const { label, matches } = buildExcerpt(text, idx, needle.length);
 		hits.push({

--- a/src/search.ts
+++ b/src/search.ts
@@ -2,7 +2,14 @@ import { Command, Component, debounce, Platform, setIcon, TAbstractFile, TFile, 
 import type { HomeView } from "./view";
 import { applyFileIcon, fileIconOptions, resolveFileIcon, type ResolvedIcon } from "./fileicons";
 import { FILE_TYPE_GROUPS, FileTypeGroup, fileTypeLabel, groupForFile, OTHER_GROUP_ID } from "./filetypes";
-import { QueryFilter, QueryHit, runQuery, searchFileContents } from "./query";
+import {
+	mergeRanked,
+	QueryFilter,
+	QueryHit,
+	runQuery,
+	searchFileContents,
+	slotsAboveBody,
+} from "./query";
 import { isOmnisearchAvailable, searchWithOmnisearch } from "./omnisearch";
 import { openFile as openInLeaf } from "./opener";
 import { renderHighlighted } from "./ui";
@@ -275,14 +282,18 @@ export class SearchSection {
 			const exclude = new Set(hits.map((h) => h.file.path));
 			void searchFileContents(this.view.app, query, {
 				exclude,
-				limit: Math.max(0, MAX_RESULTS - hits.length),
+				// Budget against the hits that actually outrank a body match, not
+				// against every hit: fuzzy name matches sort below body hits, so
+				// letting them reserve slots is what left a page of scattered-letter
+				// titles with no room for the notes that contain the word.
+				limit: Math.max(0, MAX_RESULTS - slotsAboveBody(hits)),
 				// A vault-wide body scan easily outlives the keystroke that started
 				// it. Stop walking as soon as the query moves on, so typing doesn't
 				// leave several full-vault reads racing each other in the background.
 				shouldStop: () => gen !== this.generation,
 			}).then((extra) => {
 				if (gen !== this.generation || extra.length === 0) return;
-				this.renderFileRows([...hits, ...extra]);
+				this.renderFileRows(mergeRanked(hits, extra, MAX_RESULTS));
 			});
 		}
 	}

--- a/src/search.ts
+++ b/src/search.ts
@@ -5,6 +5,7 @@ import { FILE_TYPE_GROUPS, FileTypeGroup, fileTypeLabel, groupForFile, OTHER_GRO
 import { QueryFilter, QueryHit, runQuery, searchFileContents } from "./query";
 import { isOmnisearchAvailable, searchWithOmnisearch } from "./omnisearch";
 import { openFile as openInLeaf } from "./opener";
+import { renderHighlighted } from "./ui";
 import { t } from "./i18n";
 
 /** Recently opened-via-search files, kept in the vault's local storage (never
@@ -250,10 +251,13 @@ export class SearchSection {
 		// Omnisearch mode: hand plain queries to the Omnisearch plugin instead of
 		// the built-in engine. It only runs when the plugin is actually available;
 		// otherwise (and for tag/property syntax, which Omnisearch doesn't use) we
-		// fall through to the built-in search below.
+		// fall through to the built-in search below. The folders chip also stays
+		// with the built-in engine: Omnisearch indexes notes only, so routing a
+		// folder query to it would turn every search into "no matches".
 		if (
 			this.view.plugin.settings.searchEngine === "omnisearch" &&
 			query &&
+			filter.includeFiles &&
 			isOmnisearchAvailable(this.view.app)
 		) {
 			this.runOmnisearch(query, filter);
@@ -272,6 +276,10 @@ export class SearchSection {
 			void searchFileContents(this.view.app, query, {
 				exclude,
 				limit: Math.max(0, MAX_RESULTS - hits.length),
+				// A vault-wide body scan easily outlives the keystroke that started
+				// it. Stop walking as soon as the query moves on, so typing doesn't
+				// leave several full-vault reads racing each other in the background.
+				shouldStop: () => gen !== this.generation,
 			}).then((extra) => {
 				if (gen !== this.generation || extra.length === 0) return;
 				this.renderFileRows([...hits, ...extra]);
@@ -280,13 +288,18 @@ export class SearchSection {
 	}
 
 	/** Query Omnisearch and render its results. Guarded by generation so a slow
-	 * response can't overwrite a newer query the user has already moved on to. */
+	 * response can't overwrite a newer query the user has already moved on to.
+	 * A null result means Omnisearch couldn't answer (it was disabled mid-query,
+	 * or its API threw); rather than show an empty dropdown that reads as "no
+	 * such note", quietly answer with the built-in engine instead. */
 	private runOmnisearch(query: string, filter: QueryFilter): void {
 		const gen = this.generation;
 		void searchWithOmnisearch(this.view.app, query, { filter, limit: MAX_RESULTS }).then(
 			(hits) => {
 				if (gen !== this.generation) return;
-				this.renderFileRows(hits);
+				this.renderFileRows(
+					hits ?? runQuery(this.view.app, query, { filter, limit: MAX_RESULTS }),
+				);
 			},
 		);
 	}
@@ -345,11 +358,18 @@ export class SearchSection {
 			const row = this.newRow(i, hit.badge?.icon ?? resolveFileIcon(this.view.app, hit.file, icons));
 			const text = row.createDiv("hearth-result-text");
 			const name = hit.file instanceof TFile ? hit.file.basename : hit.file.name;
-			this.renderName(text.createDiv("hearth-result-name"), name || "/", hit.matches);
+			renderHighlighted(text.createDiv("hearth-result-name"), name || "/", hit.matches);
 			// Tag/property/body hits show what actually matched instead of the
 			// folder path — the badge makes the match reason visible.
 			if (hit.badge) {
-				text.createDiv({ cls: "hearth-result-badge", text: hit.badge.label });
+				const badge = text.createDiv("hearth-result-badge");
+				// A body excerpt is a sentence of context, not a short chip: it
+				// renders muted, wrapped over two lines, with only the matched
+				// words picked out. The row is flagged too so it can top-align —
+				// cheaper than a :has() rule on a list rebuilt every keystroke.
+				badge.toggleClass("is-excerpt", Boolean(hit.badge.excerpt));
+				row.toggleClass("has-excerpt", Boolean(hit.badge.excerpt));
+				renderHighlighted(badge, hit.badge.label, hit.badge.matches);
 			} else {
 				const parentPath = hit.file.parent?.path;
 				if (parentPath && parentPath !== "/") {
@@ -390,21 +410,6 @@ export class SearchSection {
 	private commitRow(row: HTMLElement, open: () => void): void {
 		row.addEventListener("click", open);
 		this.rows.push({ el: row, open });
-	}
-
-	/** Render `name` with matched character ranges wrapped in <mark>. */
-	private renderName(el: HTMLElement, name: string, matches?: [number, number][]): void {
-		if (!matches || matches.length === 0) {
-			el.setText(name);
-			return;
-		}
-		let cursor = 0;
-		for (const [start, end] of matches) {
-			if (start > cursor) el.appendText(name.slice(cursor, start));
-			el.createEl("mark", { cls: "hearth-result-mark", text: name.slice(start, end) });
-			cursor = end;
-		}
-		if (cursor < name.length) el.appendText(name.slice(cursor));
 	}
 
 	private showEmpty(text: string = t().search.noMatches): void {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2,6 +2,31 @@ import { App, Modal, Setting } from "obsidian";
 import { t } from "./i18n";
 
 /**
+ * Write `text` into `el` with the character ranges in `matches` wrapped in
+ * `<mark>`. Ranges must be sorted and non-overlapping (see `highlightRanges`).
+ * Shared by every search surface so a result name and a body excerpt pick out
+ * the match the same way.
+ */
+export function renderHighlighted(
+	el: HTMLElement,
+	text: string,
+	matches?: readonly [number, number][],
+): void {
+	if (!matches || matches.length === 0) {
+		el.setText(text);
+		return;
+	}
+	let cursor = 0;
+	for (const [start, end] of matches) {
+		if (start >= text.length) break;
+		if (start > cursor) el.appendText(text.slice(cursor, start));
+		el.createEl("mark", { cls: "hearth-result-mark", text: text.slice(start, end) });
+		cursor = Math.min(end, text.length);
+	}
+	if (cursor < text.length) el.appendText(text.slice(cursor));
+}
+
+/**
  * Make a non-button element behave like a button for keyboard and screen-reader
  * users: it gets a role, becomes focusable, and activates on Enter/Space in
  * addition to the click handler the caller wires up separately.

--- a/styles.css
+++ b/styles.css
@@ -376,6 +376,44 @@
 	text-overflow: ellipsis;
 }
 
+/* A note-body excerpt is a sentence of context, not a short tag chip. In accent
+ * colour a whole line of it shouts as loudly as the file name above it and the
+ * list turns into a wall of highlight, so the context recedes to muted and only
+ * the matched words keep the accent (via .hearth-result-mark). */
+.hearth-result-badge.is-excerpt {
+	color: var(--text-muted);
+	line-height: 1.35;
+	/* Two lines of context read far better than one clipped one, and the row
+	 * height stays predictable because the clamp caps it. */
+	white-space: normal;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	line-clamp: 2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	/* Excerpts come out of arbitrary note text — a long URL or path must not
+	 * push the row wider than the dropdown. */
+	overflow-wrap: anywhere;
+}
+
+/* Wrapping excerpts make rows different heights; align the icon to the first
+ * line rather than to the middle of a two-line block. */
+.hearth-result.has-excerpt {
+	align-items: flex-start;
+}
+
+.hearth-result.has-excerpt .hearth-result-icon {
+	margin-top: 2px;
+}
+
+/* Give the wrapped excerpt a definite width to clamp against, instead of
+ * letting it size to its (very long) content. */
+.hearth-result.has-excerpt .hearth-result-text {
+	flex: 1;
+	min-width: 0;
+}
+
 .hearth-search-empty {
 	padding: 12px;
 	text-align: center;
@@ -1620,6 +1658,37 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+/* A list row that carries a note-body excerpt stacks name over excerpt instead
+ * of putting them side by side — a sentence squeezed into the row's spare
+ * horizontal space is unreadable at any list width. */
+.hearth-list-text {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	min-width: 0;
+	flex: 1;
+}
+
+.hearth-list-excerpt {
+	font-size: 0.76rem;
+	line-height: 1.35;
+	color: var(--text-muted);
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	line-clamp: 2;
+	overflow: hidden;
+	overflow-wrap: anywhere;
+}
+
+.hearth-list-item.has-excerpt {
+	align-items: flex-start;
+}
+
+.hearth-list-item.has-excerpt .hearth-list-icon {
+	margin-top: 2px;
 }
 
 /* Bookmark groups (folders): collapsible, nesting to any depth like Obsidian's

--- a/test/excerpt.test.ts
+++ b/test/excerpt.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildExcerpt,
+	cleanExcerptText,
+	highlightRanges,
+	windowExcerpt,
+} from "../src/excerpt";
+
+/**
+ * The excerpt pipeline is entirely pure — text in, display line + highlight
+ * ranges out — so it's all covered here. These are the cases that made body
+ * search unreadable in practice: HTML-imported notes full of entities, YAML
+ * frontmatter lists, and long matches with no visible reason for the hit.
+ */
+
+/** Apply ranges to a string the way the DOM renderer does, so assertions can
+ * talk about what the user sees rather than about index pairs. */
+function marked(text: string, ranges?: readonly [number, number][]): string {
+	if (!ranges) return text;
+	let out = "";
+	let cursor = 0;
+	for (const [start, end] of ranges) {
+		out += text.slice(cursor, start) + "[" + text.slice(start, end) + "]";
+		cursor = end;
+	}
+	return out + text.slice(cursor);
+}
+
+describe("cleanExcerptText", () => {
+	it("collapses all whitespace onto one line", () => {
+		expect(cleanExcerptText("a\n\n  b\tc  ")).toBe("a b c");
+	});
+
+	it("treats <br> as the line break it stands for", () => {
+		// Not just a space: the heading and bullet markers after it have to be
+		// recognised as line-leading, or they survive into the excerpt.
+		expect(cleanExcerptText("E-mail: x@y.cz<br>## Notes<br>- item")).toBe(
+			"E-mail: x@y.cz Notes item",
+		);
+	});
+
+	it("strips other inline HTML", () => {
+		expect(cleanExcerptText("a <span class='x'>b</span> c")).toBe("a b c");
+	});
+
+	it("decodes the named entities that show up in imported notes", () => {
+		expect(cleanExcerptText("say &quot;hi&quot; &amp; bye")).toBe('say "hi" & bye');
+		expect(cleanExcerptText("it&#039;s fine")).toBe("it's fine");
+		expect(cleanExcerptText("&#x2014; dash")).toBe("— dash");
+	});
+
+	it("leaves an unknown or malformed entity alone rather than mangling it", () => {
+		expect(cleanExcerptText("100 &widget; &notreal;")).toBe("100 &widget; &notreal;");
+	});
+
+	it("does not decode an escaped tag into a real one", () => {
+		// &lt;div&gt; must survive as visible text: entities are decoded after
+		// tags are stripped precisely so this can't be eaten.
+		expect(cleanExcerptText("use &lt;div&gt; here")).toBe("use <div> here");
+	});
+
+	it("unquotes inline YAML/JSON string lists", () => {
+		expect(cleanExcerptText('participants: ["Novák Jan", "Šikl Tomáš"]')).toBe(
+			"participants: Novák Jan, Šikl Tomáš",
+		);
+	});
+
+	it("unquotes a list even when the window cut it in half", () => {
+		expect(cleanExcerptText('s: ["kooperace", "Šikl Tomáš", "Zatlouk')).toBe(
+			"s: kooperace, Šikl Tomáš, Zatlouk",
+		);
+	});
+
+	it("drops frontmatter fences, headings, quotes and bullets", () => {
+		expect(cleanExcerptText("---\n# Title\n> quoted\n- bullet")).toBe("Title quoted bullet");
+	});
+
+	it("keeps the readable half of links", () => {
+		expect(cleanExcerptText("see [[notes/2026|last week]] and [docs](https://x.dev)")).toBe(
+			"see last week and docs",
+		);
+		expect(cleanExcerptText("see [[Plain Note]]")).toBe("see Plain Note");
+	});
+
+	it("strips emphasis markers but keeps underscores in identifiers", () => {
+		expect(cleanExcerptText("**bold** and `code` and ~~gone~~")).toBe("bold and code and gone");
+		expect(cleanExcerptText("2026-08-05__external-poptavka")).toBe(
+			"2026-08-05__external-poptavka",
+		);
+	});
+});
+
+describe("highlightRanges", () => {
+	it("finds every occurrence, case-insensitively", () => {
+		expect(marked("Jan and jan", highlightRanges("Jan and jan", ["jan"]))).toBe(
+			"[Jan] and [jan]",
+		);
+	});
+
+	it("returns undefined when nothing matched", () => {
+		expect(highlightRanges("nothing here", ["zzz"])).toBeUndefined();
+		expect(highlightRanges("nothing here", [])).toBeUndefined();
+	});
+
+	it("ignores empty needles", () => {
+		expect(highlightRanges("abc", ["", "b"])).toEqual([[1, 2]]);
+	});
+
+	it("merges overlapping ranges so highlight spans never cross", () => {
+		// "ana" at 1..4 and "nan" at 2..5 overlap inside "banana" and fuse into
+		// one span; the trailing "a" is not part of either match.
+		expect(marked("banana", highlightRanges("banana", ["ana", "nan"]))).toBe("b[anan]a");
+	});
+
+	it("keeps separate matches separate", () => {
+		expect(marked("a b a", highlightRanges("a b a", ["a"]))).toBe("[a] b [a]");
+	});
+});
+
+describe("windowExcerpt", () => {
+	const long = Array.from({ length: 60 }, (_, i) => `word${i}`).join(" ");
+
+	it("keeps a short line whole and unmarked at both ends", () => {
+		const { label } = windowExcerpt("a short line about cats", "cats");
+		expect(label).toBe("a short line about cats");
+	});
+
+	it("centres a long line on the match and highlights it", () => {
+		const { label, matches } = windowExcerpt(long, "word40");
+		expect(label).toContain("word40");
+		expect(label.startsWith("…")).toBe(true);
+		expect(label.endsWith("…")).toBe(true);
+		expect(marked(label, matches)).toContain("[word40]");
+		// The far end of the text is well outside the kept window.
+		expect(label).not.toContain("word0 ");
+	});
+
+	it("honours the caller's note that text was already cut off", () => {
+		expect(windowExcerpt("middle bit", "middle", true, true).label).toBe("…middle bit…");
+	});
+
+	it("falls back to the head of the line when the needle isn't there", () => {
+		// Markup stripping can swallow a match that straddled a tag; the excerpt
+		// should still be readable, just not centred or highlighted.
+		const { label, matches } = windowExcerpt(long, "not-present");
+		expect(label.startsWith("word0")).toBe(true);
+		expect(matches).toBeUndefined();
+	});
+
+	it("does not highlight anything for an empty needle", () => {
+		expect(windowExcerpt("some text", "").matches).toBeUndefined();
+	});
+});
+
+describe("buildExcerpt", () => {
+	it("cleans, centres and highlights a real frontmatter hit", () => {
+		const note =
+			"---\nparticipants: [&quot;Moravec Stanislav&quot;, &quot;Hanik Jan&quot;]\n---\n\n# Zápis\n";
+		const idx = note.toLowerCase().indexOf("hanik jan");
+		const { label, matches } = buildExcerpt(note, idx, "hanik jan".length);
+		expect(label).toContain("participants: Moravec Stanislav, Hanik Jan");
+		expect(label).not.toContain("&quot;");
+		expect(marked(label, matches)).toContain("[Hanik Jan]");
+	});
+
+	it("cleans a body hit full of <br> markup", () => {
+		const note = "- E-mail: jan.hanik@x.cz<br>## Dohody a poznámky<br>- 2026-08-01 call";
+		const idx = note.indexOf("Dohody");
+		const { label } = buildExcerpt(note, idx, "Dohody".length);
+		expect(label).not.toContain("<br>");
+		expect(label).toContain("Dohody a poznámky");
+	});
+
+	it("marks an ellipsis on the side it actually trimmed", () => {
+		const long = `${"filler ".repeat(200)}needle${" filler".repeat(200)}`;
+		const idx = long.indexOf("needle");
+		const { label } = buildExcerpt(long, idx, "needle".length);
+		expect(label.startsWith("…")).toBe(true);
+		expect(label.endsWith("…")).toBe(true);
+	});
+
+	it("adds no ellipsis when the whole note fits", () => {
+		const { label } = buildExcerpt("just this line", 5, 4);
+		expect(label).toBe("just this line");
+	});
+});

--- a/test/excerpt.test.ts
+++ b/test/excerpt.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	buildExcerpt,
 	cleanExcerptText,
+	foldForMatch,
 	highlightRanges,
 	windowExcerpt,
 } from "../src/excerpt";
@@ -90,6 +91,43 @@ describe("cleanExcerptText", () => {
 	});
 });
 
+describe("foldForMatch", () => {
+	it("lower-cases and strips accents", () => {
+		expect(foldForMatch("Banánové")).toBe("bananove");
+		expect(foldForMatch("Příliš Žluťoučký KŮŇ")).toBe("prilis zlutoucky kun");
+		expect(foldForMatch("Crème Brûlée")).toBe("creme brulee");
+	});
+
+	it("leaves already-folded ASCII untouched", () => {
+		expect(foldForMatch("plain lower ascii 123")).toBe("plain lower ascii 123");
+	});
+
+	/**
+	 * The invariant the whole highlight path rests on: a range found in the
+	 * folded string is applied to the *original* string, so the two must line up
+	 * character for character. Any fold that would change the length is reverted.
+	 */
+	it("always returns a string the same length as its input", () => {
+		for (const s of [
+			"Banánové Snickersky",
+			"Straße", // ß upper-cases to SS
+			"İstanbul", // dotted capital I lower-cases to two code points
+			"Ω Ϋ ǅ",
+			"emoji 🍌 and a pair",
+			"é already decomposed",
+			"",
+		]) {
+			expect(foldForMatch(s)).toHaveLength(s.length);
+		}
+	});
+
+	it("keeps a character it cannot fold without changing length", () => {
+		// "ß" has no single-character lower/upper fold, so it survives as-is
+		// rather than becoming "ss" and shifting every index after it.
+		expect(foldForMatch("Straße")).toBe("straße");
+	});
+});
+
 describe("highlightRanges", () => {
 	it("finds every occurrence, case-insensitively", () => {
 		expect(marked("Jan and jan", highlightRanges("Jan and jan", ["jan"]))).toBe(
@@ -114,6 +152,25 @@ describe("highlightRanges", () => {
 
 	it("keeps separate matches separate", () => {
 		expect(marked("a b a", highlightRanges("a b a", ["a"]))).toBe("[a] b [a]");
+	});
+
+	it("ignores accents in both directions", () => {
+		// Omnisearch reports its matched words stemmed and unaccented, so an
+		// unaccented needle has to light up the accented spelling in the note...
+		expect(marked("Banánové Snickersky", highlightRanges("Banánové Snickersky", ["banan"]))).toBe(
+			"[Banán]ové Snickersky",
+		);
+		// ...and a needle typed *with* accents has to find text without them.
+		expect(marked("bananove", highlightRanges("bananove", ["Banán"]))).toBe("[banan]ove");
+	});
+
+	it("highlights the accented spelling at the right offset", () => {
+		// The range must land on the original characters, not on folded ones:
+		// "banánů" is 6 characters either way, so the slice stays aligned.
+		const text = "400 g banánů 40 g arašídového másla";
+		expect(marked(text, highlightRanges(text, ["bananu"]))).toBe(
+			"400 g [banánů] 40 g arašídového másla",
+		);
 	});
 });
 

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1,13 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { queryMode } from "../src/query";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	clearContentSearchCache,
+	formatPropertyValue,
+	lowerBody,
+	queryMode,
+} from "../src/query";
 
 /**
- * Only `queryMode` is pure — it classifies a raw search string into a mode
- * from its syntax alone. The actual result-gathering (runQuery, searchByName,
- * searchByTag, searchByProperty, searchFileContents) all need a live Obsidian
- * `App`/vault and the fuzzy matcher, so they are intentionally NOT tested here
- * (no Obsidian API mocks). This covers the syntax-dispatch logic that a
- * typecheck can't catch.
+ * Covers the pure parts of the query engine: mode dispatch, frontmatter value
+ * stringification and the lower-cased body cache. The result-gathering entry
+ * points (runQuery, searchByName, searchByTag, searchByProperty,
+ * searchFileContents) all need a live Obsidian `App`/vault and the fuzzy
+ * matcher, so they are intentionally NOT tested here (no Obsidian API mocks).
+ * Excerpt building lives in excerpt.test.ts.
  */
 
 describe("queryMode", () => {
@@ -44,5 +49,76 @@ describe("queryMode", () => {
 	// a name query. Documented here so the behaviour is explicit, not a surprise.
 	it('">command" is treated as a name query by queryMode', () => {
 		expect(queryMode(">open settings")).toBe("name");
+	});
+});
+
+describe("formatPropertyValue", () => {
+	it("passes strings through and stringifies scalars", () => {
+		expect(formatPropertyValue("active")).toBe("active");
+		expect(formatPropertyValue(3)).toBe("3");
+		expect(formatPropertyValue(true)).toBe("true");
+		expect(formatPropertyValue(10n)).toBe("10");
+	});
+
+	it("renders null and undefined as empty, not as the words", () => {
+		expect(formatPropertyValue(null)).toBe("");
+		expect(formatPropertyValue(undefined)).toBe("");
+	});
+
+	it("falls back to JSON for anything structured", () => {
+		expect(formatPropertyValue(["a", "b"])).toBe('["a","b"]');
+		expect(formatPropertyValue({ a: 1 })).toBe('{"a":1}');
+	});
+});
+
+describe("lowerBody", () => {
+	beforeEach(() => clearContentSearchCache());
+
+	it("lower-cases the text it is given", () => {
+		expect(lowerBody("a.md", 1, "Hello World")).toBe("hello world");
+	});
+
+	it("re-uses the cached value while the mtime is unchanged", () => {
+		expect(lowerBody("a.md", 1, "Original")).toBe("original");
+		// A stale read of the same unchanged file must not be re-lowered — the
+		// cache hit is the whole point, so the second argument is ignored.
+		expect(lowerBody("a.md", 1, "IGNORED")).toBe("original");
+	});
+
+	it("re-lowers once the file's mtime moves", () => {
+		expect(lowerBody("a.md", 1, "Original")).toBe("original");
+		expect(lowerBody("a.md", 2, "Edited")).toBe("edited");
+		// ...and the new value is what sticks.
+		expect(lowerBody("a.md", 2, "IGNORED")).toBe("edited");
+	});
+
+	it("keeps separate entries per path", () => {
+		lowerBody("a.md", 1, "Apple");
+		lowerBody("b.md", 1, "Banana");
+		expect(lowerBody("a.md", 1, "x")).toBe("apple");
+		expect(lowerBody("b.md", 1, "x")).toBe("banana");
+	});
+
+	it("clearContentSearchCache forgets everything", () => {
+		lowerBody("a.md", 1, "Original");
+		clearContentSearchCache();
+		expect(lowerBody("a.md", 1, "Replaced")).toBe("replaced");
+	});
+
+	it("evicts cold entries once the budget is exceeded", () => {
+		// Two notes just over the 4M-char budget between them: caching the second
+		// must push the first out rather than grow without bound.
+		const big = "X".repeat(2_500_000);
+		lowerBody("first.md", 1, big);
+		lowerBody("second.md", 1, big);
+		// "first.md" was evicted, so it re-lowers whatever it's handed now.
+		expect(lowerBody("first.md", 1, "Fresh")).toBe("fresh");
+		// "second.md" is still cached.
+		expect(lowerBody("second.md", 1, "IGNORED").length).toBe(big.length);
+	});
+
+	it("keeps a single over-budget note rather than looping to evict itself", () => {
+		const huge = "Y".repeat(5_000_000);
+		expect(lowerBody("huge.md", 1, huge).length).toBe(huge.length);
 	});
 });

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -2,13 +2,13 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
 	clearContentSearchCache,
 	formatPropertyValue,
-	lowerBody,
+	foldedBody,
 	queryMode,
 } from "../src/query";
 
 /**
  * Covers the pure parts of the query engine: mode dispatch, frontmatter value
- * stringification and the lower-cased body cache. The result-gathering entry
+ * stringification and the folded body cache. The result-gathering entry
  * points (runQuery, searchByName, searchByTag, searchByProperty,
  * searchFileContents) all need a live Obsidian `App`/vault and the fuzzy
  * matcher, so they are intentionally NOT tested here (no Obsidian API mocks).
@@ -71,54 +71,56 @@ describe("formatPropertyValue", () => {
 	});
 });
 
-describe("lowerBody", () => {
+describe("foldedBody", () => {
 	beforeEach(() => clearContentSearchCache());
 
-	it("lower-cases the text it is given", () => {
-		expect(lowerBody("a.md", 1, "Hello World")).toBe("hello world");
+	it("folds the text it is given", () => {
+		expect(foldedBody("a.md", 1, "Hello World")).toBe("hello world");
+		// Accents come off too, so a query typed without them still matches.
+		expect(foldedBody("b.md", 1, "Banánové Snickersky")).toBe("bananove snickersky");
 	});
 
 	it("re-uses the cached value while the mtime is unchanged", () => {
-		expect(lowerBody("a.md", 1, "Original")).toBe("original");
-		// A stale read of the same unchanged file must not be re-lowered — the
+		expect(foldedBody("a.md", 1, "Original")).toBe("original");
+		// A stale read of the same unchanged file must not be re-folded — the
 		// cache hit is the whole point, so the second argument is ignored.
-		expect(lowerBody("a.md", 1, "IGNORED")).toBe("original");
+		expect(foldedBody("a.md", 1, "IGNORED")).toBe("original");
 	});
 
-	it("re-lowers once the file's mtime moves", () => {
-		expect(lowerBody("a.md", 1, "Original")).toBe("original");
-		expect(lowerBody("a.md", 2, "Edited")).toBe("edited");
+	it("re-folds once the file's mtime moves", () => {
+		expect(foldedBody("a.md", 1, "Original")).toBe("original");
+		expect(foldedBody("a.md", 2, "Edited")).toBe("edited");
 		// ...and the new value is what sticks.
-		expect(lowerBody("a.md", 2, "IGNORED")).toBe("edited");
+		expect(foldedBody("a.md", 2, "IGNORED")).toBe("edited");
 	});
 
 	it("keeps separate entries per path", () => {
-		lowerBody("a.md", 1, "Apple");
-		lowerBody("b.md", 1, "Banana");
-		expect(lowerBody("a.md", 1, "x")).toBe("apple");
-		expect(lowerBody("b.md", 1, "x")).toBe("banana");
+		foldedBody("a.md", 1, "Apple");
+		foldedBody("b.md", 1, "Banana");
+		expect(foldedBody("a.md", 1, "x")).toBe("apple");
+		expect(foldedBody("b.md", 1, "x")).toBe("banana");
 	});
 
 	it("clearContentSearchCache forgets everything", () => {
-		lowerBody("a.md", 1, "Original");
+		foldedBody("a.md", 1, "Original");
 		clearContentSearchCache();
-		expect(lowerBody("a.md", 1, "Replaced")).toBe("replaced");
+		expect(foldedBody("a.md", 1, "Replaced")).toBe("replaced");
 	});
 
 	it("evicts cold entries once the budget is exceeded", () => {
 		// Two notes just over the 4M-char budget between them: caching the second
 		// must push the first out rather than grow without bound.
 		const big = "X".repeat(2_500_000);
-		lowerBody("first.md", 1, big);
-		lowerBody("second.md", 1, big);
+		foldedBody("first.md", 1, big);
+		foldedBody("second.md", 1, big);
 		// "first.md" was evicted, so it re-lowers whatever it's handed now.
-		expect(lowerBody("first.md", 1, "Fresh")).toBe("fresh");
+		expect(foldedBody("first.md", 1, "Fresh")).toBe("fresh");
 		// "second.md" is still cached.
-		expect(lowerBody("second.md", 1, "IGNORED").length).toBe(big.length);
+		expect(foldedBody("second.md", 1, "IGNORED").length).toBe(big.length);
 	});
 
 	it("keeps a single over-budget note rather than looping to evict itself", () => {
 		const huge = "Y".repeat(5_000_000);
-		expect(lowerBody("huge.md", 1, huge).length).toBe(huge.length);
+		expect(foldedBody("huge.md", 1, huge).length).toBe(huge.length);
 	});
 });

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import type { TAbstractFile } from "obsidian";
 import {
 	clearContentSearchCache,
 	formatPropertyValue,
 	foldedBody,
+	mergeRanked,
 	queryMode,
+	RANK,
+	slotsAboveBody,
+	sortByRank,
+	type QueryHit,
 } from "../src/query";
 
 /**
@@ -68,6 +74,97 @@ describe("formatPropertyValue", () => {
 	it("falls back to JSON for anything structured", () => {
 		expect(formatPropertyValue(["a", "b"])).toBe('["a","b"]');
 		expect(formatPropertyValue({ a: 1 })).toBe('{"a":1}');
+	});
+});
+
+/** A stand-in hit; only `file.name`, `rank` and `score` affect ordering. */
+function hit(name: string, rank: number, score = 0): QueryHit {
+	return { file: { name, path: name } as TAbstractFile, rank, score };
+}
+const names = (hits: QueryHit[]) => hits.map((h) => h.file.name);
+
+describe("result ranking", () => {
+	it("puts every literal match above any fuzzy one", () => {
+		// The bug this exists for: searching "banán" scattered b-a-n-a-n across
+		// "Pohanákový chléb s avokádovo-vaječnou pomazánkou" and ranked that title
+		// above notes whose body plainly says "banánu".
+		const ranked = sortByRank([
+			hit("Pohanákový chléb", RANK.FUZZY_NAME, 10),
+			hit("Snídaně do skleničky", RANK.BODY),
+			hit("Banánové Snickersky", RANK.NAME_PREFIX),
+		]);
+		expect(names(ranked)).toEqual([
+			"Banánové Snickersky",
+			"Snídaně do skleničky",
+			"Pohanákový chléb",
+		]);
+	});
+
+	it("orders the literal bands name, path, body", () => {
+		const ranked = sortByRank([
+			hit("body", RANK.BODY),
+			hit("path", RANK.PATH),
+			hit("substring", RANK.NAME_SUBSTRING),
+			hit("word", RANK.NAME_WORD),
+			hit("prefix", RANK.NAME_PREFIX),
+		]);
+		expect(names(ranked)).toEqual(["prefix", "word", "substring", "path", "body"]);
+	});
+
+	it("a high fuzzy score still cannot beat a low-scoring literal match", () => {
+		const ranked = sortByRank([hit("fuzzy", RANK.FUZZY_NAME, 999), hit("literal", RANK.BODY, -999)]);
+		expect(names(ranked)).toEqual(["literal", "fuzzy"]);
+	});
+
+	it("falls back to score, then name, within a band", () => {
+		const ranked = sortByRank([
+			hit("b", RANK.NAME_WORD, 1),
+			hit("a", RANK.NAME_WORD, 1),
+			hit("c", RANK.NAME_WORD, 5),
+		]);
+		expect(names(ranked)).toEqual(["c", "a", "b"]);
+	});
+
+	it("treats a hit with no rank as the lowest band", () => {
+		const unranked: QueryHit = { file: { name: "x", path: "x" } as TAbstractFile, score: 0 };
+		expect(names(sortByRank([unranked, hit("body", RANK.BODY)]))).toEqual(["body", "x"]);
+	});
+});
+
+describe("mergeRanked", () => {
+	it("interleaves late body hits instead of appending them", () => {
+		const nameHits = [hit("Banánové", RANK.NAME_PREFIX), hit("Pohanákový", RANK.FUZZY_NAME, 10)];
+		const bodyHits = [hit("Snídaně", RANK.BODY)];
+		expect(names(mergeRanked(nameHits, bodyHits, 10))).toEqual([
+			"Banánové",
+			"Snídaně",
+			"Pohanákový",
+		]);
+	});
+
+	it("caps the merged list at the limit", () => {
+		const merged = mergeRanked([hit("a", RANK.NAME_PREFIX)], [hit("b", RANK.BODY)], 1);
+		expect(names(merged)).toEqual(["a"]);
+	});
+});
+
+describe("slotsAboveBody", () => {
+	it("counts only the hits that outrank a body match", () => {
+		expect(
+			slotsAboveBody([
+				hit("name", RANK.NAME_PREFIX),
+				hit("path", RANK.PATH),
+				hit("body", RANK.BODY),
+				hit("fuzzy", RANK.FUZZY_NAME),
+			]),
+		).toBe(2);
+	});
+
+	it("reserves nothing for a page of pure fuzzy hits", () => {
+		// This is the point: 40 scattered-letter titles must not starve body
+		// search of its budget, or the good matches never get looked for.
+		const fuzzy = Array.from({ length: 40 }, (_, i) => hit(`f${i}`, RANK.FUZZY_NAME));
+		expect(slotsAboveBody(fuzzy)).toBe(0);
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes from a review of the search engine, the search bar and the Omnisearch adapter. Two themes: **body-hit excerpts were unreadable**, and **the search path had several correctness/cost problems**.

### Readable excerpts (the visible one)

A note-body hit showed the raw slice of file it was cut from. On notes imported from HTML or carrying frontmatter that meant a wall of `&quot;`, `&#039;` and `<br>` with `["Novák Jan", "Šikl Tomáš"]` quoting through the middle of it — and because the badge was accent-coloured, the whole line shouted as loudly as the file name above it.

New `src/excerpt.ts` owns turning raw note text into one readable line:

- strips inline HTML (`<br>` becomes a real line break first, so heading and bullet markers after it are recognised as line-leading)
- decodes HTML entities — after tag stripping, so an escaped `&lt;div&gt;` survives as visible text
- drops frontmatter fences and heading / quote / bullet markers
- reduces `[[wikilinks]]` and `[md](links)` to the text a human reads
- unquotes inline YAML/JSON string lists, including ones the window cut in half
- narrows to a window around the match, cutting on word boundaries, and reports where the match landed

The excerpt then renders as **muted context with only the matched words highlighted**, wrapped over two lines instead of clipped to one. Omnisearch results go through the same pipeline and highlight the words Omnisearch reports matching, so both engines read the same way. Its duplicate `matchRanges` is gone, replaced by the shared `highlightRanges`; result-name highlighting moved to a shared `renderHighlighted` in `ui.ts`.

### Search path fixes

- **Stale scans are abandoned.** `searchFileContents` takes a `shouldStop` callback. The existing generation guard only suppressed *rendering*, so a few keystrokes left several full-vault reads racing each other in the background.
- **Lower-cased bodies are cached** (bounded by total characters, keyed by mtime, cleared on unload) instead of allocating a lower-cased copy of the whole vault on every query.
- **`limit <= 0` returns early** instead of scanning and then overshooting by one hit past the caller's cap.
- **Folder-filtered queries stay with the built-in engine.** Omnisearch indexes notes only, so with it selected the folders chip answered "no matches" for every query.
- **Omnisearch failure falls back** instead of showing an empty state. `searchWithOmnisearch` resolves to `null` rather than `[]` when it can't answer at all, so a broken index reads differently from a genuine zero-result search.
- **The saved-search card searches files only** — folder hits rendered as clickable rows that did nothing — and tops up to its own limit rather than asking for a second full `limit`.

## Related issue

None — review-driven cleanup, no behaviour discussed in an issue.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

`npm test` (393 passed), `npm run typecheck` and `npm run lint` (0 errors) all pass. Not vault-tested from this environment — the excerpt pipeline and body cache are covered by new unit tests, but the CSS changes (muted two-line excerpts, top-aligned rows) want a look in a real vault.

## Tests

New `test/excerpt.test.ts` covers the whole excerpt pipeline, including the exact frontmatter and `<br>` cases from the report. `test/query.test.ts` gains coverage for the body cache (hit, mtime invalidation, eviction, over-budget single note) and the frontmatter-value formatter — neither had any.

## Not included

Deliberately left out as behaviour changes worth deciding separately: making body search multi-term/fuzzy rather than literal substring, enabling body search while a filter chip is active, and making command mode fuzzy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CR5Fgp78uTuea41Z67k2rZ)_