### PR TITLE
feat(background): paint the board with the live weather sky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
+- **The weather sky, as your background.** **Settings → Appearance →
+  Background** has a new type: **Live weather sky**. The board's backdrop
+  becomes the painted sky the weather card's artistic style draws — sun,
+  crescent moon and a full field of stars, clouds drifting in three lanes,
+  rain, drizzle, snow, fog banks and lightning — spread across the whole
+  window and following the real conditions and the real time of day over a
+  place you pick. It is the same painting, redrawn for the space: a window is
+  several times a card, so it gets a wider box, more stars, more clouds and
+  more rain rather than three enormous clouds. Pick the place by searching for
+  it or by typing coordinates, or reuse one already set on a weather card in
+  one click; the forecast is shared with any card on the same place instead of
+  fetched twice, and refreshes itself every half hour.
+
+  **Or pin a sky and keep it.** Set the sky to *fixed* instead of live and
+  choose the condition yourself — always clear, always snow, always
+  thunderstorm — and whether it follows your clock or stays permanently day or
+  night. A fixed sky needs no location and never goes online at all.
+
+  Backgrounds can be set globally or per dashboard, so one board can sit under
+  a live sky and another under a permanent clear night. Opacity and blur work
+  as they do for a wallpaper (switching to a sky lifts the photo-oriented
+  default opacity once, since a gradient dimmed to 0.35 is just a grey slab).
+  Low power mode still replaces the whole background with its flat colour, and
+  a reader whose system asks for reduced motion gets the sky without the
+  motion.
 - **Weather card.** Current conditions and a forecast on the dashboard, from
   [Open-Meteo](https://open-meteo.com) — free, key-less, and with no account to
   create, so it works the moment you add the card. Point it at a place by
@@ -176,6 +201,14 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   keeps the double-click raw editor it has always had (#160).
 
 ### Fixed
+
+- **The weather card's clouds sat in the wrong place.** Every cloud carried its
+  position and size in an SVG `transform` attribute and its drift in a CSS
+  animation — and a CSS animation replaces the transform attribute outright.
+  So the moment a sky started moving, the whole bank lost its placement and
+  slid across the top edge in a row. Clouds now drift in an outer group and
+  carry their position in an inner one, so a cloudy sky is a sky with clouds in
+  it rather than a strip of them along the top.
 
 - **One card can no longer take the board down with it.** A card kind is drawn
   synchronously while the dashboard builds, and in Arrange mode the drag overlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,13 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   Background** has a new type: **Live weather sky**. The board's backdrop
   becomes the painted sky the weather card's artistic style draws — sun,
   crescent moon and a full field of stars, clouds drifting in three lanes,
-  rain, drizzle, snow, fog banks and lightning — spread across the whole
+  rain, drizzle, snow, layered fog and lightning — spread across the whole
   window and following the real conditions and the real time of day over a
-  place you pick. It is the same painting, redrawn for the space: a window is
+  place you pick. The storm and the fog were rebuilt for the size: lightning
+  is now several generated discharges, each a crooked forked stroke on its own
+  timer over a sheet flash, rather than one drawn bolt blinking in one spot;
+  fog is a bank of overlapping wisps drifting past each other at different
+  speeds and densities, rather than three flat bands. It is the same painting, redrawn for the space: a window is
   several times a card, so it gets a wider box, more stars, more clouds and
   more rain rather than three enormous clouds. Pick the place by searching for
   it or by typing coordinates, or reuse one already set on a weather card in

--- a/README.md
+++ b/README.md
@@ -167,7 +167,12 @@ calls**.
 
 ## Appearance
 
-- **Background** — solid color, vault image or URL, with opacity and blur.
+- **Background** — solid color, vault image, URL, or a **live weather sky**:
+  the board's backdrop becomes the painted sky the weather card's artistic style
+  draws, spread across the whole window and following the real conditions and
+  time of day over a place you pick. Or pin one sky — clear night, snow,
+  thunder — and keep it whatever the weather is doing, which needs no location
+  and never goes online. All with opacity and blur.
   Ships with a soft ambient default.
 - **Frosted glass** — card opacity and backdrop blur at three levels (global →
   per-dashboard → per-card). Merged cards blur as one seamless sheet.

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,14 @@
-import { TFile } from "obsidian";
+import { type Component, TFile } from "obsidian";
+import {
+	daylightFromHour,
+	drawSky,
+	parseSkyValue,
+	resolveDaylight,
+	skyGroupCode,
+} from "./sky";
 import type { HomeView } from "./view";
-import { effectiveBackground } from "./types";
+import { type BackgroundConfig, effectiveBackground } from "./types";
+import { cachedWeather, loadWeather, type WeatherRequest } from "./weather";
 
 /**
  * URL of the bundled default background. Served straight from the main branch
@@ -15,7 +23,11 @@ const DEFAULT_BG_URL =
  * content so opacity/blur don't affect the foreground. Uses the active
  * dashboard's override when set, otherwise the global default.
  */
-export function applyBackground(view: HomeView, root: HTMLElement): void {
+export function applyBackground(
+	view: HomeView,
+	root: HTMLElement,
+	component: Component,
+): void {
 	const bg = effectiveBackground(view.plugin.settings);
 	if (bg.kind === "none") return;
 	// "default" uses the bundled Hearth background; no value field needed.
@@ -27,6 +39,11 @@ export function applyBackground(view: HomeView, root: HTMLElement): void {
 
 	if (bg.kind === "color") {
 		layer.style.background = bg.value;
+		return;
+	}
+
+	if (bg.kind === "weather") {
+		applyWeatherSky(view, layer, bg, component);
 		return;
 	}
 
@@ -46,4 +63,103 @@ export function applyBackground(view: HomeView, root: HTMLElement): void {
 		const safe = url.replace(/["\\]/g, "\\$&");
 		layer.style.backgroundImage = `url("${safe}")`;
 	}
+}
+
+/** How often the backdrop refetches its forecast. Fixed rather than
+ * configurable: a sky that changes is the whole point, an hourly-published
+ * forecast is all there is to fetch, and this is a wallpaper — not a card whose
+ * refresh the reader is tuning. */
+const SKY_REFRESH_MIN = 30;
+
+/**
+ * A weather background needs no units — it draws a condition and a day/night
+ * flag — so it asks for the defaults, which is also what an unconfigured
+ * weather card asks for. The two then share one cached response instead of
+ * making the same request twice.
+ */
+function skyRequest(lat: number, lon: number): WeatherRequest {
+	return { lat, lon, tempUnit: "c", windUnit: "kmh", precipUnit: "mm" };
+}
+
+/**
+ * Paint the live sky for a place across the whole board.
+ *
+ * The same drawing as the weather card's artistic style (see sky.ts), at board
+ * spread: more stars, more clouds, more rain, because a window is several times
+ * a card. It shows whatever is cached immediately — a stale sky beats a blank
+ * one — then fetches and repaints, and keeps itself current on a timer. Low
+ * power mode never reaches here: `effectiveBackground` has already replaced the
+ * whole background with its flat colour.
+ */
+function applyWeatherSky(
+	view: HomeView,
+	layer: HTMLElement,
+	bg: BackgroundConfig,
+	component: Component,
+): void {
+	const sky = parseSkyValue(bg.value);
+	if (!sky) return;
+	const settings = view.plugin.settings;
+	const animate = settings.backgroundSkyAnimate !== false;
+
+	// A fixed sky is the whole feature for anyone who wants one weather and
+	// wants it kept: it is drawn once, from a condition the reader chose, and
+	// touches the network exactly never.
+	if (sky.mode === "fixed") {
+		drawSky(layer, {
+			code: skyGroupCode(sky.group),
+			isDay: resolveDaylight(sky.daylight, new Date().getHours()),
+			animate,
+			spread: "board",
+		});
+		return;
+	}
+
+	const req = skyRequest(sky.place.lat, sky.place.lon);
+	const disabled = settings.disableExternalCalls;
+
+	// The view is rebuilt often; a resolved fetch must not draw into a layer
+	// that has since been thrown away.
+	let destroyed = false;
+	component.register(() => {
+		destroyed = true;
+	});
+
+	const paint = (): void => {
+		layer.empty();
+		const snapshot = cachedWeather(req);
+		if (snapshot) {
+			drawSky(layer, {
+				code: snapshot.now.code,
+				isDay: snapshot.now.isDay,
+				animate,
+				spread: "board",
+			});
+			return;
+		}
+		// Nothing cached yet (a cold start, or external calls are off). Rather
+		// than flash an empty board, paint a neutral overcast sky — the one
+		// condition that claims nothing — lit by the reader's own clock so it at
+		// least agrees with whether it is dark outside their window.
+		drawSky(layer, {
+			code: 3,
+			isDay: daylightFromHour(new Date().getHours()),
+			animate,
+			spread: "board",
+		});
+	};
+
+	paint();
+	void loadWeather(req, { ttlMs: SKY_REFRESH_MIN * 60_000, disabled }).then(() => {
+		if (!destroyed) paint();
+	});
+	component.registerInterval(
+		window.setInterval(() => {
+			void loadWeather(req, { ttlMs: SKY_REFRESH_MIN * 60_000, disabled, force: true }).then(
+				() => {
+					if (!destroyed) paint();
+				},
+			);
+		}, SKY_REFRESH_MIN * 60_000),
+	);
 }

--- a/src/cards/weather.ts
+++ b/src/cards/weather.ts
@@ -27,15 +27,15 @@ import {
 	today,
 	upcomingDays,
 	upcomingHours,
-	weatherGroup,
 	type WeatherDay,
-	type WeatherGroup,
 	type WeatherHour,
 	weatherIcon,
 	weatherLabelKey,
 	type WeatherRequest,
 	type WeatherSnapshot,
 } from "../weather";
+import { configuredPlaces, renderPlacePicker } from "../placepicker";
+import { drawSky } from "../sky";
 import { type CardDefinition, type CardEditorContext } from "./definition";
 
 
@@ -547,197 +547,10 @@ function paintForecast(wrap: HTMLElement, snapshot: WeatherSnapshot, cfg: Weathe
 }
 
 
-// ---- The painted sky (artistic style) -----------------------------------
-
-/** Positions for the night sky's stars, in viewBox units. Fixed rather than
- * random so a redraw doesn't reshuffle the constellation under the reader. */
-const STARS: readonly { x: number; y: number; r: number; delay: number }[] = [
-	{ x: 18, y: 22, r: 1.1, delay: 0 },
-	{ x: 40, y: 12, r: 0.8, delay: 1.4 },
-	{ x: 62, y: 30, r: 1.0, delay: 0.7 },
-	{ x: 88, y: 16, r: 0.7, delay: 2.1 },
-	{ x: 112, y: 26, r: 1.2, delay: 0.3 },
-	{ x: 134, y: 10, r: 0.8, delay: 1.8 },
-	{ x: 152, y: 34, r: 0.9, delay: 1.1 },
-	{ x: 176, y: 20, r: 1.1, delay: 2.6 },
-	{ x: 28, y: 44, r: 0.7, delay: 2.3 },
-	{ x: 104, y: 48, r: 0.8, delay: 0.9 },
-];
-
-/** The cloud bank, back to front: each entry is a centre, a scale and the
- * animation lane it drifts in. */
-const CLOUDS: readonly { x: number; y: number; scale: number; lane: number }[] = [
-	{ x: 40, y: 44, scale: 1.5, lane: 1 },
-	{ x: 130, y: 32, scale: 1.1, lane: 2 },
-	{ x: 90, y: 58, scale: 0.85, lane: 3 },
-];
-
-/** Draw one cloud as three overlapping discs on a slab — the shape reads as a
- * cloud at any size, and it costs four nodes instead of a path. */
-function drawCloud(svg: SVGElement, x: number, y: number, scale: number, lane: number): void {
-	const group = svg.createSvg("g", {
-		// An array, not "a b": createSvg hands `cls` to classList.add(), which
-		// rejects a token containing a space. (createDiv sets the class
-		// attribute instead, which is why a two-class string is fine there.)
-		cls: ["hearth-weather-cloud", `is-lane-${lane}`],
-		attr: { transform: `translate(${x} ${y}) scale(${scale})` },
-	});
-	group.createSvg("ellipse", { attr: { cx: "-14", cy: "4", rx: "16", ry: "10" } });
-	group.createSvg("ellipse", { attr: { cx: "2", cy: "-2", rx: "18", ry: "13" } });
-	group.createSvg("ellipse", { attr: { cx: "18", cy: "5", rx: "15", ry: "9" } });
-	group.createSvg("rect", { attr: { x: "-28", y: "4", width: "58", height: "11", rx: "5.5" } });
-}
-
-/** Falling precipitation: slanted streaks for rain and drizzle, drifting discs
- * for snow. Positions are evenly spread with a per-drop delay so the fall never
- * looks like a marching row. */
-function drawPrecipitation(svg: SVGElement, group: WeatherGroup): void {
-	const snow = group === "snow";
-	const count = group === "drizzle" ? 14 : snow ? 16 : 20;
-	// Two classes, so an array — see drawCloud.
-	const layer = svg.createSvg("g", { cls: ["hearth-weather-fall", `is-${group}`] });
-	for (let i = 0; i < count; i++) {
-		// A prime-ish stride spreads the drops across the width without clumping
-		// into visible columns the way `i * width / count` would.
-		const x = ((i * 37) % 190) + 5;
-		const duration = (snow ? 3.4 : 1.1) + (i % 5) * 0.18;
-		const drop = snow
-			? layer.createSvg("circle", { attr: { cx: String(x), cy: "0", r: "1.6" } })
-			: layer.createSvg("line", {
-					attr: {
-						x1: String(x),
-						y1: "0",
-						x2: String(x - 3),
-						y2: group === "drizzle" ? "7" : "11",
-					},
-			  });
-		// Spread the field down the sky. Two mechanisms, because the card can be
-		// drawn either way: a static offset for a still sky (low power, motion
-		// off), and a *negative* delay for a moving one — every drop starts
-		// partway through its own fall, so the first frame is already a shower
-		// rather than a row of drops queued at the top. A running animation
-		// overrides the inline transform, so the two never fight.
-		const progress = i / count;
-		drop.style.transform = `translate(${-progress * 24}px, ${progress * 130 - 10}px)`;
-		drop.style.animationDelay = `${(-progress * duration).toFixed(2)}s`;
-		// Staggering the duration too keeps the field from pulsing in unison.
-		drop.style.animationDuration = `${duration}s`;
-	}
-}
-
-/** The sun, with a soft corona. */
-function drawSun(svg: SVGElement): void {
-	const group = svg.createSvg("g", { cls: "hearth-weather-sun" });
-	group.createSvg("circle", { cls: "hearth-weather-sun-glow", attr: { cx: "158", cy: "28", r: "30" } });
-	group.createSvg("circle", { cls: "hearth-weather-sun-disc", attr: { cx: "158", cy: "28", r: "15" } });
-}
-
-/** The moon: one path holding two overlapping circles, filled `evenodd`, so the
- * overlap punches the bite out of the disc. A `<mask>` would draw the same
- * crescent, but it needs a `<defs>` and a document-unique id — state to keep
- * correct across every card and every redraw, in exchange for nothing visible. */
-function drawMoon(svg: SVGElement): void {
-	const group = svg.createSvg("g", { cls: "hearth-weather-moon" });
-	group.createSvg("circle", { cls: "hearth-weather-moon-glow", attr: { cx: "158", cy: "28", r: "26" } });
-	group.createSvg("path", {
-		cls: "hearth-weather-moon-disc",
-		attr: {
-			// Two arcs meeting at the points where the disc (centre 158,28 r15)
-			// and the bite (centre 149,19 r17) cross: the major arc of the disc
-			// out and round the lit side, then the bite's minor arc back along
-			// the terminator. Two overlapping circles filled `evenodd` would be
-			// the obvious shortcut and is wrong — that fills their symmetric
-			// difference, so the bite's own outer lobe lights up too.
-			d: "M165.53,15.03 A15,15 0 1 1 145.03,35.53 A17,17 0 0 0 165.53,15.03 Z",
-		},
-	});
-}
-
-/** Horizontal fog banks. */
-function drawFog(svg: SVGElement): void {
-	const layer = svg.createSvg("g", { cls: "hearth-weather-fogbank" });
-	const bands = [
-		{ y: 46, h: 9, lane: 1 },
-		{ y: 62, h: 7, lane: 2 },
-		{ y: 78, h: 8, lane: 3 },
-	];
-	for (const band of bands) {
-		layer.createSvg("rect", {
-			cls: `is-lane-${band.lane}`,
-			attr: { x: "-40", y: String(band.y), width: "280", height: String(band.h), rx: String(band.h / 2) },
-		});
-	}
-}
-
-/** The lightning bolt, flashed by CSS. */
-function drawBolt(svg: SVGElement): void {
-	svg.createSvg("polygon", {
-		cls: "hearth-weather-bolt",
-		attr: { points: "96,50 84,76 94,76 86,102 108,70 97,70 106,50" },
-	});
-}
-
-/**
- * Paint the sky behind the artistic style.
- *
- * The gradient itself is CSS (`.sky-<group>`, plus `.is-night`); this draws
- * what moves in front of it. Nothing here reacts to a pointer or holds state —
- * it is a backdrop, and it is rebuilt wholesale on every redraw.
- */
-function drawSky(parent: HTMLElement, code: number, isDay: boolean, animate: boolean): HTMLElement {
-	const group = weatherGroup(code);
-	const sky = parent.createDiv(`hearth-weather-sky sky-${group}`);
-	sky.toggleClass("is-night", !isDay);
-	sky.toggleClass("is-animated", animate);
-
-	const svg = sky.createSvg("svg", {
-		cls: "hearth-weather-art",
-		// `slice` fills the card at any aspect ratio, cropping rather than
-		// letterboxing — a sky with bars around it isn't a sky.
-		attr: { viewBox: "0 0 200 120", preserveAspectRatio: "xMidYMid slice", "aria-hidden": "true" },
-	});
-
-	const celestial = group === "clear" || group === "partly";
-	if (celestial) {
-		if (isDay) drawSun(svg);
-		else drawMoon(svg);
-	}
-	if (!isDay && (group === "clear" || group === "partly")) {
-		const stars = svg.createSvg("g", { cls: "hearth-weather-stars" });
-		for (const star of STARS) {
-			const dot = stars.createSvg("circle", {
-				attr: { cx: String(star.x), cy: String(star.y), r: String(star.r) },
-			});
-			dot.style.animationDelay = `${star.delay}s`;
-		}
-	}
-
-	if (group === "fog") drawFog(svg);
-
-	// Every group but a clear sky has cloud cover; how much of the bank is drawn
-	// is what separates "partly cloudy" from "overcast".
-	const cloudCount =
-		group === "clear" ? 0 : group === "partly" ? 1 : group === "fog" ? 2 : CLOUDS.length;
-	for (let i = 0; i < cloudCount; i++) {
-		const cloud = CLOUDS[i];
-		drawCloud(svg, cloud.x, cloud.y, cloud.scale, cloud.lane);
-	}
-
-	if (group === "rain" || group === "drizzle" || group === "snow") {
-		drawPrecipitation(svg, group);
-	}
-	if (group === "thunder") {
-		drawPrecipitation(svg, "rain");
-		drawBolt(svg);
-	}
-
-	return sky;
-}
-
 /** Artistic: an edge-to-edge painted sky with the reading laid over it. */
 function paintArtistic(wrap: HTMLElement, snapshot: WeatherSnapshot, cfg: WeatherConfig, r: Resolved): void {
 	const now = snapshot.now;
-	const sky = drawSky(wrap, now.code, now.isDay, r.animate);
+	const sky = drawSky(wrap, { code: now.code, isDay: now.isDay, animate: r.animate });
 	const content = sky.createDiv("hearth-weather-art-content");
 
 	const top = content.createDiv("hearth-weather-art-top");
@@ -876,151 +689,6 @@ export function renderWeather(
 
 // ---- Editor -------------------------------------------------------------
 
-/** Session keys the place picker keeps between the modal's in-place rerenders. */
-const SESSION_QUERY = "weatherQuery";
-const SESSION_RESULTS = "weatherResults";
-const SESSION_SEARCHED = "weatherSearched";
-const SESSION_VERSION = "weatherSearchVersion";
-
-/** The place-name search: type a name, hit Search, pick one of the matches.
- * This is the only lookup the card ever does, and only when asked. */
-function placePicker(ctx: CardEditorContext, containerEl: HTMLElement, cfg: WeatherConfig): void {
-	const strings = t().editors.weather;
-
-	const search = new Setting(containerEl)
-		.setName(strings.search)
-		.setDesc(
-			ctx.opts.externalCallsDisabled ? strings.searchDisabled : strings.searchDesc,
-		)
-		.setClass("hearth-weather-search");
-
-	search.addText((txt) => {
-		txt
-			.setPlaceholder(strings.searchPlaceholder)
-			.setValue((ctx.session[SESSION_QUERY] as string) ?? "")
-			.onChange((v) => {
-				ctx.session[SESSION_QUERY] = v;
-			});
-		txt.inputEl.addClass("hearth-weather-search-input");
-	});
-
-	const run = async (button: { setDisabled(v: boolean): unknown }): Promise<void> => {
-		const query = ((ctx.session[SESSION_QUERY] as string) ?? "").trim();
-		if (!query) {
-			new Notice(strings.searchEmpty);
-			return;
-		}
-		// Ignore a slow search whose results land after a newer one (or after the
-		// modal has moved on), the way the Jira filter loader does.
-		const version = ((ctx.session[SESSION_VERSION] as number) ?? 0) + 1;
-		ctx.session[SESSION_VERSION] = version;
-		button.setDisabled(true);
-		const results = await searchPlaces(query, {
-			disabled: ctx.opts.externalCallsDisabled,
-		});
-		if (version !== ctx.session[SESSION_VERSION] || !search.settingEl.isConnected) {
-			button.setDisabled(false);
-			return;
-		}
-		ctx.session[SESSION_RESULTS] = results;
-		ctx.session[SESSION_SEARCHED] = true;
-		ctx.requestRender();
-	};
-
-	search.addButton((b) =>
-		b
-			.setButtonText(strings.searchButton)
-			.setCta()
-			.setDisabled(ctx.opts.externalCallsDisabled)
-			.onClick(() => {
-				void run(b);
-			}),
-	);
-
-	const results = (ctx.session[SESSION_RESULTS] as GeoResult[] | undefined) ?? [];
-	if (ctx.session[SESSION_SEARCHED] && !results.length) {
-		containerEl.createDiv({
-			cls: "hearth-weather-search-empty setting-item-description",
-			text: strings.searchNoResults,
-		});
-	}
-	for (const result of results) {
-		new Setting(containerEl)
-			.setName(result.name)
-			.setDesc(result.region || `${result.lat.toFixed(2)}, ${result.lon.toFixed(2)}`)
-			.setClass("hearth-weather-result")
-			.addButton((b) =>
-				b.setButtonText(strings.usePlace).onClick(() => {
-					cfg.place = {
-						name: result.name,
-						region: result.region || undefined,
-						lat: result.lat,
-						lon: result.lon,
-						timezone: result.timezone || undefined,
-					};
-					ctx.session[SESSION_RESULTS] = [];
-					ctx.session[SESSION_SEARCHED] = false;
-					ctx.opts.save();
-					ctx.opts.rerender();
-					ctx.requestRender();
-				}),
-			);
-	}
-}
-
-/** Latitude/longitude entry, for a place the geocoder doesn't know — or for
- * anyone who would rather not send a place name anywhere at all. */
-function coordinateFields(ctx: CardEditorContext, containerEl: HTMLElement, cfg: WeatherConfig): void {
-	const strings = t().editors.weather;
-
-	/** Write one coordinate, creating the place if this is the first one typed. */
-	const setCoord = (which: "lat" | "lon", raw: string): void => {
-		const value = Number(raw.trim());
-		if (raw.trim() === "" || Number.isNaN(value)) return;
-		const limit = which === "lat" ? 90 : 180;
-		if (Math.abs(value) > limit) return;
-		const place = (cfg.place ??= { name: "", lat: 0, lon: 0 });
-		place[which] = value;
-		if (!place.name.trim()) {
-			place.name = `${place.lat.toFixed(2)}, ${place.lon.toFixed(2)}`;
-		}
-		ctx.opts.save();
-		ctx.opts.rerender();
-	};
-
-	const coords = new Setting(containerEl)
-		.setName(strings.coordinates)
-		.setDesc(strings.coordinatesDesc);
-	coords.addText((txt) =>
-		txt
-			.setPlaceholder(strings.latPlaceholder)
-			.setValue(cfg.place ? String(cfg.place.lat) : "")
-			.onChange((v) => setCoord("lat", v)),
-	);
-	coords.addText((txt) =>
-		txt
-			.setPlaceholder(strings.lonPlaceholder)
-			.setValue(cfg.place ? String(cfg.place.lon) : "")
-			.onChange((v) => setCoord("lon", v)),
-	);
-
-	new Setting(containerEl)
-		.setName(strings.placeName)
-		.setDesc(strings.placeNameDesc)
-		.addText((txt) =>
-			txt
-				.setPlaceholder(strings.placeNamePlaceholder)
-				.setValue(cfg.place?.name ?? "")
-				.setDisabled(!cfg.place)
-				.onChange((v) => {
-					if (!cfg.place) return;
-					cfg.place.name = v;
-					ctx.opts.save();
-					ctx.opts.rerender();
-				}),
-		);
-}
-
 /** A 0-means-off count slider with a reset button, shared by the hourly and
  * daily strip lengths. */
 function countSlider(
@@ -1066,29 +734,18 @@ export function weatherEditor(ctx: CardEditorContext, containerEl: HTMLElement):
 
 	// ---- Location ----
 	new Setting(containerEl).setName(strings.location).setHeading();
-	if (cfg.place) {
-		new Setting(containerEl)
-			.setName(cfg.place.name || strings.unnamedPlace)
-			.setDesc(
-				[cfg.place.region, `${cfg.place.lat.toFixed(3)}, ${cfg.place.lon.toFixed(3)}`]
-					.filter(Boolean)
-					.join(" · "),
-			)
-			.setClass("hearth-weather-current-place")
-			.addExtraButton((b) =>
-				b
-					.setIcon("trash-2")
-					.setTooltip(strings.clearPlace)
-					.onClick(() => {
-						cfg.place = undefined;
-						ctx.opts.save();
-						ctx.opts.rerender();
-						ctx.requestRender();
-					}),
-			);
-	}
-	placePicker(ctx, containerEl, cfg);
-	coordinateFields(ctx, containerEl, cfg);
+	renderPlacePicker(containerEl, {
+		current: cfg.place,
+		onPick: (place) => {
+			cfg.place = place;
+			ctx.opts.save();
+			ctx.opts.rerender();
+		},
+		rerender: () => ctx.requestRender(),
+		disabled: ctx.opts.externalCallsDisabled,
+		session: ctx.session,
+		suggestions: configuredPlaces(ctx.opts.settings),
+	});
 
 	// ---- Style ----
 	new Setting(containerEl).setName(strings.appearance).setHeading();

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -18,6 +18,8 @@ import {
 	newDashboardId,
 } from "./types";
 import { cloneCard } from "./cards";
+import { configuredPlaces, renderSkySource } from "./placepicker";
+import { formatSkyValue, parseSkyValue } from "./sky";
 import { confirmAction } from "./ui";
 import type { WorkspacesInstance } from "./obsidian-ext";
 import { HearthTabbedModal, type HearthModalTab } from "./tabbedmodal";
@@ -202,6 +204,10 @@ function showDashboardMenu(
 class DashboardSettingsModal extends HearthTabbedModal {
 	private view: HomeView;
 	private dash: Dashboard;
+
+	/** Scratch space for the background place picker; survives this modal's
+	 * in-place rerenders, and goes when it closes. */
+	private placeSession: Record<string, unknown> = {};
 
 	constructor(view: HomeView, dash: Dashboard) {
 		super(view.app);
@@ -746,10 +752,13 @@ class DashboardSettingsModal extends HearthTabbedModal {
 					if (v === "default") {
 						dash.background = undefined;
 					} else {
+						const opacity = bg?.opacity ?? DEFAULT_DASH_BG_OPACITY;
 						dash.background = {
 							kind: v as BackgroundKind,
 							value: bg?.value ?? "",
-							opacity: bg?.opacity ?? DEFAULT_DASH_BG_OPACITY,
+							// See the same lift in the global background settings:
+							// the photo default (0.35) mutes the sky to a slab.
+							opacity: v === "weather" && opacity <= 0.5 ? 1 : opacity,
 							blur: bg?.blur ?? DEFAULT_DASH_BG_BLUR,
 						};
 					}
@@ -760,7 +769,23 @@ class DashboardSettingsModal extends HearthTabbedModal {
 
 		if (!bg || bg.kind === "none") return;
 
-		if (bg.kind !== "default") {
+		// The weather sky stores a place, not a typed-in value, so it gets the
+		// shared picker in place of the text field below.
+		if (bg.kind === "weather") {
+			renderSkySource(containerEl, {
+				current: parseSkyValue(bg.value),
+				onChange: (next) => {
+					bg.value = next ? formatSkyValue(next) : "";
+					this.commit();
+				},
+				rerender: () => this.render(),
+				disabled: this.view.plugin.settings.disableExternalCalls,
+				session: this.placeSession,
+				suggestions: configuredPlaces(this.view.plugin.settings),
+			});
+		}
+
+		if (bg.kind !== "default" && bg.kind !== "weather") {
 			const desc =
 				bg.kind === "color"
 					? t().dashboards.backgroundValueDesc.color

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -813,7 +813,7 @@ function sanitizeLeafView(r: Record<string, unknown>): LeafViewConfig {
 function sanitizeBackground(raw: unknown): BackgroundConfig | undefined {
 	if (!raw || typeof raw !== "object") return undefined;
 	const r = raw as Record<string, unknown>;
-	const kinds: BackgroundKind[] = ["none", "color", "image", "url"];
+	const kinds: BackgroundKind[] = ["none", "color", "image", "url", "weather"];
 	if (!kinds.includes(r.kind as BackgroundKind)) return undefined;
 	return {
 		kind: r.kind as BackgroundKind,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -222,6 +222,7 @@ export const en = {
 			color: "Solid color",
 			image: "Vault image",
 			url: "Image URL",
+			weather: "Live weather sky",
 		},
 		backgroundValueDesc: {
 			color: "A CSS color, e.g. #1e1e2e.",
@@ -410,7 +411,32 @@ export const en = {
 				color: "Solid color",
 				image: "Vault image",
 				url: "Image URL",
+				weather: "Live weather sky",
 			},
+			weatherHeading: "Weather sky",
+			weatherDesc:
+				"The board's backdrop becomes a painted sky — the same one the weather " +
+				"card's artistic style uses, spread across the whole window. Follow the " +
+				"real conditions over a place (from Open-Meteo; only the coordinates are " +
+				"sent, and nothing is fetched while external calls are off), or pin one " +
+				"sky and keep it, which needs no location and never goes online.",
+			weatherNoPlace: "Pick a location below to paint the sky.",
+			skySource: "Sky",
+			skySourceDesc:
+				"Follow the real weather somewhere, or keep one sky whatever it's doing outside.",
+			skySourceLive: "Live weather",
+			skySourceFixed: "A fixed sky",
+			skyCondition: "Condition",
+			skyConditionDesc: "The weather this sky always shows.",
+			skyDaylight: "Time of day",
+			skyDaylightDesc: "Whether the sky follows your clock or stays day or night.",
+			skyDaylightAuto: "Follow the clock",
+			skyDaylightDay: "Always day",
+			skyDaylightNight: "Always night",
+			skyAnimate: "Animate the sky",
+			skyAnimateDesc:
+				"Drifting clouds, falling rain and twinkling stars behind the board. Always " +
+				"off in low power mode, and for readers whose system asks for reduced motion.",
 		},
 		behaviour: {
 			heading: "Behaviour",
@@ -658,8 +684,10 @@ export const en = {
 				weather: {
 					name: "Weather forecasts",
 					desc:
-						"Weather cards fetch conditions and forecasts from Open-Meteo — free, " +
-						"key-less, no account. Only the coordinates you pick are ever sent.",
+						"Weather cards — and the live weather sky background — fetch conditions " +
+						"from Open-Meteo: free, key-less, no account. Only the coordinates you " +
+						"pick are ever sent, and a sky pinned to one condition needs no " +
+						"location at all.",
 				},
 				webSearch: {
 					name: "Web search",
@@ -1467,6 +1495,9 @@ export const en = {
 			searchEmpty: "Type a place name to search for.",
 			searchNoResults: "No places matched that name.",
 			usePlace: "Use",
+			reuse: "Reuse a location",
+			reuseDesc: "A place already set on one of your weather cards.",
+			reusePick: "Choose a location…",
 			unnamedPlace: "(unnamed place)",
 			clearPlace: "Clear location",
 			coordinates: "Coordinates",

--- a/src/placepicker.ts
+++ b/src/placepicker.ts
@@ -1,0 +1,349 @@
+/**
+ * The location controls, shared by everything that needs to know where the
+ * weather is: the weather card's editor, the global background settings, and a
+ * dashboard's background override. The background adds one more choice on top
+ * — live weather or a sky pinned to one condition — which is `renderSkySource`
+ * at the bottom of this file.
+ *
+ * It is one control rather than three copies because the behaviour is fiddly
+ * and worth getting right once — the search is a real network call that has to
+ * be cancellable, degrade when external calls are off, and survive the
+ * in-place re-renders its own buttons trigger. The caller supplies a scratch
+ * object to keep the query and results in, and gets told when a place is
+ * chosen; everything else is in here.
+ */
+import { Notice, Setting } from "obsidian";
+import { t } from "./i18n";
+import type { DashboardCard, HomeSettings, WeatherPlace } from "./types";
+import {
+	type SkyBackground,
+	type SkyDaylight,
+	SKY_GROUPS,
+	skyGroupCode,
+} from "./sky";
+import { type GeoResult, searchPlaces, type WeatherGroup, weatherLabelKey } from "./weather";
+
+/** Scratch-space keys. Namespaced because the card editor's session object is
+ * shared with the other kind editors. */
+const QUERY = "placeQuery";
+const RESULTS = "placeResults";
+const SEARCHED = "placeSearched";
+const VERSION = "placeSearchVersion";
+
+export interface PlacePickerOptions {
+	/** The place currently configured, shown with a clear button. */
+	current: WeatherPlace | undefined;
+	/** Called with the chosen place, or undefined when it is cleared. */
+	onPick: (place: WeatherPlace | undefined) => void;
+	/** Rebuild the surrounding pane, so the picker can show what changed. */
+	rerender: () => void;
+	/** True while Hearth's privacy setting blocks outbound requests: the search
+	 * is disabled and says so, but coordinates can still be typed. */
+	disabled: boolean;
+	/** Per-open scratch space that survives `rerender()` but not a reopen. */
+	session: Record<string, unknown>;
+	/** Places already configured elsewhere in the vault, offered as one-click
+	 * choices so the same location isn't looked up twice. */
+	suggestions?: WeatherPlace[];
+}
+
+/** Every distinct place already configured on a weather card, so a second
+ * consumer (a background, another card) can borrow one instead of searching
+ * again. Deduplicated on the rounded coordinates the forecast cache uses. */
+export function configuredPlaces(settings: HomeSettings): WeatherPlace[] {
+	const seen = new Set<string>();
+	const out: WeatherPlace[] = [];
+	const consider = (place: WeatherPlace | undefined): void => {
+		if (!place || !Number.isFinite(place.lat) || !Number.isFinite(place.lon)) return;
+		const key = `${place.lat.toFixed(4)},${place.lon.toFixed(4)}`;
+		if (seen.has(key)) return;
+		seen.add(key);
+		out.push(place);
+	};
+	const fromCards = (cards: DashboardCard[] | undefined): void => {
+		for (const card of cards ?? []) consider(card.weather?.place);
+	};
+	// Every board, plus the cards pinned across all of them.
+	for (const dash of settings.dashboards ?? []) fromCards(dash.cards);
+	fromCards(settings.pinnedCards);
+	return out;
+}
+
+/** A short label for a place: its name, or its coordinates when it has none. */
+export function placeLabel(place: WeatherPlace): string {
+	const name = place.name?.trim();
+	if (name) return name;
+	return `${place.lat.toFixed(2)}, ${place.lon.toFixed(2)}`;
+}
+
+/** The row showing what is configured now, with a button to clear it. */
+function currentRow(containerEl: HTMLElement, opts: PlacePickerOptions): void {
+	const place = opts.current;
+	if (!place) return;
+	const strings = t().editors.weather;
+	new Setting(containerEl)
+		.setName(placeLabel(place))
+		.setDesc(
+			[place.region, `${place.lat.toFixed(3)}, ${place.lon.toFixed(3)}`]
+				.filter(Boolean)
+				.join(" · "),
+		)
+		.setClass("hearth-weather-current-place")
+		.addExtraButton((b) =>
+			b
+				.setIcon("trash-2")
+				.setTooltip(strings.clearPlace)
+				.onClick(() => {
+					opts.onPick(undefined);
+					opts.rerender();
+				}),
+		);
+}
+
+/** One-click reuse of a place already configured on a weather card. */
+function suggestionRow(containerEl: HTMLElement, opts: PlacePickerOptions): void {
+	const suggestions = (opts.suggestions ?? []).filter(
+		(p) =>
+			!opts.current ||
+			p.lat.toFixed(4) !== opts.current.lat.toFixed(4) ||
+			p.lon.toFixed(4) !== opts.current.lon.toFixed(4),
+	);
+	if (!suggestions.length) return;
+	const strings = t().editors.weather;
+	const setting = new Setting(containerEl)
+		.setName(strings.reuse)
+		.setDesc(strings.reuseDesc);
+	let chosen = "";
+	setting.addDropdown((d) => {
+		d.addOption("", strings.reusePick);
+		suggestions.forEach((place, i) => {
+			d.addOption(String(i), placeLabel(place));
+		});
+		d.onChange((v) => {
+			chosen = v;
+		});
+	});
+	setting.addButton((b) =>
+		b.setButtonText(strings.usePlace).onClick(() => {
+			const place = suggestions[Number(chosen)];
+			if (!place) return;
+			opts.onPick({ ...place });
+			opts.rerender();
+		}),
+	);
+}
+
+/** The name search: type a name, hit Search, pick one of the matches. This is
+ * the only lookup Hearth ever does, and only when asked. */
+function searchRows(containerEl: HTMLElement, opts: PlacePickerOptions): void {
+	const strings = t().editors.weather;
+
+	const search = new Setting(containerEl)
+		.setName(strings.search)
+		.setDesc(opts.disabled ? strings.searchDisabled : strings.searchDesc)
+		.setClass("hearth-weather-search");
+
+	search.addText((txt) => {
+		txt
+			.setPlaceholder(strings.searchPlaceholder)
+			.setValue((opts.session[QUERY] as string) ?? "")
+			.onChange((v) => {
+				opts.session[QUERY] = v;
+			});
+		txt.inputEl.addClass("hearth-weather-search-input");
+	});
+
+	const run = async (button: { setDisabled(v: boolean): unknown }): Promise<void> => {
+		const query = ((opts.session[QUERY] as string) ?? "").trim();
+		if (!query) {
+			new Notice(strings.searchEmpty);
+			return;
+		}
+		// Ignore a slow search whose results land after a newer one, or after the
+		// pane has moved on.
+		const version = ((opts.session[VERSION] as number) ?? 0) + 1;
+		opts.session[VERSION] = version;
+		button.setDisabled(true);
+		const results = await searchPlaces(query, { disabled: opts.disabled });
+		if (version !== opts.session[VERSION] || !search.settingEl.isConnected) {
+			button.setDisabled(false);
+			return;
+		}
+		opts.session[RESULTS] = results;
+		opts.session[SEARCHED] = true;
+		opts.rerender();
+	};
+
+	search.addButton((b) =>
+		b
+			.setButtonText(strings.searchButton)
+			.setCta()
+			.setDisabled(opts.disabled)
+			.onClick(() => {
+				void run(b);
+			}),
+	);
+
+	const results = (opts.session[RESULTS] as GeoResult[] | undefined) ?? [];
+	if (opts.session[SEARCHED] && !results.length) {
+		containerEl.createDiv({
+			cls: "hearth-weather-search-empty setting-item-description",
+			text: strings.searchNoResults,
+		});
+	}
+	for (const result of results) {
+		new Setting(containerEl)
+			.setName(result.name)
+			.setDesc(result.region || `${result.lat.toFixed(2)}, ${result.lon.toFixed(2)}`)
+			.setClass("hearth-weather-result")
+			.addButton((b) =>
+				b.setButtonText(strings.usePlace).onClick(() => {
+					opts.onPick({
+						name: result.name,
+						region: result.region || undefined,
+						lat: result.lat,
+						lon: result.lon,
+						timezone: result.timezone || undefined,
+					});
+					opts.session[RESULTS] = [];
+					opts.session[SEARCHED] = false;
+					opts.rerender();
+				}),
+			);
+	}
+}
+
+/** Latitude/longitude entry, for a place the geocoder doesn't know — or for
+ * anyone who would rather not send a place name anywhere at all. */
+function coordinateRows(containerEl: HTMLElement, opts: PlacePickerOptions): void {
+	const strings = t().editors.weather;
+
+	/** Write one coordinate, creating the place if this is the first one typed. */
+	const setCoord = (which: "lat" | "lon", raw: string): void => {
+		const value = Number(raw.trim());
+		if (raw.trim() === "" || Number.isNaN(value)) return;
+		const limit = which === "lat" ? 90 : 180;
+		if (Math.abs(value) > limit) return;
+		const place: WeatherPlace = opts.current
+			? { ...opts.current }
+			: { name: "", lat: 0, lon: 0 };
+		place[which] = value;
+		if (!place.name.trim()) place.name = `${place.lat.toFixed(2)}, ${place.lon.toFixed(2)}`;
+		opts.onPick(place);
+	};
+
+	const coords = new Setting(containerEl)
+		.setName(strings.coordinates)
+		.setDesc(strings.coordinatesDesc);
+	coords.addText((txt) =>
+		txt
+			.setPlaceholder(strings.latPlaceholder)
+			.setValue(opts.current ? String(opts.current.lat) : "")
+			.onChange((v) => setCoord("lat", v)),
+	);
+	coords.addText((txt) =>
+		txt
+			.setPlaceholder(strings.lonPlaceholder)
+			.setValue(opts.current ? String(opts.current.lon) : "")
+			.onChange((v) => setCoord("lon", v)),
+	);
+
+	new Setting(containerEl)
+		.setName(strings.placeName)
+		.setDesc(strings.placeNameDesc)
+		.addText((txt) =>
+			txt
+				.setPlaceholder(strings.placeNamePlaceholder)
+				.setValue(opts.current?.name ?? "")
+				.setDisabled(!opts.current)
+				.onChange((v) => {
+					if (!opts.current) return;
+					opts.onPick({ ...opts.current, name: v });
+				}),
+		);
+}
+
+/** Draw the whole picker: what is set now, one-click reuse, name search, and
+ * manual coordinates. */
+export function renderPlacePicker(containerEl: HTMLElement, opts: PlacePickerOptions): void {
+	currentRow(containerEl, opts);
+	suggestionRow(containerEl, opts);
+	searchRows(containerEl, opts);
+	coordinateRows(containerEl, opts);
+}
+
+export interface SkySourceOptions extends Omit<PlacePickerOptions, "current" | "onPick"> {
+	/** What the background is set to now, or null when it is unset. */
+	current: SkyBackground | null;
+	/** Called with the new setting, or undefined to clear it. */
+	onChange: (sky: SkyBackground | undefined) => void;
+}
+
+/**
+ * Where a weather background gets its sky: the live weather over a place, or
+ * one condition pinned and kept.
+ *
+ * The fixed branch is deliberately the same painting, not a lesser one — it is
+ * for anyone who wants a clear night behind their notes whatever the sky is
+ * doing outside. It also needs no location, and so makes no request at all.
+ */
+export function renderSkySource(containerEl: HTMLElement, opts: SkySourceOptions): void {
+	const strings = t().settings.background;
+	const mode = opts.current?.mode ?? "live";
+
+	new Setting(containerEl)
+		.setName(strings.skySource)
+		.setDesc(strings.skySourceDesc)
+		.addDropdown((d) => {
+			d.addOption("live", strings.skySourceLive);
+			d.addOption("fixed", strings.skySourceFixed);
+			d.setValue(mode).onChange((v) => {
+				if (v === "fixed") {
+					// Default to the sky most people picking "fixed" are after,
+					// and keep following the clock until told otherwise.
+					opts.onChange({ mode: "fixed", group: "clear", daylight: "auto" });
+				} else {
+					// Switching back to live keeps whatever place was last set, if
+					// this control still has one; otherwise the picker below asks.
+					opts.onChange(undefined);
+				}
+				opts.rerender();
+			});
+		});
+
+	if (mode === "fixed" && opts.current?.mode === "fixed") {
+		const fixed = opts.current;
+		const conditions = t().cards.weather.conditions;
+		new Setting(containerEl)
+			.setName(strings.skyCondition)
+			.setDesc(strings.skyConditionDesc)
+			.addDropdown((d) => {
+				for (const group of SKY_GROUPS) {
+					d.addOption(group, conditions[weatherLabelKey(skyGroupCode(group))]);
+				}
+				d.setValue(fixed.group).onChange((v) => {
+					opts.onChange({ ...fixed, group: v as WeatherGroup });
+					opts.rerender();
+				});
+			});
+		new Setting(containerEl)
+			.setName(strings.skyDaylight)
+			.setDesc(strings.skyDaylightDesc)
+			.addDropdown((d) => {
+				d.addOption("auto", strings.skyDaylightAuto);
+				d.addOption("day", strings.skyDaylightDay);
+				d.addOption("night", strings.skyDaylightNight);
+				d.setValue(fixed.daylight).onChange((v) => {
+					opts.onChange({ ...fixed, daylight: v as SkyDaylight });
+					opts.rerender();
+				});
+			});
+		return;
+	}
+
+	renderPlacePicker(containerEl, {
+		...opts,
+		current: opts.current?.mode === "live" ? opts.current.place : undefined,
+		onPick: (place) => opts.onChange(place ? { mode: "live", place } : undefined),
+	});
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,10 +4,12 @@ import { TaskFieldsModal } from "./cards/tasks";
 import { hasFileIconPlugin } from "./fileicons";
 import { FILE_TYPE_GROUPS, fileTypeLabel } from "./filetypes";
 import { CommandPickerModal } from "./pickers";
+import { configuredPlaces, renderSkySource } from "./placepicker";
 import { type BackgroundKind, CARD_BORDER_WIDTH_MAX, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, LOW_POWER_BACKGROUND, type MobileActionButton, OPEN_IN_MODES, OPEN_SOURCES, type OpenIn, type OpenInRule, type OpenOutsideRule } from "./types";
 import { exportLayout, exportSettings, importLayout, importSettings } from "./layout";
 import { confirmAction, downloadTextFile, makeClickable, pickTextFile } from "./ui";
 import { isOmnisearchAvailable, OMNISEARCH_PLUGIN_ID } from "./omnisearch";
+import { formatSkyValue, parseSkyValue } from "./sky";
 import {
 	type IntegrationEntry,
 	type IntegrationGroup,
@@ -102,6 +104,11 @@ const ACTIVE_TAB_KEY = "hearth-settings-tab";
  */
 export class HomeSettingTab extends PluginSettingTab {
 	plugin: HearthPlugin;
+
+	/** Scratch space for the background place picker (its query and the last
+	 * search's results). Kept on the tab so it survives the in-place rerenders
+	 * the picker's own buttons trigger, and is dropped when the tab closes. */
+	private placeSession: Record<string, unknown> = {};
 
 	/** Members we deliberately override — the documented extension points of
 	 * `SettingTab`. Anything else that exists on the base prototype chain is an
@@ -788,13 +795,34 @@ export class HomeSettingTab extends PluginSettingTab {
 				});
 				d.setValue(s.backgroundKind).onChange((v) => {
 					s.backgroundKind = v as BackgroundKind;
+					// Opacity means different things to the two kinds of backdrop.
+					// For a photo it is "dim this so the text on top reads", and
+					// the default (0.35) is set for that. The weather sky is a
+					// gradient, not a photo — dimmed that far it is a grey slab
+					// with the weather invisible in it, and the contrast the
+					// reader needs comes from the card surfaces instead. So lift
+					// it once on the switch, only from a photo-ish value, with
+					// the slider right below to put it back.
+					if (v === "weather" && s.backgroundOpacity <= 0.5) {
+						s.backgroundOpacity = 1;
+					}
 					void this.save();
 					this.rerender();
 				});
 			});
 
-		// "default" and "none" have no value field; the others do.
-		if (s.backgroundKind !== "none" && s.backgroundKind !== "default") {
+		// The weather sky stores a place rather than a typed-in value, so it gets
+		// the shared place picker instead of the text field below.
+		if (s.backgroundKind === "weather") {
+			this.weatherBackgroundSection(containerEl);
+		}
+
+		// "default", "none" and "weather" have no free-text value field; the rest do.
+		if (
+			s.backgroundKind !== "none" &&
+			s.backgroundKind !== "default" &&
+			s.backgroundKind !== "weather"
+		) {
 			const desc =
 				s.backgroundKind === "color"
 					? t().settings.background.valueColorDesc
@@ -848,6 +876,43 @@ export class HomeSettingTab extends PluginSettingTab {
 				this.addSliderReset(blur, sl, "backgroundBlur");
 			});
 		}
+	}
+
+	/** The weather sky's own controls: where it is, and whether it moves. The
+	 * place is stored packed into `backgroundValue` — the same field the other
+	 * kinds use for a colour, a path or a URL. */
+	private weatherBackgroundSection(containerEl: HTMLElement): void {
+		const s = this.plugin.settings;
+		const strings = t().settings.background;
+		const sky = parseSkyValue(s.backgroundValue);
+
+		new Setting(containerEl).setName(strings.weatherHeading).setHeading();
+		containerEl.createDiv({
+			cls: "setting-item-description hearth-setting-note",
+			text: sky ? strings.weatherDesc : `${strings.weatherNoPlace} ${strings.weatherDesc}`,
+		});
+
+		renderSkySource(containerEl, {
+			current: sky,
+			onChange: (next) => {
+				s.backgroundValue = next ? formatSkyValue(next) : "";
+				void this.save();
+			},
+			rerender: () => this.rerender(),
+			disabled: s.disableExternalCalls,
+			session: this.placeSession,
+			suggestions: configuredPlaces(s),
+		});
+
+		new Setting(containerEl)
+			.setName(strings.skyAnimate)
+			.setDesc(strings.skyAnimateDesc)
+			.addToggle((tg) =>
+				tg.setValue(s.backgroundSkyAnimate !== false).onChange(async (v) => {
+					s.backgroundSkyAnimate = v ? undefined : false;
+					await this.save();
+				}),
+			);
 	}
 
 	// ---- Startup & tabs -------------------------------------------------

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -372,9 +372,6 @@ function drawSun(svg: SVGElement, field: SkyField): void {
 		cls: "hearth-weather-sun-disc",
 		attr: { cx: String(cx), cy: String(cy), r: "15" },
 	});
-	// The glow pulses around its own centre, which moves with the spread.
-	group.style.setProperty("--sky-celestial-x", `${cx}px`);
-	group.style.setProperty("--sky-celestial-y", `${cy}px`);
 }
 
 /** The moon: two arcs meeting where the lit disc and the shadow circle cross.
@@ -404,45 +401,109 @@ function drawMoon(svg: SVGElement, field: SkyField): void {
 			d: "M165.53,15.03 A15,15 0 1 1 145.03,35.53 A17,17 0 0 0 165.53,15.03 Z",
 		},
 	});
-	group.style.setProperty("--sky-celestial-x", `${cx}px`);
-	group.style.setProperty("--sky-celestial-y", `${cy}px`);
 }
 
-/** Horizontal fog banks, drifting against each other. */
-function drawFog(svg: SVGElement, field: SkyField): void {
+/**
+ * Fog: overlapping wisps of different sizes, drifting past each other at
+ * different speeds and depths.
+ *
+ * Three flat bands — which is what this was — read as three lines drawn across
+ * the sky, because that is what they are. Fog has no edges: what sells it is
+ * many soft shapes at low opacity, sliding over one another so the density
+ * keeps changing. The whole bank is faded as a group, so the overlaps merge
+ * into one body of haze instead of stacking into visible seams.
+ */
+function drawFog(svg: SVGElement, field: SkyField, seed = 0xf066): void {
 	const layer = svg.createSvg("g", { cls: "hearth-weather-fogbank" });
-	const bands = [
-		{ y: 0.383, h: 9, lane: 1 },
-		{ y: 0.517, h: 7, lane: 2 },
-		{ y: 0.65, h: 8, lane: 3 },
-	];
-	for (const band of bands) {
-		const h = band.h * (field.height / 120);
-		layer.createSvg("rect", {
-			cls: `is-lane-${band.lane}`,
-			attr: {
-				x: "-40",
-				y: String(Math.round(band.y * field.height)),
-				width: String(field.width + 80),
-				height: String(h),
-				rx: String(h / 2),
-			},
+	const rand = seeded(seed);
+	const count = Math.round(field.width / 26);
+	for (let i = 0; i < count; i++) {
+		// Spread down the whole sky, thickening towards the bottom the way fog
+		// actually sits: the lower half gets the bigger, denser wisps.
+		const depth = rand();
+		const y = Math.round(field.height * (0.18 + depth * 0.72));
+		const rx = Math.round(field.width * (0.12 + rand() * 0.22));
+		const ry = Math.round(field.height * (0.03 + depth * 0.055));
+		const wisp = layer.createSvg("ellipse", {
+			attr: { cx: "0", cy: String(y), rx: String(rx), ry: String(ry) },
 		});
+		// Nearer wisps (lower down) are denser and slide past faster, which is
+		// the whole parallax cue that makes a flat gradient read as depth.
+		wisp.style.opacity = (0.25 + depth * 0.45).toFixed(2);
+		const seconds = 34 + (1 - depth) * 46;
+		const x = Math.round(rand() * (field.width + rx * 2) - rx);
+		wisp.style.transform = `translateX(${x}px)`;
+		wisp.style.animationDuration = `${seconds.toFixed(1)}s`;
+		wisp.style.animationDelay = `${(-(x / field.width) * seconds).toFixed(1)}s`;
 	}
 }
 
-/** The lightning bolt, flashed by CSS. */
-function drawBolt(svg: SVGElement, field: SkyField): void {
-	// Written for the card box, then moved into place on a wider one.
-	const dx = Math.round(field.width * 0.48) - 96;
-	const dy = Math.round(field.height * 0.42) - 50;
-	svg.createSvg("polygon", {
-		cls: "hearth-weather-bolt",
-		attr: {
-			points: "96,50 84,76 94,76 86,102 108,70 97,70 106,50",
-			transform: `translate(${dx} ${dy})`,
-		},
+/**
+ * One jagged discharge, as a path: a stroke that walks down the sky, wandering
+ * sideways as it goes, with a chance of throwing off a short fork.
+ *
+ * Generated rather than drawn, because a hand-drawn bolt is a *shape* — the eye
+ * learns it in one flash and every strike after that is the same cartoon in the
+ * same place. A walk gives each strike its own crooked line, and three of them
+ * on coprime timers means the storm rarely repeats itself.
+ */
+function boltPath(rand: () => number, x: number, top: number, bottom: number): string {
+	const steps = 5 + Math.floor(rand() * 3);
+	const dy = (bottom - top) / steps;
+	let cx = x;
+	let cy = top;
+	const points = [`M${cx.toFixed(1)},${cy.toFixed(1)}`];
+	let fork = "";
+	for (let i = 0; i < steps; i++) {
+		// Each segment leans one way or the other, and the lean grows as the
+		// discharge travels — a bolt frays as it descends.
+		cx += (rand() - 0.5) * 14 * (1 + i / steps);
+		cy += dy;
+		points.push(`L${cx.toFixed(1)},${cy.toFixed(1)}`);
+		// One branch, from somewhere in the middle of the run.
+		if (!fork && i > 1 && rand() < 0.45) {
+			const fx = cx + (rand() - 0.5) * 26;
+			const fy = cy + dy * (0.7 + rand());
+			fork = ` M${cx.toFixed(1)},${cy.toFixed(1)} L${fx.toFixed(1)},${fy.toFixed(1)}`;
+		}
+	}
+	return points.join(" ") + fork;
+}
+
+/**
+ * The storm: a few discharges over a sheet flash.
+ *
+ * Each bolt runs on its own timer, and the durations are coprime-ish so they
+ * drift out of phase rather than striking together on a loop. The sheet flash
+ * behind them is what actually reads as lightning at a glance — a whole sky
+ * momentarily going pale — with the bolts as the detail inside it.
+ */
+function drawStorm(svg: SVGElement, field: SkyField, seed = 0xb017): void {
+	const rand = seeded(seed);
+	// Behind everything: the sky itself going pale for an instant.
+	svg.createSvg("rect", {
+		cls: "hearth-weather-flash",
+		attr: { x: "0", y: "0", width: String(field.width), height: String(field.height) },
 	});
+
+	const layer = svg.createSvg("g", { cls: "hearth-weather-bolts" });
+	const durations = [7.3, 11.1, 13.7];
+	const count = field.width > 300 ? 3 : 2;
+	for (let i = 0; i < count; i++) {
+		// One discharge per band of the sky, jittered inside it. Drawing all of
+		// them from one unconstrained roll let the seed put three strikes on top
+		// of each other, which reads as a scribble rather than a storm.
+		const band = (i + 0.5) / count;
+		const x = field.width * (0.12 + band * 0.76 + (rand() - 0.5) * 0.14);
+		const top = field.height * (0.1 + rand() * 0.12);
+		const bottom = field.height * (0.55 + rand() * 0.3);
+		const bolt = layer.createSvg("path", {
+			cls: "hearth-weather-bolt",
+			attr: { d: boltPath(rand, x, top, bottom) },
+		});
+		bolt.style.animationDuration = `${durations[i % durations.length]}s`;
+		bolt.style.animationDelay = `${(-rand() * 9).toFixed(1)}s`;
+	}
 }
 
 /** How many of the cloud bank a condition puts on screen — what separates
@@ -519,7 +580,7 @@ export function drawSky(parent: HTMLElement, opts: SkyOptions): HTMLElement {
 	}
 	if (group === "thunder") {
 		drawPrecipitation(svg, "rain", field);
-		drawBolt(svg, field);
+		drawStorm(svg, field);
 	}
 
 	return sky;

--- a/src/sky.ts
+++ b/src/sky.ts
@@ -1,0 +1,526 @@
+/**
+ * The painted sky: an SVG backdrop that follows the real weather and the real
+ * time of day.
+ *
+ * It started as the weather card's "artistic" style and is now shared, because
+ * the same sky can fill the whole board as its background (see background.ts).
+ * The two differ only in *spread*: a card-sized sky wants a few large shapes, a
+ * window-sized one wants many smaller ones, or a single cloud ends up the size
+ * of a note. Everything else — the palettes, the drifting, the falling — is the
+ * same code and the same CSS.
+ *
+ * The gradient itself lives in styles.css (`.sky-<group>`, plus `.is-night`);
+ * this module draws what moves in front of it. Nothing here reacts to a
+ * pointer, holds state, or survives a redraw: a sky is rebuilt wholesale each
+ * time and the caller owns when that happens.
+ */
+import type { WeatherPlace } from "./types";
+import { parsePlaceValue, type WeatherGroup, weatherGroup } from "./weather";
+
+/** How much sky there is to fill. */
+export type SkySpread = "card" | "board";
+
+// ---- Choosing which sky to paint ----------------------------------------
+
+/** Whether a sky is lit by the clock or pinned to one half of the day. */
+export type SkyDaylight = "auto" | "day" | "night";
+
+/**
+ * What a weather background is set to: the live sky over a place, or one
+ * condition chosen and kept.
+ *
+ * A fixed sky is not a lesser version of the live one — it is the reason to
+ * pick "always clear night" and keep it, and it makes the backdrop entirely
+ * offline: no place, no request, nothing to send.
+ */
+export type SkyBackground =
+	| { mode: "live"; place: WeatherPlace }
+	| { mode: "fixed"; group: WeatherGroup; daylight: SkyDaylight };
+
+/** The WMO code that stands in for a whole group when the reader picked the
+ * group rather than a forecast. Any code in the group draws the same sky; these
+ * are simply the plainest member of each. */
+const GROUP_CODES: Record<WeatherGroup, number> = {
+	clear: 0,
+	partly: 2,
+	cloudy: 3,
+	fog: 45,
+	drizzle: 53,
+	rain: 63,
+	snow: 73,
+	thunder: 95,
+};
+
+/** Every condition a fixed sky can be pinned to, in the order they're offered
+ * — clearest first, wildest last. */
+export const SKY_GROUPS: readonly WeatherGroup[] = [
+	"clear",
+	"partly",
+	"cloudy",
+	"fog",
+	"drizzle",
+	"rain",
+	"snow",
+	"thunder",
+];
+
+/** The code to draw a fixed group with. */
+export function skyGroupCode(group: WeatherGroup): number {
+	return GROUP_CODES[group];
+}
+
+/** Is it daytime, for a sky that follows the clock? The reader's own clock —
+ * a fixed sky has no location to ask about sunrise. */
+export function daylightFromHour(hour: number): boolean {
+	return hour >= 7 && hour < 20;
+}
+
+/** Resolve a fixed sky's day/night flag. */
+export function resolveDaylight(daylight: SkyDaylight, hour: number): boolean {
+	if (daylight === "day") return true;
+	if (daylight === "night") return false;
+	return daylightFromHour(hour);
+}
+
+/**
+ * Pack a weather background into the one string a `BackgroundConfig` has for it
+ * (`value`, which for the other kinds is a colour, a vault path or a URL).
+ *
+ * A live sky is stored as its packed place; a fixed one as
+ * `fixed:<group>:<daylight>`, which no place format can be mistaken for since
+ * a place starts with a number.
+ */
+export function formatSkyValue(sky: SkyBackground): string {
+	if (sky.mode === "fixed") return `fixed:${sky.group}:${sky.daylight}`;
+	const { lat, lon, name } = sky.place;
+	const head = `${lat.toFixed(4)},${lon.toFixed(4)}`;
+	return name.trim() ? `${head},${name.trim()}` : head;
+}
+
+/** Unpack a weather background. Returns null when the value is neither — an
+ * empty setting, or a colour left behind by a previous background kind. */
+export function parseSkyValue(value: string): SkyBackground | null {
+	const trimmed = value.trim();
+	if (trimmed.startsWith("fixed:")) {
+		const [, rawGroup, rawDaylight] = trimmed.split(":");
+		const group = SKY_GROUPS.find((g) => g === rawGroup);
+		if (!group) return null;
+		const daylight: SkyDaylight =
+			rawDaylight === "day" || rawDaylight === "night" ? rawDaylight : "auto";
+		return { mode: "fixed", group, daylight };
+	}
+	const place = parsePlaceValue(trimmed);
+	return place ? { mode: "live", place } : null;
+}
+
+/** One twinkling star. */
+interface Star {
+	x: number;
+	y: number;
+	r: number;
+	/** Seconds, staggering the twinkle so the field doesn't pulse in unison. */
+	delay: number;
+}
+
+/** One cloud: a centre, a size, and which of the three drift lanes it rides. */
+interface Cloud {
+	x: number;
+	y: number;
+	scale: number;
+	lane: number;
+}
+
+/**
+ * Everything that changes between a card-sized sky and a board-sized one.
+ *
+ * The shapes are drawn at a fixed size in user units, so widening the viewBox
+ * is what makes them relatively smaller — the board then adds more of them to
+ * fill the extra room. The two boxes have different aspects, chosen for the
+ * shape each one usually ends up in (see BOARD_FIELD).
+ */
+interface SkyField {
+	width: number;
+	height: number;
+	stars: readonly Star[];
+	clouds: readonly Cloud[];
+	/** Drops in the heaviest precipitation; lighter kinds scale off it. */
+	drops: number;
+	/** How far a cloud travels, in user units, before it wraps. */
+	driftFrom: number;
+	driftTo: number;
+	/** How far a drop falls before it fades out, in user units. */
+	fall: number;
+}
+
+/**
+ * A tiny deterministic generator (mulberry32).
+ *
+ * The board's star and cloud fields are too big to write out by hand, but they
+ * must not be *random*: `Math.random()` would deal a new sky on every redraw —
+ * every forecast refresh, every dashboard switch — and the constellation would
+ * visibly reshuffle behind the reader. Seeded once at module load, the field is
+ * fixed for the life of the process and identical between runs, which also
+ * makes it testable.
+ */
+function seeded(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a = (a + 0x6d2b79f5) >>> 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+/** Scatter `count` stars over the top `band` (0–1) of a `width`×`height` sky. */
+export function starField(
+	count: number,
+	width: number,
+	height: number,
+	seed: number,
+	band = 0.55,
+): Star[] {
+	const rand = seeded(seed);
+	const out: Star[] = [];
+	for (let i = 0; i < count; i++) {
+		out.push({
+			// Rounded to a tenth: the full float would only bloat the markup.
+			x: Math.round(rand() * width * 10) / 10,
+			// On a card the stars stay up top, clear of the reading laid over
+			// them; a backdrop has nothing on it, so its band reaches further down.
+			y: Math.round(rand() * height * band * 10) / 10,
+			r: Math.round((0.6 + rand() * 0.7) * 10) / 10,
+			delay: Math.round(rand() * 30) / 10,
+		});
+	}
+	return out;
+}
+
+/** Scatter `count` clouds across a `width`×`height` sky, spread over three
+ * drift lanes so the bank never moves as one slab. `top`/`depth` (both 0–1)
+ * bound the band they hang in. */
+export function cloudField(
+	count: number,
+	width: number,
+	height: number,
+	seed: number,
+	top = 0.16,
+	depth = 0.45,
+): Cloud[] {
+	const rand = seeded(seed);
+	const out: Cloud[] = [];
+	for (let i = 0; i < count; i++) {
+		out.push({
+			x: Math.round(rand() * width),
+			y: Math.round(height * top + rand() * height * depth),
+			scale: Math.round((0.7 + rand() * 0.9) * 100) / 100,
+			lane: (i % 3) + 1,
+		});
+	}
+	return out;
+}
+
+/** The card sky: hand-placed, because at three clouds and ten stars the
+ * placement is a composition rather than a scatter. */
+const CARD_FIELD: SkyField = {
+	width: 200,
+	height: 120,
+	stars: [
+		{ x: 18, y: 22, r: 1.1, delay: 0 },
+		{ x: 40, y: 12, r: 0.8, delay: 1.4 },
+		{ x: 62, y: 30, r: 1.0, delay: 0.7 },
+		{ x: 88, y: 16, r: 0.7, delay: 2.1 },
+		{ x: 112, y: 26, r: 1.2, delay: 0.3 },
+		{ x: 134, y: 10, r: 0.8, delay: 1.8 },
+		{ x: 152, y: 34, r: 0.9, delay: 1.1 },
+		{ x: 176, y: 20, r: 1.1, delay: 2.6 },
+		{ x: 28, y: 44, r: 0.7, delay: 2.3 },
+		{ x: 104, y: 48, r: 0.8, delay: 0.9 },
+	],
+	clouds: [
+		{ x: 40, y: 44, scale: 1.5, lane: 1 },
+		{ x: 130, y: 32, scale: 1.1, lane: 2 },
+		{ x: 90, y: 58, scale: 0.85, lane: 3 },
+	],
+	drops: 20,
+	driftFrom: -60,
+	driftTo: 260,
+	fall: 140,
+};
+
+/**
+ * The board sky: the same shapes over several times the area, so the field is
+ * generated rather than written out.
+ *
+ * The box is 2:1 rather than the card's 5:3 because a window is wider than a
+ * card is. `slice` crops whichever axis is in surplus, and at 5:3 a wide
+ * monitor loses a third of the height — which is exactly the band the clouds
+ * hang in, so they'd sit off the top of the screen. The field also spreads
+ * further down its box than the card's: a backdrop has no reading laid over it
+ * to keep clear of.
+ */
+const BOARD_FIELD: SkyField = {
+	width: 400,
+	height: 200,
+	stars: starField(38, 400, 200, 0x5eed, 0.85),
+	clouds: cloudField(9, 400, 200, 0xc10d, 0.08, 0.62),
+	drops: 52,
+	driftFrom: -80,
+	driftTo: 500,
+	fall: 240,
+};
+
+function fieldFor(spread: SkySpread): SkyField {
+	return spread === "board" ? BOARD_FIELD : CARD_FIELD;
+}
+
+/** How long one cloud takes to cross, by lane. Three speeds, so the bank never
+ * reads as a single sliding slab. */
+function driftSeconds(lane: number): number {
+	return 46 + lane * 20;
+}
+
+/**
+ * Draw one cloud as three overlapping discs on a slab — the shape reads as a
+ * cloud at any size, and it costs four nodes instead of a path.
+ *
+ * It comes in two nested groups, and that nesting is load-bearing. A CSS
+ * animation sets the transform *property*, which wholly replaces an element's
+ * transform *attribute* — so a cloud that carried its position in the attribute
+ * and its drift in the animation lost its position the moment it started
+ * moving, and the whole bank collapsed to the top-left corner and marched
+ * across in a row. The outer group therefore owns the horizontal drift and
+ * nothing else; the inner one owns where the cloud sits and how big it is.
+ */
+function drawCloud(svg: SVGElement, cloud: Cloud, field: SkyField): void {
+	const drift = svg.createSvg("g", {
+		// An array, not "a b": createSvg hands `cls` to classList.add(), which
+		// rejects a token containing a space. (createDiv sets the class
+		// attribute instead, which is why a two-class string is fine there.)
+		cls: ["hearth-weather-cloud", `is-lane-${cloud.lane}`],
+	});
+	const seconds = driftSeconds(cloud.lane);
+	// Same two mechanisms as the raindrops: a static offset so a still sky still
+	// has its clouds spread out, and a negative delay so a moving one starts
+	// mid-crossing rather than with every cloud queued off the left edge. The
+	// running animation overrides the inline transform, so they never fight.
+	drift.style.transform = `translateX(${cloud.x}px)`;
+	drift.style.animationDuration = `${seconds}s`;
+	drift.style.animationDelay = `${(-(cloud.x / field.width) * seconds).toFixed(1)}s`;
+
+	const group = drift.createSvg("g", {
+		attr: { transform: `translate(0 ${cloud.y}) scale(${cloud.scale})` },
+	});
+	group.createSvg("ellipse", { attr: { cx: "-14", cy: "4", rx: "16", ry: "10" } });
+	group.createSvg("ellipse", { attr: { cx: "2", cy: "-2", rx: "18", ry: "13" } });
+	group.createSvg("ellipse", { attr: { cx: "18", cy: "5", rx: "15", ry: "9" } });
+	group.createSvg("rect", { attr: { x: "-28", y: "4", width: "58", height: "11", rx: "5.5" } });
+}
+
+/** Falling precipitation: slanted streaks for rain and drizzle, drifting discs
+ * for snow. Positions are evenly spread with a per-drop delay so the fall never
+ * looks like a marching row. */
+function drawPrecipitation(svg: SVGElement, group: WeatherGroup, field: SkyField): void {
+	const snow = group === "snow";
+	const count = Math.round(field.drops * (group === "drizzle" ? 0.7 : snow ? 0.8 : 1));
+	// Two classes, so an array — see drawCloud.
+	const layer = svg.createSvg("g", { cls: ["hearth-weather-fall", `is-${group}`] });
+	const span = field.width - 10;
+	for (let i = 0; i < count; i++) {
+		// A prime-ish stride spreads the drops across the width without clumping
+		// into visible columns the way `i * width / count` would.
+		const x = ((i * 37) % span) + 5;
+		const duration = (snow ? 3.4 : 1.1) + (i % 5) * 0.18;
+		const drop = snow
+			? layer.createSvg("circle", { attr: { cx: String(x), cy: "0", r: "1.6" } })
+			: layer.createSvg("line", {
+					attr: {
+						x1: String(x),
+						y1: "0",
+						x2: String(x - 3),
+						y2: group === "drizzle" ? "7" : "11",
+					},
+			  });
+		// Spread the field down the sky. Two mechanisms, because the sky can be
+		// drawn either way: a static offset for a still sky (low power, motion
+		// off), and a *negative* delay for a moving one — every drop starts
+		// partway through its own fall, so the first frame is already a shower
+		// rather than a row of drops queued at the top. A running animation
+		// overrides the inline transform, so the two never fight.
+		const progress = i / count;
+		drop.style.transform = `translate(${-progress * 24}px, ${progress * field.fall - 10}px)`;
+		drop.style.animationDelay = `${(-progress * duration).toFixed(2)}s`;
+		// Staggering the duration too keeps the field from pulsing in unison.
+		drop.style.animationDuration = `${duration}s`;
+	}
+}
+
+/** Where the sun or moon hangs: up and to the right, in both spreads. */
+function celestialCentre(field: SkyField): { cx: number; cy: number } {
+	return { cx: Math.round(field.width * 0.79), cy: Math.round(field.height * 0.233) };
+}
+
+/** The sun, with a soft corona. */
+function drawSun(svg: SVGElement, field: SkyField): void {
+	const { cx, cy } = celestialCentre(field);
+	const group = svg.createSvg("g", { cls: "hearth-weather-sun" });
+	group.createSvg("circle", {
+		cls: "hearth-weather-sun-glow",
+		attr: { cx: String(cx), cy: String(cy), r: "30" },
+	});
+	group.createSvg("circle", {
+		cls: "hearth-weather-sun-disc",
+		attr: { cx: String(cx), cy: String(cy), r: "15" },
+	});
+	// The glow pulses around its own centre, which moves with the spread.
+	group.style.setProperty("--sky-celestial-x", `${cx}px`);
+	group.style.setProperty("--sky-celestial-y", `${cy}px`);
+}
+
+/** The moon: two arcs meeting where the lit disc and the shadow circle cross.
+ * Two overlapping circles filled `evenodd` would be the obvious shortcut and is
+ * wrong — that fills their symmetric difference, so the shadow's own outer lobe
+ * lights up too. A `<mask>` draws it correctly but needs a `<defs>` and a
+ * document-unique id: state to keep correct across every sky and every redraw,
+ * in exchange for nothing visible. */
+function drawMoon(svg: SVGElement, field: SkyField): void {
+	const { cx, cy } = celestialCentre(field);
+	const group = svg.createSvg("g", {
+		cls: "hearth-weather-moon",
+		// The crescent path below is written for the card's centre (158,28), so
+		// the whole group is translated rather than the path re-derived.
+		attr: { transform: `translate(${cx - 158} ${cy - 28})` },
+	});
+	group.createSvg("circle", {
+		cls: "hearth-weather-moon-glow",
+		attr: { cx: "158", cy: "28", r: "26" },
+	});
+	group.createSvg("path", {
+		cls: "hearth-weather-moon-disc",
+		attr: {
+			// Disc centred (158,28) r15; shadow centred (149,19) r17. The major
+			// arc of the disc out round the lit side, then the shadow's minor arc
+			// back along the terminator.
+			d: "M165.53,15.03 A15,15 0 1 1 145.03,35.53 A17,17 0 0 0 165.53,15.03 Z",
+		},
+	});
+	group.style.setProperty("--sky-celestial-x", `${cx}px`);
+	group.style.setProperty("--sky-celestial-y", `${cy}px`);
+}
+
+/** Horizontal fog banks, drifting against each other. */
+function drawFog(svg: SVGElement, field: SkyField): void {
+	const layer = svg.createSvg("g", { cls: "hearth-weather-fogbank" });
+	const bands = [
+		{ y: 0.383, h: 9, lane: 1 },
+		{ y: 0.517, h: 7, lane: 2 },
+		{ y: 0.65, h: 8, lane: 3 },
+	];
+	for (const band of bands) {
+		const h = band.h * (field.height / 120);
+		layer.createSvg("rect", {
+			cls: `is-lane-${band.lane}`,
+			attr: {
+				x: "-40",
+				y: String(Math.round(band.y * field.height)),
+				width: String(field.width + 80),
+				height: String(h),
+				rx: String(h / 2),
+			},
+		});
+	}
+}
+
+/** The lightning bolt, flashed by CSS. */
+function drawBolt(svg: SVGElement, field: SkyField): void {
+	// Written for the card box, then moved into place on a wider one.
+	const dx = Math.round(field.width * 0.48) - 96;
+	const dy = Math.round(field.height * 0.42) - 50;
+	svg.createSvg("polygon", {
+		cls: "hearth-weather-bolt",
+		attr: {
+			points: "96,50 84,76 94,76 86,102 108,70 97,70 106,50",
+			transform: `translate(${dx} ${dy})`,
+		},
+	});
+}
+
+/** How many of the cloud bank a condition puts on screen — what separates
+ * "partly cloudy" from "overcast". */
+function cloudCount(group: WeatherGroup, total: number): number {
+	if (group === "clear") return 0;
+	if (group === "partly") return Math.max(1, Math.round(total / 3));
+	if (group === "fog") return Math.max(2, Math.round(total * 0.6));
+	return total;
+}
+
+export interface SkyOptions {
+	/** WMO weather code — what the sky is doing. */
+	code: number;
+	/** Daylight at the location, not at the reader's desk. */
+	isDay: boolean;
+	/** Drift, fall and twinkle. Callers switch this off for low power mode. */
+	animate: boolean;
+	/** How much sky there is to fill. Default "card". */
+	spread?: SkySpread;
+}
+
+/**
+ * Paint a sky into `parent` and return the element it created, so a caller can
+ * lay its own content over the top.
+ */
+export function drawSky(parent: HTMLElement, opts: SkyOptions): HTMLElement {
+	const group = weatherGroup(opts.code);
+	const field = fieldFor(opts.spread ?? "card");
+
+	const sky = parent.createDiv(`hearth-weather-sky sky-${group}`);
+	sky.toggleClass("is-night", !opts.isDay);
+	sky.toggleClass("is-animated", opts.animate);
+	// The drift and fall distances are the one part of the animation that has to
+	// know how big the box is, so they cross into CSS as variables rather than
+	// being baked into the keyframes.
+	sky.style.setProperty("--sky-drift-from", `${field.driftFrom}px`);
+	sky.style.setProperty("--sky-drift-to", `${field.driftTo}px`);
+	sky.style.setProperty("--sky-fall", `${field.fall}px`);
+
+	const svg = sky.createSvg("svg", {
+		cls: "hearth-weather-art",
+		attr: {
+			viewBox: `0 0 ${field.width} ${field.height}`,
+			// `slice` fills the box at any aspect ratio, cropping rather than
+			// letterboxing — a sky with bars around it isn't a sky.
+			preserveAspectRatio: "xMidYMid slice",
+			"aria-hidden": "true",
+		},
+	});
+
+	const celestial = group === "clear" || group === "partly";
+	if (celestial) {
+		if (opts.isDay) drawSun(svg, field);
+		else drawMoon(svg, field);
+	}
+	if (celestial && !opts.isDay) {
+		const stars = svg.createSvg("g", { cls: "hearth-weather-stars" });
+		for (const star of field.stars) {
+			const dot = stars.createSvg("circle", {
+				attr: { cx: String(star.x), cy: String(star.y), r: String(star.r) },
+			});
+			dot.style.animationDelay = `${star.delay}s`;
+		}
+	}
+
+	if (group === "fog") drawFog(svg, field);
+
+	const clouds = cloudCount(group, field.clouds.length);
+	for (let i = 0; i < clouds; i++) drawCloud(svg, field.clouds[i], field);
+
+	if (group === "rain" || group === "drizzle" || group === "snow") {
+		drawPrecipitation(svg, group, field);
+	}
+	if (group === "thunder") {
+		drawPrecipitation(svg, "rain", field);
+		drawBolt(svg, field);
+	}
+
+	return sky;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -984,9 +984,16 @@ export interface DashboardCard {
 }
 
 /** Background mode for the home view. "default" uses Hearth's bundled
- * background (a curated image shipped with a release); the other kinds use the
- * user's own value. */
-export type BackgroundKind = "none" | "default" | "color" | "image" | "url";
+ * background (a curated image shipped with a release); "weather" paints the
+ * live sky for a place (see sky.ts); the other kinds use the user's own
+ * value. */
+export type BackgroundKind =
+	| "none"
+	| "default"
+	| "color"
+	| "image"
+	| "url"
+	| "weather";
 
 /** The flat backdrop low power mode paints instead of the wallpaper: a muted
  * grey-purple that sits close to Hearth's brand colour without any image
@@ -997,6 +1004,8 @@ export const LOW_POWER_BACKGROUND = "#4a4459";
  * as well as the global default). */
 export interface BackgroundConfig {
 	kind: BackgroundKind;
+	/** A CSS colour, a vault image path, a URL, or — for "weather" — a packed
+	 * place (see formatPlaceValue in weather.ts), depending on `kind`. */
 	value: string;
 	opacity: number;
 	blur: number;
@@ -1145,10 +1154,15 @@ export interface HomeSettings {
 
 	// ---- Background ----
 	backgroundKind: BackgroundKind;
-	/** A CSS color, a vault image path, or a URL depending on backgroundKind. */
+	/** A CSS colour, a vault image path, a URL, or a packed weather place
+	 * depending on backgroundKind. */
 	backgroundValue: string;
 	backgroundOpacity: number;
 	backgroundBlur: number;
+	/** Let the "weather" background drift, fall and twinkle. Default true; low
+	 * power mode replaces the whole background anyway, and a reader who has
+	 * asked their OS for reduced motion gets a still sky regardless. */
+	backgroundSkyAnimate?: boolean;
 
 	// ---- Behaviour ----
 	openOnStartup: boolean;

--- a/src/view.ts
+++ b/src/view.ts
@@ -167,7 +167,7 @@ export class HomeView extends ItemView {
 			renderCards(this.plugin.settings).length === 0;
 		root.toggleClass("hearth-empty-board", emptyBoard);
 
-		applyBackground(this, root);
+		applyBackground(this, root, child);
 
 		const scroll = root.createDiv("hearth-scroll");
 		scroll.toggleClass("hearth-fit", effectiveFitToPage(this.plugin.settings));

--- a/src/weather.ts
+++ b/src/weather.ts
@@ -20,7 +20,12 @@
  * without a network or a DOM — see test/weather.test.ts.
  */
 import { requestUrl } from "obsidian";
-import type { PrecipitationUnit, TemperatureUnit, WindUnit } from "./types";
+import type {
+	PrecipitationUnit,
+	TemperatureUnit,
+	WeatherPlace,
+	WindUnit,
+} from "./types";
 
 const FORECAST_ENDPOINT = "https://api.open-meteo.com/v1/forecast";
 const GEOCODING_ENDPOINT = "https://geocoding-api.open-meteo.com/v1/search";
@@ -618,6 +623,40 @@ export function parsePlaces(json: unknown): GeoResult[] {
 		out.push({ name, region, lat, lon, timezone: str(row.timezone) });
 	}
 	return out;
+}
+
+// ---- Packing a place into one string ------------------------------------
+
+/**
+ * A place, packed for somewhere that only has a string to store it in — the
+ * background config, whose `value` field is already a colour, a vault path or a
+ * URL depending on the kind, and which is copied around (per dashboard, through
+ * layout export/import) as a flat record.
+ *
+ * The format is `lat,lon[,name]`. The name goes last and may itself contain
+ * commas ("Praha, Czechia"), so the parser takes the first two fields as
+ * numbers and the whole remainder as the name.
+ */
+export function formatPlaceValue(place: WeatherPlace): string {
+	// Four decimals is ~10 m: past the point a forecast distinguishes, and it
+	// keeps the stored value short and readable.
+	const head = `${place.lat.toFixed(4)},${place.lon.toFixed(4)}`;
+	const name = place.name.trim();
+	return name ? `${head},${name}` : head;
+}
+
+/** Unpack a place written by {@link formatPlaceValue}. Returns null for
+ * anything that isn't one — an empty value, a leftover colour from a previous
+ * background kind, coordinates off the globe. */
+export function parsePlaceValue(value: string): WeatherPlace | null {
+	const parts = value.split(",");
+	if (parts.length < 2) return null;
+	const lat = Number(parts[0]);
+	const lon = Number(parts[1]);
+	if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+	if (Math.abs(lat) > 90 || Math.abs(lon) > 180) return null;
+	const name = parts.slice(2).join(",").trim();
+	return { name, lat, lon };
 }
 
 /**

--- a/styles.css
+++ b/styles.css
@@ -3248,10 +3248,14 @@
 .is-animated .hearth-weather-sun-glow,
 .is-animated .hearth-weather-moon-glow {
 	animation: hearth-weather-breathe 6s ease-in-out infinite;
-	/* The centre travels with the spread (a board sky is drawn in a wider
-	 * viewBox), so sky.ts publishes it rather than the stylesheet assuming the
-	 * card's. */
-	transform-origin: var(--sky-celestial-x, 158px) var(--sky-celestial-y, 28px);
+	/* Scale about the glow's own centre. Naming a point in user units instead
+	 * is what made the moon slide sideways as it breathed: the moon's crescent
+	 * is drawn in a group that is translated into place, so a coordinate that
+	 * is correct on screen is the wrong point inside that group — and scaling
+	 * about a point off to one side moves the disc rather than growing it.
+	 * `fill-box` sidesteps the whole question. */
+	transform-box: fill-box;
+	transform-origin: center;
 }
 
 @keyframes hearth-weather-breathe {
@@ -3324,36 +3328,24 @@
 	}
 }
 
-/* ---- Fog banks ---- */
+/* ---- Fog ----
+ *
+ * A bank of overlapping wisps rather than a few bands. The group is faded as a
+ * whole so the overlaps merge into one body of haze; each wisp carries its own
+ * opacity (set in sky.ts, by depth) and its own speed, and they drift the same
+ * way the clouds do. */
 .hearth-weather-fogbank {
-	opacity: 0.16;
+	opacity: 0.5;
 }
 
-.hearth-weather-fogbank rect {
+.hearth-weather-fogbank ellipse {
 	fill: #fff;
 }
 
-.is-animated .hearth-weather-fogbank rect.is-lane-1 {
-	animation: hearth-weather-fog 34s ease-in-out infinite;
-}
-
-.is-animated .hearth-weather-fogbank rect.is-lane-2 {
-	animation: hearth-weather-fog 48s ease-in-out infinite reverse;
-}
-
-.is-animated .hearth-weather-fogbank rect.is-lane-3 {
-	animation: hearth-weather-fog 60s ease-in-out infinite;
-	animation-delay: -12s;
-}
-
-@keyframes hearth-weather-fog {
-	0%,
-	100% {
-		transform: translateX(-18px);
-	}
-	50% {
-		transform: translateX(18px);
-	}
+.is-animated .hearth-weather-fogbank ellipse {
+	animation-name: hearth-weather-drift;
+	animation-timing-function: linear;
+	animation-iteration-count: infinite;
 }
 
 /* ---- Rain, drizzle and snow ---- */
@@ -3418,28 +3410,84 @@
 	}
 }
 
-/* ---- Lightning ---- */
+/* ---- Lightning ----
+ *
+ * A stroke, not a filled shape: a discharge is a line that forked, and drawing
+ * it as one lets the same path carry a bright core and a soft halo. */
 .hearth-weather-bolt {
-	fill: #ffe57a;
+	fill: none;
+	stroke: #fff6cf;
+	stroke-width: 1.4;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+	opacity: 0;
+	/* The halo. Cheaper than a blur filter over the whole backdrop, and it
+	 * survives on hardware where filters are the first thing to stutter. */
+	filter: drop-shadow(0 0 3px rgba(255, 240, 170, 0.9));
+}
+
+/* A still storm (low power, motion off, reduced motion) still needs to look
+ * like a storm rather than plain rain, so the discharges simply stay lit. */
+.hearth-weather-sky:not(.is-animated) .hearth-weather-bolt {
+	opacity: 0.85;
+}
+
+.hearth-weather-flash {
+	fill: #fff;
 	opacity: 0;
 }
 
+/* Each bolt gets its own duration and phase in sky.ts, so the strikes drift
+ * out of step instead of firing together on a loop. */
 .is-animated .hearth-weather-bolt {
-	animation: hearth-weather-flash 7s steps(1, end) infinite;
+	animation-name: hearth-weather-strike;
+	animation-timing-function: steps(1, end);
+	animation-iteration-count: infinite;
 }
 
-@keyframes hearth-weather-flash {
+.is-animated .hearth-weather-flash {
+	animation: hearth-weather-sheet 11.1s steps(1, end) infinite;
+}
+
+/* Most of the cycle is dark. The strike itself is a stutter — bright, gone,
+ * brighter — because that flicker is what the eye reads as lightning. */
+@keyframes hearth-weather-strike {
 	0%,
-	4%,
+	2.4%,
 	100% {
 		opacity: 0;
 	}
-	1%,
-	3% {
+	0.4% {
 		opacity: 0.95;
 	}
-	2% {
-		opacity: 0.3;
+	0.9% {
+		opacity: 0.15;
+	}
+	1.4% {
+		opacity: 1;
+	}
+	1.9% {
+		opacity: 0.4;
+	}
+}
+
+@keyframes hearth-weather-sheet {
+	0%,
+	3%,
+	100% {
+		opacity: 0;
+	}
+	0.5% {
+		opacity: 0.16;
+	}
+	1% {
+		opacity: 0.04;
+	}
+	1.6% {
+		opacity: 0.2;
+	}
+	2.2% {
+		opacity: 0.05;
 	}
 }
 

--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,17 @@
 	background-position: center;
 }
 
+/* The live weather sky as the board's backdrop. It is the same element the
+ * weather card's artistic style draws (see sky.ts), so it arrives styled —
+ * all it needs here is to fill the layer instead of sitting in a card's flex
+ * column, and to stay behind everything. The layer's own opacity and blur
+ * still apply, so a sky can be dialled back to a wash like any wallpaper. */
+.hearth-bg > .hearth-weather-sky {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+}
+
 /* ---- Low power mode ---------------------------------------------------
  *
  * The paint-cost half of the setting. Everything with a value behind it — the
@@ -3237,7 +3248,10 @@
 .is-animated .hearth-weather-sun-glow,
 .is-animated .hearth-weather-moon-glow {
 	animation: hearth-weather-breathe 6s ease-in-out infinite;
-	transform-origin: 158px 28px;
+	/* The centre travels with the spread (a board sky is drawn in a wider
+	 * viewBox), so sky.ts publishes it rather than the stylesheet assuming the
+	 * card's. */
+	transform-origin: var(--sky-celestial-x, 158px) var(--sky-celestial-y, 28px);
 }
 
 @keyframes hearth-weather-breathe {
@@ -3289,28 +3303,24 @@
 }
 
 /* Each lane drifts at its own speed, so the bank never moves as one slab. The
- * translation is in viewBox units: -60 to 260 crosses the full 200-wide box
- * with enough overshoot that a cloud is never seen popping in. */
-.is-animated .hearth-weather-cloud.is-lane-1 {
-	animation: hearth-weather-drift 46s linear infinite;
+ * duration and the phase are set per cloud in sky.ts (they depend on where in
+ * the box the cloud starts); the stylesheet only says what the motion is. */
+.is-animated .hearth-weather-cloud {
+	animation-name: hearth-weather-drift;
+	animation-timing-function: linear;
+	animation-iteration-count: infinite;
 }
 
-.is-animated .hearth-weather-cloud.is-lane-2 {
-	animation: hearth-weather-drift 66s linear infinite;
-	animation-delay: -20s;
-}
-
-.is-animated .hearth-weather-cloud.is-lane-3 {
-	animation: hearth-weather-drift 86s linear infinite;
-	animation-delay: -50s;
-}
-
+/* The distances are variables because they are the one part of the animation
+ * that has to know how wide the box is: a board-sized sky is drawn in a wider
+ * viewBox, and a cloud that stops at the card's 260 would strand mid-screen.
+ * sky.ts sets them; the fallbacks are the card's. */
 @keyframes hearth-weather-drift {
 	from {
-		transform: translateX(-60px);
+		transform: translateX(var(--sky-drift-from, -60px));
 	}
 	to {
-		transform: translateX(260px);
+		transform: translateX(var(--sky-drift-to, 260px));
 	}
 }
 
@@ -3389,7 +3399,7 @@
 		opacity: 0.6;
 	}
 	to {
-		transform: translate(-24px, 140px);
+		transform: translate(-24px, var(--sky-fall, 140px));
 		opacity: 0;
 	}
 }
@@ -3403,7 +3413,7 @@
 		opacity: 0.85;
 	}
 	to {
-		transform: translate(14px, 136px);
+		transform: translate(14px, var(--sky-fall, 140px));
 		opacity: 0;
 	}
 }
@@ -3430,6 +3440,15 @@
 	}
 	2% {
 		opacity: 0.3;
+	}
+}
+
+/* A reader who has asked the OS for less motion gets a still sky: the shapes
+ * stay where sky.ts placed them (drops are spread down the field for exactly
+ * this case), so nothing disappears — it simply stops moving. */
+@media (prefers-reduced-motion: reduce) {
+	.hearth-weather-sky.is-animated * {
+		animation: none !important;
 	}
 }
 

--- a/test/sky.test.ts
+++ b/test/sky.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+	cloudField,
+	daylightFromHour,
+	formatSkyValue,
+	parseSkyValue,
+	resolveDaylight,
+	SKY_GROUPS,
+	skyGroupCode,
+	starField,
+} from "../src/sky";
+import { weatherGroup } from "../src/weather";
+
+/**
+ * The sky's pure half: which sky a background is set to, and the generated
+ * star/cloud fields behind a board-sized one. The drawing itself is SVG in a
+ * DOM and stays untested here (see the preview harness in the PR notes); what
+ * is covered is everything that decides *what* gets drawn.
+ */
+
+describe("packing a sky background", () => {
+	it("round-trips a live place", () => {
+		const value = formatSkyValue({
+			mode: "live",
+			place: { name: "Prague", lat: 50.0755, lon: 14.4378 },
+		});
+		expect(value).toBe("50.0755,14.4378,Prague");
+		expect(parseSkyValue(value)).toEqual({
+			mode: "live",
+			place: { name: "Prague", lat: 50.0755, lon: 14.4378 },
+		});
+	});
+
+	it("keeps a place name that contains a comma", () => {
+		// The name goes last precisely so it can hold "Praha, Czechia".
+		const value = formatSkyValue({
+			mode: "live",
+			place: { name: "Praha, Czechia", lat: 50.0755, lon: 14.4378 },
+		});
+		expect(parseSkyValue(value)).toMatchObject({
+			mode: "live",
+			place: { name: "Praha, Czechia" },
+		});
+	});
+
+	it("round-trips a fixed sky", () => {
+		const value = formatSkyValue({ mode: "fixed", group: "snow", daylight: "night" });
+		expect(value).toBe("fixed:snow:night");
+		expect(parseSkyValue(value)).toEqual({
+			mode: "fixed",
+			group: "snow",
+			daylight: "night",
+		});
+	});
+
+	it("round-trips every condition a fixed sky can be pinned to", () => {
+		for (const group of SKY_GROUPS) {
+			const value = formatSkyValue({ mode: "fixed", group, daylight: "auto" });
+			expect(parseSkyValue(value), group).toEqual({ mode: "fixed", group, daylight: "auto" });
+		}
+	});
+
+	it("tells a fixed sky from a place without ambiguity", () => {
+		// A packed place always starts with a number, so the "fixed:" prefix can
+		// never be one — which is what lets both live in the same field.
+		expect(parseSkyValue("fixed:rain:day")?.mode).toBe("fixed");
+		expect(parseSkyValue("50.07,14.44")?.mode).toBe("live");
+	});
+
+	it("falls back to following the clock on an unknown daylight", () => {
+		expect(parseSkyValue("fixed:rain:whenever")).toEqual({
+			mode: "fixed",
+			group: "rain",
+			daylight: "auto",
+		});
+		expect(parseSkyValue("fixed:rain")).toMatchObject({ daylight: "auto" });
+	});
+
+	it("rejects anything that is neither", () => {
+		// Chiefly a value left behind by a previous background kind.
+		expect(parseSkyValue("")).toBeNull();
+		expect(parseSkyValue("#1e1e2e")).toBeNull();
+		expect(parseSkyValue("Attachments/bg.png")).toBeNull();
+		expect(parseSkyValue("https://example.com/sky.jpg")).toBeNull();
+		expect(parseSkyValue("fixed:hurricane:day")).toBeNull();
+		// Coordinates off the globe.
+		expect(parseSkyValue("500,14")).toBeNull();
+	});
+
+	it("drops a name that is only whitespace rather than storing a trailing comma", () => {
+		expect(formatSkyValue({ mode: "live", place: { name: "  ", lat: 1, lon: 2 } })).toBe(
+			"1.0000,2.0000",
+		);
+	});
+});
+
+describe("fixed sky conditions", () => {
+	it("gives every group a code that classifies back to it", () => {
+		// The stand-in code has to round-trip, or picking "Snow" would paint rain.
+		for (const group of SKY_GROUPS) {
+			expect(weatherGroup(skyGroupCode(group)), group).toBe(group);
+		}
+	});
+
+	it("offers every group the drawing knows", () => {
+		expect([...SKY_GROUPS].sort()).toEqual([
+			"clear",
+			"cloudy",
+			"drizzle",
+			"fog",
+			"partly",
+			"rain",
+			"snow",
+			"thunder",
+		]);
+	});
+});
+
+describe("daylight", () => {
+	it("calls the middle of the day day, and the small hours night", () => {
+		expect(daylightFromHour(12)).toBe(true);
+		expect(daylightFromHour(7)).toBe(true);
+		expect(daylightFromHour(19)).toBe(true);
+		expect(daylightFromHour(20)).toBe(false);
+		expect(daylightFromHour(3)).toBe(false);
+		expect(daylightFromHour(0)).toBe(false);
+	});
+
+	it("lets a fixed sky override the clock in both directions", () => {
+		expect(resolveDaylight("day", 3)).toBe(true);
+		expect(resolveDaylight("night", 12)).toBe(false);
+		expect(resolveDaylight("auto", 12)).toBe(true);
+		expect(resolveDaylight("auto", 3)).toBe(false);
+	});
+});
+
+describe("generated fields", () => {
+	it("deals the same sky every time for a given seed", () => {
+		// The whole reason the generator is seeded: a redraw (every forecast
+		// refresh, every dashboard switch) must not reshuffle the constellation
+		// under the reader.
+		expect(starField(12, 400, 200, 99)).toEqual(starField(12, 400, 200, 99));
+		expect(cloudField(6, 400, 200, 7)).toEqual(cloudField(6, 400, 200, 7));
+	});
+
+	it("deals a different sky for a different seed", () => {
+		expect(starField(12, 400, 200, 1)).not.toEqual(starField(12, 400, 200, 2));
+	});
+
+	it("keeps stars inside the box and inside their band", () => {
+		for (const star of starField(60, 400, 200, 5, 0.85)) {
+			expect(star.x).toBeGreaterThanOrEqual(0);
+			expect(star.x).toBeLessThanOrEqual(400);
+			expect(star.y).toBeGreaterThanOrEqual(0);
+			expect(star.y).toBeLessThanOrEqual(200 * 0.85);
+			expect(star.r).toBeGreaterThan(0);
+		}
+	});
+
+	it("keeps clouds in their band and spread across the three drift lanes", () => {
+		const clouds = cloudField(9, 400, 200, 11, 0.08, 0.62);
+		for (const cloud of clouds) {
+			expect(cloud.x).toBeGreaterThanOrEqual(0);
+			expect(cloud.x).toBeLessThanOrEqual(400);
+			expect(cloud.y).toBeGreaterThanOrEqual(200 * 0.08);
+			expect(cloud.y).toBeLessThanOrEqual(200 * 0.7);
+			expect(cloud.scale).toBeGreaterThan(0);
+		}
+		expect(new Set(clouds.map((c) => c.lane))).toEqual(new Set([1, 2, 3]));
+	});
+
+	it("asks for nothing when asked for nothing", () => {
+		expect(starField(0, 400, 200, 1)).toEqual([]);
+		expect(cloudField(0, 400, 200, 1)).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Turns the weather card's artistic style into a **background**. **Settings → Appearance → Background** gains a new type, **Live weather sky** — and so does a dashboard's own background override, so one board can sit under a live sky and another under a permanent clear night.

The whole window becomes the painted sky: sun, crescent moon and a full field of stars, clouds drifting in three lanes, rain, drizzle, snow, fog banks and lightning, following the real conditions and the real time of day over a place you pick.

**It's the same painting redrawn for the space, not the card's one stretched.** A window is several times a card, so the board spread gets its own box (2:1 rather than the card's 5:3 — closer to a window's shape, so `slice` crops less of the band the clouds hang in), a fuller star field, more clouds and more rain. The star and cloud fields come from a seeded PRNG rather than `Math.random`, so a redraw — every forecast refresh, every dashboard switch — doesn't reshuffle the constellation under the reader.

**Or pin a sky and keep it.** Set the sky to *fixed* instead of live, choose the condition yourself (clear, partly cloudy, overcast, fog, drizzle, rain, snow, thunderstorm) and whether it follows your clock or stays permanently day or night. A fixed sky needs no location and **never goes online at all**.

Picking a place is the card's own search, or coordinates, or **one-click reuse** of a place already set on a weather card. The background asks Open-Meteo for default units precisely so its cache entry is the same one a default card uses — a card and a background on the same place make one request, not two — and it refreshes every half hour.

### Structure

- `src/sky.ts` — the drawing, now shared by the card and the background, with a `spread` of `"card"` or `"board"`; also the pure "which sky is this set to" packing
- `src/placepicker.ts` — the location controls, shared by the card editor and both background editors
- `background.ts`, `settings.ts`, `dashboards.ts`, `types.ts`, `layout.ts`, `locales/en.ts`, `styles.css`, README, CHANGELOG
- `test/sky.test.ts` — 17 assertions over the packed value, the fixed-sky conditions, daylight resolution and the generated fields

### A bug this uncovered in the merged card

Every cloud carried its position and scale in an SVG `transform` **attribute** and its drift in a CSS animation — and a CSS animation replaces the transform attribute outright. So the moment a sky started moving, the whole bank lost its placement and slid across the top edge in a row. I had seen this in the card screenshots and read it as "clouds hanging from the top". Drift now lives in an outer group and placement in an inner one, so a cloudy sky is a sky with clouds in it. This fixes the card as well as the background.

### Odds and ends

- Skies stop moving under `prefers-reduced-motion`; low power mode still replaces the whole background with its flat colour.
- Switching to a sky lifts the background opacity once if it's still at a photo-oriented value — 0.35 is right for dimming a photograph and turns a gradient into a grey slab. The slider is right below it.
- The layout importer accepts the new kind, so an exported board keeps its sky.

## Related issue

None. Happy to open one if you'd rather align first.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (also `npm run typecheck`, `npm run lint` with 0 errors, and `npm test` — 476 tests)
- [ ] I've tested this in an actual vault

On the last box: as with #186 I bundled the real render code against a DOM shim and screenshotted it in Chromium — every condition at board spread, day and night, at several window shapes, plus every fixed-sky mode and the card styles after the refactor. That shim now mirrors Obsidian's `createSvg`/`classList` strictness, which is what let the cloud bug above surface. **A pass in a real vault is still worth doing before merge** — particularly the settings flow (switching background type, picking a place, switching to a fixed sky) and a dashboard-level override.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeUEsubMEwXYY35j8r5Pay)_