### PR TITLE
feat(cards): add a Datacore card alongside Dataview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
+- **Datacore card.** Dataview is winding down in favour of
+  [Datacore](https://github.com/blacksmithgu/datacore), so Hearth now has a card
+  for it, in the same shape as the Dataview card: pick a query type, write a
+  query, get a live result. **Query** is the no-code mode — type a Datacore
+  query like `@page and #project` and the card renders the matches as a list of
+  links that re-runs itself whenever the index changes, with optional paging.
+  The other four modes run the text as a Datacore script (JSX, JS, TSX or TS),
+  exactly as inside a `datacorejsx` block, so anything you can draw in a note —
+  tables, cards, interactive views — you can put on the dashboard. A query with
+  a syntax error says so on the card instead of failing silently, and the card
+  only appears in the "Add card" picker while Datacore is enabled. Datacore also
+  joins the Integrations catalogue.
 - **Every integration in one place.** **Settings → Integrations** now opens with
   a complete catalogue of everything Hearth works with — community plugins
   (Omnisearch, TaskNotes, Dataview, Iconic, Iconize, Excalidraw), Obsidian's own

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Add cards from the **Arrange** toolbar; configure each one from the card itself
 - **Dataview** *(requires [Dataview](https://github.com/blacksmithgu/obsidian-dataview))*
   — run a DQL or DataviewJS query and render it through Dataview's own,
   live-updating renderers, with resizable table columns.
+- **Datacore** *(requires [Datacore](https://github.com/blacksmithgu/datacore))*
+  — the same for Dataview's successor: write a Datacore query and get a live
+  list of what it matches, or a full JS/JSX/TS/TSX script rendered by
+  Datacore's own views.
 
 **Tasks**
 

--- a/src/cardbodies.ts
+++ b/src/cardbodies.ts
@@ -143,47 +143,71 @@ function stripFrontmatter(text: string): string {
  * (like a dashboard embed) do nothing on their own. A delegated click listener
  * on the stable host handles internal (wiki) links, external URLs and tags —
  * and keeps working as the content node is re-rendered underneath it.
+ *
+ * `capture` moves the listener to the capture phase and stops the event once a
+ * link is handled. Needed when the content's own renderer puts a click handler
+ * on the anchor itself: Datacore's `dc.Link` opens the note in the active tab,
+ * which would otherwise run *before* this one and open the note twice, once
+ * ignoring the user's "open notes in" setting. Left off by default so
+ * Obsidian-rendered content (which has no such handler) behaves exactly as it
+ * always has.
  */
-export function wireMarkdownLinks(view: HomeView, host: HTMLElement, sourcePath: string): void {
-	host.addEventListener("click", (evt) => {
-		const anchor = (evt.target as HTMLElement | null)?.closest("a");
-		if (!(anchor instanceof HTMLAnchorElement) || !host.contains(anchor)) return;
+export function wireMarkdownLinks(
+	view: HomeView,
+	host: HTMLElement,
+	sourcePath: string,
+	opts: { capture?: boolean } = {},
+): void {
+	host.addEventListener(
+		"click",
+		(evt) => {
+			const anchor = (evt.target as HTMLElement | null)?.closest("a");
+			if (!(anchor instanceof HTMLAnchorElement) || !host.contains(anchor)) return;
 
-		if (anchor.classList.contains("external-link")) {
-			const href = anchor.getAttribute("href");
-			if (href) {
+			/** Take the click for Hearth: never the browser's default, and — in
+			 * capture mode — never the anchor's own handler either. */
+			const claim = () => {
 				evt.preventDefault();
-				window.open(href, "_blank");
-			}
-			return;
-		}
+				if (opts.capture) evt.stopPropagation();
+			};
 
-		if (anchor.classList.contains("tag")) {
-			const tag = anchor.getAttribute("href");
-			if (tag) {
-				evt.preventDefault();
-				const search = view.app.internalPlugins.getPluginById("global-search");
-				const instance = search?.instance as
-					| { openGlobalSearch?: (query: string) => void }
-					| undefined;
-				instance?.openGlobalSearch?.(`tag:${tag}`);
+			if (anchor.classList.contains("external-link")) {
+				const href = anchor.getAttribute("href");
+				if (href) {
+					claim();
+					window.open(href, "_blank");
+				}
+				return;
 			}
-			return;
-		}
 
-		// Not gated on the `internal-link` class: an embedded Bases view (and
-		// other plugin-rendered content) draws note links without it, and those
-		// clicks would otherwise fall through to Obsidian's own handler, which
-		// always takes over the tab the click came from — the Hearth tab (#106).
-		const linktext = internalLinkText(
-			anchor.getAttribute("data-href"),
-			anchor.getAttribute("href"),
-		);
-		if (linktext) {
-			evt.preventDefault();
-			void openLink(view, linktext, sourcePath, "link", evt);
-		}
-	});
+			if (anchor.classList.contains("tag")) {
+				const tag = anchor.getAttribute("href");
+				if (tag) {
+					claim();
+					const search = view.app.internalPlugins.getPluginById("global-search");
+					const instance = search?.instance as
+						| { openGlobalSearch?: (query: string) => void }
+						| undefined;
+					instance?.openGlobalSearch?.(`tag:${tag}`);
+				}
+				return;
+			}
+
+			// Not gated on the `internal-link` class: an embedded Bases view (and
+			// other plugin-rendered content) draws note links without it, and those
+			// clicks would otherwise fall through to Obsidian's own handler, which
+			// always takes over the tab the click came from — the Hearth tab (#106).
+			const linktext = internalLinkText(
+				anchor.getAttribute("data-href"),
+				anchor.getAttribute("href"),
+			);
+			if (linktext) {
+				claim();
+				void openLink(view, linktext, sourcePath, "link", evt);
+			}
+		},
+		{ capture: opts.capture === true },
+	);
 }
 
 

--- a/src/cards/datacore.ts
+++ b/src/cards/datacore.ts
@@ -1,0 +1,172 @@
+import { Component, Setting } from "obsidian";
+import { emptyState, wireMarkdownLinks } from "../cardbodies";
+import {
+	datacoreQueryError,
+	datacoreQueryScript,
+	getDatacoreApi,
+	isDatacoreAvailable,
+	runDatacoreScript,
+	type DatacoreLanguage,
+} from "../datacore";
+import { t } from "../i18n";
+import { type DashboardCard } from "../types";
+import { type HomeView } from "../view";
+import { type CardDefinition, type CardEditorContext } from "./definition";
+
+
+// ---- Datacore query -----------------------------------------------------
+
+/** A card that renders a Datacore query or script through Datacore's own
+ * Preact renderer, so tables, lists and cards look exactly as they do in a
+ * note. Datacore is the successor to Dataview, and this card is the successor
+ * to Hearth's Dataview card: same shape (a query, a language, a live result),
+ * different engine.
+ *
+ * Depends on the Datacore community plugin — the "Add card" picker only offers
+ * this card when Datacore is installed, and the card shows a friendly prompt if
+ * Datacore is later disabled. Datacore attaches its own render child to
+ * `component` and its hooks subscribe to the index, so results update live as
+ * the vault changes without Hearth re-running anything. */
+export function renderDatacore(
+	view: HomeView,
+	card: DashboardCard,
+	body: HTMLElement,
+	component: Component,
+): void {
+	const api = getDatacoreApi(view.app);
+	if (!api) {
+		emptyState(body, "database", t().cards.empty.datacoreEnable);
+		return;
+	}
+	const cfg = card.datacore ?? {};
+	const query = (cfg.query ?? "").trim();
+	if (!query) {
+		emptyState(body, "code", t().cards.empty.datacoreNoQuery);
+		return;
+	}
+
+	const language: DatacoreLanguage = cfg.language ?? "query";
+	// The dashboard has no "current note", so scripts run with an empty origin
+	// path: global queries work fully, but `dc.useCurrentFile()` and friends have
+	// no meaningful current file to resolve to.
+	const origin = "";
+	let source = query;
+	if (language === "query") {
+		const parseError = datacoreQueryError(api, query);
+		if (parseError) {
+			emptyState(body, "alert-triangle", parseError);
+			return;
+		}
+		source = datacoreQueryScript(query, cfg.pageSize);
+	}
+
+	const host = body.createDiv("hearth-datacore");
+	try {
+		runDatacoreScript(
+			api,
+			language === "query" ? "jsx" : language,
+			source,
+			host,
+			component,
+			origin,
+		);
+	} catch (err) {
+		// Datacore catches script errors itself and renders them inline; this
+		// guards the call into it, so a Datacore version mismatch shows as a
+		// readable message instead of taking down the dashboard render.
+		host.empty();
+		const message = err instanceof Error ? err.message : String(err);
+		emptyState(host, "alert-triangle", message);
+		return;
+	}
+	// Datacore renders internal links as anchors; wire them up so they open like
+	// links elsewhere on the dashboard. Captured, because Datacore's own `dc.Link`
+	// carries a click handler that opens the note in the active tab — the Hearth
+	// tab — so it has to be intercepted before it runs rather than after (#106).
+	wireMarkdownLinks(view, host, origin, { capture: true });
+}
+
+
+export function datacoreEditor(ctx: CardEditorContext, containerEl: HTMLElement): void {
+	const cfg = (ctx.card.datacore ??= {});
+	const language: DatacoreLanguage = cfg.language ?? "query";
+	new Setting(containerEl)
+		.setName(t().editors.datacore.language)
+		.setDesc(t().editors.datacore.languageDesc)
+		.addDropdown((d) => {
+			d.addOption("query", t().editors.datacore.languageQuery);
+			d.addOption("jsx", t().editors.datacore.languageJsx);
+			d.addOption("js", t().editors.datacore.languageJs);
+			d.addOption("tsx", t().editors.datacore.languageTsx);
+			d.addOption("ts", t().editors.datacore.languageTs);
+			d.setValue(language).onChange((v) => {
+				// "query" is the default, so it's stored as absent — the same way
+				// every other card writes its default back as undefined.
+				cfg.language = v === "query" ? undefined : (v as DatacoreLanguage);
+				ctx.opts.save();
+				ctx.opts.rerender();
+				ctx.requestRender();
+			});
+		});
+
+	const isQuery = language === "query";
+	const query = new Setting(containerEl)
+		.setName(isQuery ? t().editors.datacore.query : t().editors.datacore.script)
+		.setDesc(
+			isQuery ? t().editors.datacore.queryDesc : t().editors.datacore.scriptDesc,
+		);
+	query.addTextArea((txt) => {
+		txt
+			.setPlaceholder(
+				isQuery
+					? t().editors.datacore.queryPlaceholder
+					: t().editors.datacore.scriptPlaceholder,
+			)
+			.setValue(cfg.query ?? "")
+			.onChange((v) => {
+				cfg.query = v;
+				ctx.opts.save();
+			});
+		txt.inputEl.rows = 6;
+		txt.inputEl.addClass("hearth-datacore-input");
+	});
+	query.settingEl.addClass("hearth-setting-stacked");
+
+	// Paging only applies to the list Hearth generates for a query; a script
+	// draws its own view and decides its own paging.
+	if (!isQuery) return;
+	const paging = new Setting(containerEl)
+		.setName(t().editors.datacore.pageSize)
+		.setDesc(t().editors.datacore.pageSizeDesc);
+	paging.addSlider((s) => {
+		s.setLimits(0, 100, 5)
+			.setValue(cfg.pageSize ?? 0)
+			.setDynamicTooltip()
+			.onChange((v) => {
+				cfg.pageSize = v > 0 ? v : undefined;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			});
+	});
+}
+
+/** A Datacore query or script, rendered through the Datacore plugin. Gated on
+ * that plugin. */
+export const datacoreCard: CardDefinition<"datacore"> = {
+	kind: "datacore",
+	templates: [
+		{
+			id: "datacore",
+			name: "Datacore query",
+			icon: "database-zap",
+			build: () => ({ kind: "datacore", title: "Datacore", datacore: {}, w: 6, h: 4 }),
+			available: (app) => isDatacoreAvailable(app),
+		},
+	],
+	render: (view, card, body, component) => renderDatacore(view, card, body, component),
+	renderEditor: (container, ctx) => datacoreEditor(ctx, container),
+	cloneConfig: (source, copy) => {
+		if (source.datacore) copy.datacore = { ...source.datacore };
+	},
+	liveness: { mode: "static" },
+};

--- a/src/cards/datacore.ts
+++ b/src/cards/datacore.ts
@@ -1,4 +1,4 @@
-import { Component, Setting } from "obsidian";
+import { Component, setIcon, Setting } from "obsidian";
 import { emptyState, wireMarkdownLinks } from "../cardbodies";
 import {
 	datacoreQueryError,
@@ -54,7 +54,7 @@ export function renderDatacore(
 	if (language === "query") {
 		const parseError = datacoreQueryError(api, query);
 		if (parseError) {
-			emptyState(body, "alert-triangle", parseError);
+			datacoreError(body, queryErrorTitle(query), parseError);
 			return;
 		}
 		source = datacoreQueryScript(query, cfg.pageSize);
@@ -76,7 +76,7 @@ export function renderDatacore(
 		// readable message instead of taking down the dashboard render.
 		host.empty();
 		const message = err instanceof Error ? err.message : String(err);
-		emptyState(host, "alert-triangle", message);
+		datacoreError(host, t().cards.empty.datacoreFailed, message);
 		return;
 	}
 	// Datacore renders internal links as anchors; wire them up so they open like
@@ -84,6 +84,37 @@ export function renderDatacore(
 	// carries a click handler that opens the note in the active tab — the Hearth
 	// tab — so it has to be intercepted before it runs rather than after (#106).
 	wireMarkdownLinks(view, host, origin, { capture: true });
+}
+
+
+/**
+ * Show a failed query/script: a one-line headline plus the engine's own message
+ * verbatim, in a monospaced block.
+ *
+ * Not `emptyState`, which centres a single line of proportional text: Datacore's
+ * parse errors are parsimmon's, and those are *drawings* — a numbered echo of
+ * the query with a caret under the offending column. Reflowed into centred prose
+ * (as the first cut did) the caret points at nothing and the message reads as
+ * noise, which is exactly the moment a user most needs to read it.
+ */
+function datacoreError(body: HTMLElement, title: string, detail: string): void {
+	const wrap = body.createDiv("hearth-datacore-error");
+	const head = wrap.createDiv("hearth-datacore-error-head");
+	setIcon(head.createSpan("hearth-datacore-error-icon"), "alert-triangle");
+	head.createSpan({ cls: "hearth-datacore-error-title", text: title });
+	wrap.createEl("pre", { cls: "hearth-datacore-error-detail", text: detail });
+}
+
+
+/** The headline for a query that didn't parse. A multi-line query gets a more
+ * specific one: a card runs exactly one query, and pasting a block of several
+ * (or a query with a trailing note about what it does) is the overwhelmingly
+ * common way to land here — the parse error underneath explains the *symptom*
+ * ("expected 'and', 'or', EOF") without ever naming that cause. */
+function queryErrorTitle(query: string): string {
+	return query.includes("\n")
+		? t().cards.empty.datacoreOneQuery
+		: t().cards.empty.datacoreBadQuery;
 }
 
 

--- a/src/cards/datacore.ts
+++ b/src/cards/datacore.ts
@@ -106,11 +106,17 @@ function datacoreError(body: HTMLElement, title: string, detail: string): void {
 }
 
 
-/** The headline for a query that didn't parse. A multi-line query gets a more
- * specific one: a card runs exactly one query, and pasting a block of several
- * (or a query with a trailing note about what it does) is the overwhelmingly
- * common way to land here — the parse error underneath explains the *symptom*
- * ("expected 'and', 'or', EOF") without ever naming that cause. */
+/** The headline for a query that didn't parse. One that spans lines gets a more
+ * specific one: pasting a block of several queries (or a query with a trailing
+ * note about what it does) is the overwhelmingly common way to land here, and
+ * the parse error underneath only ever explains the *symptom* ("expected 'and',
+ * 'or', EOF") without naming that cause.
+ *
+ * Spanning lines is not itself the fault — Datacore's parser treats a newline
+ * as ordinary whitespace, so one query may be wrapped across as many lines as
+ * you like. That's why this only refines the headline of a failure rather than
+ * rejecting multi-line input, and why it says "looks like several" instead of
+ * claiming the line count is the problem. */
 function queryErrorTitle(query: string): string {
 	return query.includes("\n")
 		? t().cards.empty.datacoreOneQuery

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -19,6 +19,7 @@ import { searchCard } from "./search";
 import { heatmapCard } from "./heatmap";
 import { calculatorCard } from "./calculator";
 import { dataviewCard } from "./dataview";
+import { datacoreCard } from "./datacore";
 import { rssCard } from "./rss";
 import { jiraCard } from "./jira";
 import { leafCard } from "./leaf";
@@ -55,6 +56,7 @@ export const CARD_DEFINITIONS: { [K in CardKind]: CardDefinition<K> } = {
 	heatmap: heatmapCard,
 	calculator: calculatorCard,
 	dataview: dataviewCard,
+	datacore: datacoreCard,
 	rss: rssCard,
 	jira: jiraCard,
 	leaf: leafCard,
@@ -113,6 +115,7 @@ export const TEMPLATE_MENU_ORDER: string[] = [
 	"text",
 	"calculator",
 	"dataview",
+	"datacore",
 	"rss",
 	"jira",
 	"leaf",

--- a/src/datacore.ts
+++ b/src/datacore.ts
@@ -1,0 +1,175 @@
+import type { App, Component, MarkdownRenderChild } from "obsidian";
+
+/** The community-plugin id Datacore registers itself under. */
+export const DATACORE_PLUGIN_ID = "datacore";
+
+/** The script dialects Datacore can execute, matching its four codeblock
+ * languages (`datacorejs`, `datacorejsx`, `datacorets`, `datacoretsx`). */
+export type DatacoreScriptLanguage = "js" | "jsx" | "ts" | "tsx";
+
+/** How a Datacore card's `query` text is interpreted.
+ *
+ * - `"query"` — a Datacore query (`@page and #project`), rendered by Hearth as
+ *   a link list. This is the no-code option, the closest thing Datacore has to
+ *   Dataview's DQL: Datacore itself ships no query-only codeblock, so Hearth
+ *   wraps the query in a small JSX view (see {@link datacoreQueryScript}).
+ * - the four script dialects — the text is a Datacore script, exactly as inside
+ *   the matching codeblock. */
+export type DatacoreLanguage = "query" | DatacoreScriptLanguage;
+
+/** Every accepted `language` value, in the order the card's editor offers them.
+ * Doubles as the allow-list an imported layout is validated against. */
+export const DATACORE_LANGUAGES: readonly DatacoreLanguage[] = [
+	"query",
+	"jsx",
+	"js",
+	"tsx",
+	"ts",
+];
+
+/** Datacore's monadic result: `{ successful: true, value }` on success,
+ * `{ successful: false, error }` on failure. */
+type DatacoreResult<T> =
+	| { successful: true; value: T }
+	| { successful: false; error: string };
+
+/**
+ * The slice of Datacore's public API Hearth calls. Exposed by the plugin at
+ * `app.plugins.plugins.datacore.api` once Datacore is enabled.
+ *
+ * Each `execute*` transpiles and runs the script, rendering it into `container`
+ * with Preact and attaching a `MarkdownRenderChild` to `component` — so the
+ * result re-renders itself as Datacore's index changes (Datacore's hooks, e.g.
+ * `dc.useQuery`, subscribe to the index) for as long as the component lives.
+ * Hearth passes the per-card component, which lives until the card is next
+ * redrawn, so live updates come for free. Script errors are caught by
+ * Datacore's own error boundary and rendered inline rather than thrown.
+ */
+interface DatacoreApi {
+	/** Run a plain JavaScript script (no JSX). */
+	executeJs(
+		source: string,
+		container: HTMLElement,
+		component: Component,
+		sourcePath: string,
+	): MarkdownRenderChild;
+	/** Run a JSX script (also accepts plain JavaScript). */
+	executeJsx(
+		source: string,
+		container: HTMLElement,
+		component: Component,
+		sourcePath: string,
+	): MarkdownRenderChild;
+	/** Run a TypeScript script (no TSX). */
+	executeTs(
+		source: string,
+		container: HTMLElement,
+		component: Component,
+		sourcePath: string,
+	): MarkdownRenderChild;
+	/** Run a TSX script (also accepts TS and JS). */
+	executeTsx(
+		source: string,
+		container: HTMLElement,
+		component: Component,
+		sourcePath: string,
+	): MarkdownRenderChild;
+	/** Parse a query without running it. Optional: treated as absent on a
+	 * Datacore old enough not to expose it, in which case an invalid query
+	 * simply surfaces through Datacore's own inline error instead. */
+	tryParseQuery?(query: string): DatacoreResult<unknown>;
+}
+
+/** Reach Datacore's public API, or null when the plugin isn't installed, isn't
+ * enabled, or is too old to expose the script methods Hearth uses. */
+export function getDatacoreApi(app: App): DatacoreApi | null {
+	const plugin = app.plugins.plugins[DATACORE_PLUGIN_ID] as
+		| { api?: unknown }
+		| undefined;
+	const api = plugin?.api;
+	if (
+		api &&
+		typeof (api as DatacoreApi).executeJs === "function" &&
+		typeof (api as DatacoreApi).executeJsx === "function" &&
+		typeof (api as DatacoreApi).executeTs === "function" &&
+		typeof (api as DatacoreApi).executeTsx === "function"
+	) {
+		return api as DatacoreApi;
+	}
+	return null;
+}
+
+/** Whether Datacore is enabled and its script API is reachable right now. */
+export function isDatacoreAvailable(app: App): boolean {
+	return getDatacoreApi(app) !== null;
+}
+
+/** Run `source` in the dialect `language` names, rendering into `container`. */
+export function runDatacoreScript(
+	api: DatacoreApi,
+	language: DatacoreScriptLanguage,
+	source: string,
+	container: HTMLElement,
+	component: Component,
+	sourcePath: string,
+): MarkdownRenderChild {
+	switch (language) {
+		case "js":
+			return api.executeJs(source, container, component, sourcePath);
+		case "ts":
+			return api.executeTs(source, container, component, sourcePath);
+		case "tsx":
+			return api.executeTsx(source, container, component, sourcePath);
+		case "jsx":
+		default:
+			return api.executeJsx(source, container, component, sourcePath);
+	}
+}
+
+/**
+ * Check a query for syntax errors before it is run, so a typo shows as a
+ * readable card message instead of a Preact error boundary. Returns the parse
+ * error, or null when the query parses (or when this Datacore build can't
+ * parse-without-running, in which case the error surfaces at render time).
+ */
+export function datacoreQueryError(api: DatacoreApi, query: string): string | null {
+	if (typeof api.tryParseQuery !== "function") return null;
+	try {
+		const parsed = api.tryParseQuery(query);
+		return parsed.successful ? null : String(parsed.error);
+	} catch (err) {
+		return err instanceof Error ? err.message : String(err);
+	}
+}
+
+/**
+ * Wrap a Datacore query in the smallest JSX view that renders it: a live list
+ * of links to whatever the query matched.
+ *
+ * This is what makes the card's no-code "Query" mode possible. Datacore's own
+ * codeblocks are all script-based — unlike Dataview, there is no query-only
+ * block to hand a bare query to — so Hearth generates the view around it. The
+ * query is embedded as a JSON string literal, which quotes and escapes it
+ * safely no matter what the user typed.
+ *
+ * `dc.useQuery` re-runs on every index change, so the list stays live. Results
+ * that carry a `$link` (pages, sections, blocks, tasks) render as real Obsidian
+ * links; anything else falls back to its path or id so the row is never blank.
+ *
+ * @param query    the Datacore query, e.g. `@page and #project`
+ * @param pageSize rows per page; 0 or omitted renders every result unpaged
+ */
+export function datacoreQueryScript(query: string, pageSize?: number): string {
+	const paging =
+		typeof pageSize === "number" && Number.isFinite(pageSize) && pageSize > 0
+			? String(Math.round(pageSize))
+			: "false";
+	return [
+		"return function HearthDatacoreQuery() {",
+		`\tconst rows = dc.useQuery(${JSON.stringify(query)});`,
+		`\treturn <dc.List rows={rows} paging={${paging}} renderer={(row) =>`,
+		"\t\trow && row.$link ? <dc.Link link={row.$link} /> : String((row && (row.$path || row.$id)) ?? row)",
+		"\t} />;",
+		"}",
+	].join("\n");
+}

--- a/src/datacore.ts
+++ b/src/datacore.ts
@@ -152,9 +152,13 @@ export function datacoreQueryError(api: DatacoreApi, query: string): string | nu
  * query is embedded as a JSON string literal, which quotes and escapes it
  * safely no matter what the user typed.
  *
- * `dc.useQuery` re-runs on every index change, so the list stays live. Results
- * that carry a `$link` (pages, sections, blocks, tasks) render as real Obsidian
- * links; anything else falls back to its path or id so the row is never blank.
+ * `dc.useQuery` re-runs on every index change, so the list stays live. What a
+ * row renders as depends on what Datacore returns, because its object types are
+ * not uniform: pages and sections carry a `$link` (as do blocks with a block
+ * id) and render as real Obsidian links; tasks and list items carry no link at
+ * all, so their Markdown text is rendered instead — which is what makes
+ * `@task and !$completed` useful here rather than a column of ids. Anything
+ * else falls back to its path or id, so a row is never blank.
  *
  * @param query    the Datacore query, e.g. `@page and #project`
  * @param pageSize rows per page; 0 or omitted renders every result unpaged
@@ -168,7 +172,9 @@ export function datacoreQueryScript(query: string, pageSize?: number): string {
 		"return function HearthDatacoreQuery() {",
 		`\tconst rows = dc.useQuery(${JSON.stringify(query)});`,
 		`\treturn <dc.List rows={rows} paging={${paging}} renderer={(row) =>`,
-		"\t\trow && row.$link ? <dc.Link link={row.$link} /> : String((row && (row.$path || row.$id)) ?? row)",
+		"\t\trow && row.$link ? <dc.Link link={row.$link} /> :",
+		"\t\trow && row.$text ? <dc.Markdown content={row.$text} /> :",
+		"\t\tString((row && (row.$path || row.$id)) ?? row)",
 		"\t} />;",
 		"}",
 	].join("\n");

--- a/src/datacore.ts
+++ b/src/datacore.ts
@@ -160,6 +160,15 @@ export function datacoreQueryError(api: DatacoreApi, query: string): string | nu
  * `@task and !$completed` useful here rather than a column of ids. Anything
  * else falls back to its path or id, so a row is never blank.
  *
+ * The one place Hearth composes Datacore's UI rather than just handing it a
+ * script, so it is also the one place a Datacore release can break this card
+ * without changing anything Hearth calls directly. It touches exactly four of
+ * Datacore's surfaces — `dc.useQuery`, `dc.List` (its `rows`, `paging` and
+ * `renderer` props), `dc.Link` and `dc.Markdown` — and nothing else in Hearth
+ * depends on them. If a card shows Datacore's error boundary after a Datacore
+ * update while script cards still render, this function is the place to look.
+ * Script modes pass through untouched and cannot be affected.
+ *
  * @param query    the Datacore query, e.g. `@page and #project`
  * @param pageSize rows per page; 0 or omitted renders every result unpaged
  */

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -20,6 +20,7 @@
  * carries no rendering concerns — {@link HomeSettingTab} renders it.
  */
 import type { App } from "obsidian";
+import { DATACORE_PLUGIN_ID } from "./datacore";
 import { DATAVIEW_PLUGIN_ID } from "./dataview";
 import { ICONIC_PLUGIN_ID, ICONIZE_PLUGIN_ID } from "./fileicons";
 import { EXCALIDRAW_PLUGIN_ID } from "./filetypes";
@@ -70,6 +71,7 @@ export type IntegrationId =
 	| "omnisearch"
 	| "tasknotes"
 	| "dataview"
+	| "datacore"
 	| "iconic"
 	| "iconize"
 	| "excalidraw"
@@ -123,6 +125,12 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
 		id: "dataview",
 		group: "plugin",
 		pluginId: DATAVIEW_PLUGIN_ID,
+		where: { kind: "card" },
+	},
+	{
+		id: "datacore",
+		group: "plugin",
+		pluginId: DATACORE_PLUGIN_ID,
 		where: { kind: "card" },
 	},
 	{

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -8,6 +8,7 @@ import {
 	type CommandItem,
 	type Dashboard,
 	type DashboardCard,
+	type DatacoreConfig,
 	type DataviewConfig,
 	type HeatmapConfig,
 	type HomeSettings,
@@ -37,6 +38,7 @@ import {
 } from "./types";
 import { CARD_KINDS } from "./cards";
 import { isEmbeddableBaseViewName } from "./bases";
+import { DATACORE_LANGUAGES, type DatacoreLanguage } from "./datacore";
 import { t } from "./i18n";
 
 /** Current dashboard-layout export schema version. v2 carries every dashboard
@@ -348,6 +350,9 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 	}
 	if (r.dataview && typeof r.dataview === "object") {
 		card.dataview = sanitizeDataview(r.dataview as Record<string, unknown>);
+	}
+	if (r.datacore && typeof r.datacore === "object") {
+		card.datacore = sanitizeDatacore(r.datacore as Record<string, unknown>);
 	}
 	if (r.leafView && typeof r.leafView === "object") {
 		card.leafView = sanitizeLeafView(r.leafView as Record<string, unknown>);
@@ -778,6 +783,19 @@ function sanitizeDataview(r: Record<string, unknown>): DataviewConfig {
 		cfg.columnWidths = r.columnWidths.filter(
 			(w): w is number => typeof w === "number" && Number.isFinite(w),
 		);
+	}
+	return cfg;
+}
+
+function sanitizeDatacore(r: Record<string, unknown>): DatacoreConfig {
+	const cfg: DatacoreConfig = {};
+	const query = str(r.query);
+	if (query !== undefined) cfg.query = query;
+	if (DATACORE_LANGUAGES.includes(r.language as DatacoreLanguage)) {
+		cfg.language = r.language as DatacoreLanguage;
+	}
+	if (typeof r.pageSize === "number" && Number.isFinite(r.pageSize)) {
+		cfg.pageSize = Math.max(0, Math.min(100, Math.round(r.pageSize)));
 	}
 	return cfg;
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1571,7 +1571,7 @@ export const en = {
 			datacoreNoQuery: "Set a Datacore query in card settings",
 			datacoreBadQuery: "Datacore couldn't read this query",
 			datacoreOneQuery:
-				"A card runs one query — this is several lines. Keep a single query, with no comment after it.",
+				"A card runs one query — this looks like several. Keep just the one you want, with no comment after it.",
 			datacoreFailed: "Datacore couldn't run this card",
 			rssNoSources: "Add a feed in card settings",
 			leafPickView: "Pick a plugin view in card settings",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -564,6 +564,12 @@ export const en = {
 						"The Dataview card runs DQL queries and DataviewJS blocks and renders " +
 						"them with Dataview's own renderers, refreshing as its index changes.",
 				},
+				datacore: {
+					name: "Datacore",
+					desc:
+						"Dataview's successor. The Datacore card runs a Datacore query — or a " +
+						"JS/JSX/TS/TSX script — and renders it with Datacore's own live views.",
+				},
 				iconic: {
 					name: "Iconic",
 					desc:
@@ -824,6 +830,7 @@ export const en = {
 			heatmap: "Activity heatmap",
 			calculator: "Calculator",
 			dataview: "Dataview query",
+			datacore: "Datacore query",
 			rss: "RSS feed",
 			jira: "Jira filter",
 			leaf: "Plugin view (beta)",
@@ -1377,6 +1384,31 @@ export const en = {
 				'TABLE file.mtime AS "Modified" FROM #project SORT file.mtime DESC',
 			queryJsPlaceholder: "dv.list(dv.pages('#project').file.link)",
 		},
+		datacore: {
+			language: "Query type",
+			languageDesc:
+				"A Datacore query rendered as a live list, or a Datacore script that draws its own view.",
+			languageQuery: "Datacore query",
+			languageJsx: "Script (JSX)",
+			languageJs: "Script (JS)",
+			languageTsx: "Script (TSX)",
+			languageTs: "Script (TS)",
+			query: "Query",
+			queryDesc:
+				"A Datacore query, e.g. @page and #project. Hearth renders the matches as a " +
+				"live list of links. Runs with no “current note”, so global queries work " +
+				"fully but file-relative ones have no file to resolve to.",
+			queryPlaceholder: "@page and #project",
+			script: "Script",
+			scriptDesc:
+				"A Datacore script, as inside a ```datacorejsx block (without the fences). " +
+				"The dc API is in scope and the script returns the view to render. Runs " +
+				"arbitrary code — only use code you trust.",
+			scriptPlaceholder:
+				"return function View() {\n\tconst pages = dc.useQuery(\"@page and #project\");\n\treturn <dc.List rows={pages} renderer={(p) => <dc.Link link={p.$link} />} />;\n}",
+			pageSize: "Rows per page",
+			pageSizeDesc: "Page the generated list at this many rows. 0 shows every match at once.",
+		},
 		rss: {
 			feeds: "Feeds",
 			namePlaceholder: "Name (optional)",
@@ -1535,6 +1567,8 @@ export const en = {
 				"No Kanban board found — pick a board note in card settings, or create one with the Kanban plugin",
 			dataviewEnable: "Enable the Dataview plugin to run queries",
 			dataviewNoQuery: "Set a Dataview query in card settings",
+			datacoreEnable: "Enable the Datacore plugin to run queries",
+			datacoreNoQuery: "Set a Datacore query in card settings",
 			rssNoSources: "Add a feed in card settings",
 			leafPickView: "Pick a plugin view in card settings",
 			leafViewMissing:
@@ -1853,6 +1887,7 @@ export const en = {
 		text: "Text / jot-down",
 		calculator: "Calculator",
 		dataview: "Dataview query",
+		datacore: "Datacore query",
 		rss: "RSS feed",
 		jira: "Jira filter",
 		leaf: "Plugin view (beta)",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1569,6 +1569,10 @@ export const en = {
 			dataviewNoQuery: "Set a Dataview query in card settings",
 			datacoreEnable: "Enable the Datacore plugin to run queries",
 			datacoreNoQuery: "Set a Datacore query in card settings",
+			datacoreBadQuery: "Datacore couldn't read this query",
+			datacoreOneQuery:
+				"A card runs one query — this is several lines. Keep a single query, with no comment after it.",
+			datacoreFailed: "Datacore couldn't run this card",
 			rssNoSources: "Add a feed in card settings",
 			leafPickView: "Pick a plugin view in card settings",
 			leafViewMissing:

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { DatacoreLanguage } from "./datacore";
 import type { EventNoteConfig } from "./eventnote";
 
 /** The kind of content a dashboard card renders. */
@@ -19,6 +20,7 @@ export type CardKind =
 	| "heatmap"
 	| "calculator"
 	| "dataview"
+	| "datacore"
 	| "rss"
 	| "jira"
 	| "leaf";
@@ -563,6 +565,26 @@ export interface DataviewConfig {
 	columnWidths?: number[];
 }
 
+/** Per-card configuration for a "datacore" card. Datacore is Dataview's
+ * successor, and this card is the Dataview card's: it renders a Datacore query
+ * or script through Datacore's own Preact renderer, live-updating as the index
+ * changes. Only offered by the "Add card" picker when the Datacore community
+ * plugin is installed and enabled. */
+export interface DatacoreConfig {
+	/** The query text. For "query" (default) this is a Datacore query, e.g.
+	 * `@page and #project`; for the script languages it is the script source,
+	 * exactly as inside the matching `datacore…` codeblock. */
+	query?: string;
+	/** How `query` is interpreted. "query" (default) renders the query as a live
+	 * link list; "js" / "jsx" / "ts" / "tsx" run it as a Datacore script, which
+	 * is arbitrary code. */
+	language?: DatacoreLanguage;
+	/** "query" mode only: rows per page in the generated list. Absent or 0
+	 * renders every result unpaged. Ignored by the script languages, which draw
+	 * their own views. */
+	pageSize?: number;
+}
+
 /** Per-card configuration for a "leaf" card, which hosts another plugin's (or a
  * core) registered side-panel view inside the dashboard. Beta. */
 export interface LeafViewConfig {
@@ -758,6 +780,8 @@ export interface DashboardCard {
 	calculator?: CalculatorConfig;
 	/** kind === "dataview": the query text and language. */
 	dataview?: DataviewConfig;
+	/** kind === "datacore": the query/script text, language and paging. */
+	datacore?: DatacoreConfig;
 	/** kind === "rss": feed sources, layout and refresh options. */
 	rss?: RssConfig;
 	/** kind === "jira": connection, saved filter, and refinement options. */

--- a/styles.css
+++ b/styles.css
@@ -4136,6 +4136,32 @@
 	resize: vertical;
 }
 
+/* Datacore query/script editor: same monospaced code box as Dataview's. */
+.hearth-datacore-input {
+	width: 100%;
+	font-family: var(--font-monospace);
+	font-size: 0.82rem;
+	line-height: 1.5;
+	resize: vertical;
+}
+
+/* Datacore card body: Datacore's own rendered views (tables, lists, cards).
+   Datacore sizes its tables to the container, so this only needs to scroll a
+   wider-than-the-card result instead of forcing the whole board wider. */
+.hearth-datacore {
+	width: 100%;
+	max-width: 100%;
+	overflow-x: auto;
+}
+
+/* Keep a long-text column (note bodies, paths) from ballooning: wrap past a
+   sensible width instead of pushing every other column off-screen. */
+.hearth-datacore th,
+.hearth-datacore td {
+	max-width: 32ch;
+	overflow-wrap: anywhere;
+}
+
 /* Dataview card body: Dataview's own rendered output (tables, lists, task
    lists). A table wider than the card scrolls horizontally here instead of
    forcing the whole board wider. */

--- a/styles.css
+++ b/styles.css
@@ -4154,6 +4154,56 @@
 	overflow-x: auto;
 }
 
+/* A failed Datacore query or script. Left-aligned, not centred like the generic
+   empty state: the detail below is the engine's own message, and Datacore's
+   parse errors are ASCII drawings (a numbered echo of the query with a caret
+   under the offending column) that only line up in a monospaced block. */
+.hearth-datacore-error {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5em;
+	padding: 0.75em 0.9em;
+	min-width: 0;
+}
+
+.hearth-datacore-error-head {
+	display: flex;
+	align-items: center;
+	gap: 0.45em;
+	color: var(--text-muted);
+}
+
+.hearth-datacore-error-icon {
+	display: flex;
+	color: var(--text-warning);
+}
+
+.hearth-datacore-error-icon .svg-icon {
+	width: 1em;
+	height: 1em;
+}
+
+.hearth-datacore-error-title {
+	font-size: 0.9rem;
+}
+
+/* The engine's message, verbatim. Scrolls in its own box rather than stretching
+   the card, and keeps its line breaks so the caret stays under its column. */
+.hearth-datacore-error-detail {
+	margin: 0;
+	max-height: 14em;
+	overflow: auto;
+	padding: 0.6em 0.7em;
+	border-radius: var(--radius-s);
+	background: var(--background-secondary);
+	color: var(--text-muted);
+	font-family: var(--font-monospace);
+	font-size: 0.75rem;
+	line-height: 1.45;
+	white-space: pre;
+	tab-size: 4;
+}
+
 /* Keep a long-text column (note bodies, paths) from ballooning: wrap past a
    sensible width instead of pushing every other column off-screen. */
 .hearth-datacore th,

--- a/styles.css
+++ b/styles.css
@@ -4146,8 +4146,12 @@
 }
 
 /* Datacore card body: Datacore's own rendered views (tables, lists, cards).
-   Datacore sizes its tables to the container, so this only needs to scroll a
-   wider-than-the-card result instead of forcing the whole board wider. */
+   Deliberately almost empty. Datacore's `.datacore-table` is `width: 100%` with
+   `max-width: 100%` cells — it already fits its container, unlike Dataview's
+   content-sized tables — so the card wants no width opinions of its own: the
+   card should render what a note renders. All that's left is a scroll box, for
+   content that is intrinsically wide (a Markdown table, a long code line)
+   rather than forcing the whole board wider. */
 .hearth-datacore {
 	width: 100%;
 	max-width: 100%;
@@ -4202,14 +4206,6 @@
 	line-height: 1.45;
 	white-space: pre;
 	tab-size: 4;
-}
-
-/* Keep a long-text column (note bodies, paths) from ballooning: wrap past a
-   sensible width instead of pushing every other column off-screen. */
-.hearth-datacore th,
-.hearth-datacore td {
-	max-width: 32ch;
-	overflow-wrap: anywhere;
 }
 
 /* Dataview card body: Dataview's own rendered output (tables, lists, task

--- a/test/cards-registry.test.ts
+++ b/test/cards-registry.test.ts
@@ -53,6 +53,7 @@ describe("CARD_TEMPLATES (add-card menu)", () => {
 			{ id: "text", icon: "pencil", gated: false, build: { kind: "text", title: "Notes", text: "", w: 4, h: 2 } },
 			{ id: "calculator", icon: "calculator", gated: false, build: { kind: "calculator", title: "Calculator", calculator: {}, w: 4, h: 3 } },
 			{ id: "dataview", icon: "database", gated: true, build: { kind: "dataview", title: "Dataview", dataview: {}, w: 6, h: 4 } },
+			{ id: "datacore", icon: "database-zap", gated: true, build: { kind: "datacore", title: "Datacore", datacore: {}, w: 6, h: 4 } },
 			{ id: "rss", icon: "rss", gated: false, build: { kind: "rss", title: "RSS", rss: { sources: [] }, w: 4, h: 5 } },
 			{
 				id: "jira",
@@ -123,6 +124,7 @@ function maximalCard(): DashboardCard {
 		clock: { format: "24" } as never,
 		calculator: { keypad: "basic" } as never,
 		dataview: { columnWidths: [1, 2, 3] },
+		datacore: { query: "@page and #project", language: "query", pageSize: 25 },
 		rss: { sources: [{ id: "s1", name: "Feed", url: "https://example.com/feed" }] },
 		jira: {
 			controls: ["status"],
@@ -157,6 +159,7 @@ describe("cloneCard deep-clone independence", () => {
 		(copy.clock as { format: string }).format = "12";
 		(copy.calculator as { keypad: string }).keypad = "sci";
 		copy.dataview!.columnWidths!.push(4);
+		copy.datacore!.query = "@page and #other";
 		copy.rss!.sources!.push({ id: "s2", name: "Feed 2", url: "https://example.com/feed2" });
 		copy.jira!.controls!.push("assignee");
 		copy.jira!.selections!.status!.push("Closed");
@@ -174,6 +177,7 @@ describe("cloneCard deep-clone independence", () => {
 		expect(orig.clock).toEqual(pristine.clock);
 		expect(orig.calculator).toEqual(pristine.calculator);
 		expect(orig.dataview).toEqual(pristine.dataview);
+		expect(orig.datacore).toEqual(pristine.datacore);
 		expect(orig.rss).toEqual(pristine.rss);
 		expect(orig.jira).toEqual(pristine.jira);
 	});
@@ -206,6 +210,7 @@ describe("liveness classification", () => {
 			heatmap: "vault",
 			calculator: "static",
 			dataview: "static",
+			datacore: "static",
 			rss: "static",
 			jira: "static",
 			leaf: "static",

--- a/test/datacore.test.ts
+++ b/test/datacore.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { DATACORE_LANGUAGES, datacoreQueryScript } from "../src/datacore";
+
+/**
+ * The Datacore card's no-code "Query" mode works by generating a small JSX view
+ * around the user's query — Datacore ships no query-only codeblock to hand a
+ * bare query to. That generation is the one piece of pure logic in the
+ * integration, and the one that can silently produce a broken script, so it is
+ * pinned here. (Executing it needs the Datacore plugin, which tests don't have.)
+ */
+describe("datacoreQueryScript", () => {
+	it("embeds the query as a string literal and returns a component", () => {
+		const script = datacoreQueryScript("@page and #project");
+		expect(script).toContain('dc.useQuery("@page and #project")');
+		expect(script.startsWith("return function ")).toBe(true);
+		expect(script).toContain("<dc.List");
+	});
+
+	it("escapes quotes, backslashes and newlines in the query", () => {
+		const script = datacoreQueryScript('@page and path("a\\b") and\n#x');
+		// The literal round-trips: what Datacore evaluates is exactly what was
+		// typed, and no stray quote can break out into the surrounding script.
+		const literal = script.match(/dc\.useQuery\((".*?[^\\]")\)/)?.[1];
+		expect(literal).toBeDefined();
+		expect(JSON.parse(literal!)).toBe('@page and path("a\\b") and\n#x');
+		// The embedded newline must not split the generated line.
+		expect(script.split("\n").filter((l) => l.includes("dc.useQuery"))).toHaveLength(1);
+	});
+
+	it("pages the list only when a positive page size is given", () => {
+		expect(datacoreQueryScript("@page", 25)).toContain("paging={25}");
+		expect(datacoreQueryScript("@page")).toContain("paging={false}");
+		expect(datacoreQueryScript("@page", 0)).toContain("paging={false}");
+		expect(datacoreQueryScript("@page", -5)).toContain("paging={false}");
+		expect(datacoreQueryScript("@page", Number.NaN)).toContain("paging={false}");
+		// Non-integer sliders/hand-edited data still yield a valid literal.
+		expect(datacoreQueryScript("@page", 12.4)).toContain("paging={12}");
+	});
+});
+
+describe("DATACORE_LANGUAGES", () => {
+	it("lists the query mode plus Datacore's four script dialects", () => {
+		expect([...DATACORE_LANGUAGES].sort()).toEqual(["js", "jsx", "query", "ts", "tsx"]);
+	});
+});

--- a/test/datacore.test.ts
+++ b/test/datacore.test.ts
@@ -16,6 +16,15 @@ describe("datacoreQueryScript", () => {
 		expect(script).toContain("<dc.List");
 	});
 
+	it("renders linkable results as links and text-bearing ones as Markdown", () => {
+		// Datacore's types are not uniform: pages/sections have $link, tasks and
+		// list items have only $text. Both branches must be in the generated view
+		// or a @task query renders a column of ids.
+		const script = datacoreQueryScript("@task and !$completed");
+		expect(script).toContain("<dc.Link link={row.$link} />");
+		expect(script).toContain("<dc.Markdown content={row.$text} />");
+	});
+
 	it("escapes quotes, backslashes and newlines in the query", () => {
 		const script = datacoreQueryScript('@page and path("a\\b") and\n#x');
 		// The literal round-trips: what Datacore evaluates is exactly what was


### PR DESCRIPTION
## What does this PR do?

Adds a **Datacore** card, shaped like the Dataview card it succeeds: pick a query type, write a query, get a live result. Dataview is winding down in favour of [Datacore](https://github.com/blacksmithgu/datacore), so the dashboard now covers both.

Datacore's public API (`app.plugins.plugins.datacore.api`) only offers script execution — `executeJs/Jsx/Ts/Tsx(source, container, component, sourcePath)`. Unlike Dataview there is no query-only codeblock to hand a bare query to, so the card has two faces:

- **Query** (default, the no-code mode) — type a Datacore query such as `@page and #project`; Hearth wraps it in the smallest JSX view that renders it (a `dc.useQuery`-backed `dc.List` of `dc.Link`s, with optional paging). The hook subscribes to Datacore's index, so the list is live.
- **Script (JSX / JS / TSX / TS)** — the text goes straight to Datacore, exactly as inside a `datacorejsx` block, with `dc` in scope.

Either way Datacore attaches its own render child to the card's component, so results update themselves as the vault changes and unmount with the card. Queries are validated with `tryParseQuery` before running, so a typo shows as a readable card message instead of a Preact error boundary, and the template is gated on the plugin so it only appears in the "Add card" picker while Datacore is enabled. Datacore also joins the Integrations catalogue.

**Files**

- `src/datacore.ts` — plugin id, the API surface Hearth calls, availability check, and the pure `datacoreQueryScript` generator
- `src/cards/datacore.ts` — render, editor and `CardDefinition`
- Wiring — `types.ts` (kind + `DatacoreConfig`), `layout.ts` (import sanitizer), `cards/index.ts` (registry + menu order), `integrations.ts`, `locales/en.ts`, `styles.css`, README, CHANGELOG
- `test/datacore.test.ts` — covers the generated script, including query-literal escaping and paging

**One shared change worth flagging:** `wireMarkdownLinks` gains an opt-in `capture` mode. Datacore's `dc.Link` carries its own click handler that calls `workspace.openLinkText` on the active tab — the Hearth tab — so on this card the click has to be intercepted in the capture phase rather than after it, or the note opens twice and ignores the "open notes in" setting (#106). Default behaviour for every existing caller is unchanged.

**Not carried over:** the Dataview card's drag-resizable table columns. Datacore's tables are Preact-rendered and continuously reconciled, so injecting resize handles into its header cells would fight the renderer — that needs a different approach than the MutationObserver trick.

## Related issue

None — happy to open one first if you'd rather align on the query-mode design before this lands.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (also `npm run typecheck`, `npm test` — 413 passing — and `npm run lint`, 0 errors)
- [ ] I've tested this in an actual vault — not possible from this environment; the Datacore API surface used here was verified against the published `@blacksmithgu/datacore` typings and the plugin's source, but a real-vault pass is worth doing before merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4Q56Z9kwRpnGTnmztmHb6)_