### PR TITLE
feat(cards): add a Git card driven by the obsidian-git plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,34 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   than blanking the card, the sky stops animating in low power mode, and the
   whole thing goes quiet under **Settings → Behaviour → Disable external
   calls**. Open-Meteo joins the Integrations catalogue.
+- **Git card.** If your vault is a repository kept by the
+  [Git](https://github.com/Vinzent03/obsidian-git) plugin, the dashboard can now
+  show and drive it. The card puts the branch, the staged and changed files, the
+  unpushed commit count, the time of the last commit and the recent log on the
+  board, and gives you buttons for **commit-and-sync, commit, push, pull, fetch,
+  stage all, unstage all, discard all** and **switch branch**, plus one-click
+  ways into the Git plugin's own source-control and history panels.
+  Right-clicking a changed file offers its diff, staging, unstaging and discard;
+  clicking one opens the note.
+
+  **None of it is a second git client.** Every action is the Git plugin doing
+  the work, queued on that plugin's own task queue — so your remote,
+  credentials, commit-message template, submodule and backup settings all apply
+  exactly as they do from the command palette, a card button can't interleave
+  with an automatic backup, and errors surface where you already expect them.
+  The card follows the Git plugin's own events instead of polling, so it moves
+  in step with its source-control view, including after an automatic backup.
+
+  **Built to be arranged.** Choose which of the four sections the card stacks
+  (status, buttons, changed files, recent commits) and which buttons it offers,
+  in which order, as icons or icons with labels. Decide what a commit from the
+  card covers — staged-if-anything-is-staged (what the Git plugin itself does),
+  everything, or only staged — give it a fixed commit message or let the plugin
+  prompt for one each time, cap the file and commit lists, and turn on folder
+  paths or an extra timed re-read for a repo that also changes outside Obsidian.
+  Discarding asks first unless you say otherwise. The card only appears in the
+  "Add card" picker while the Git plugin is enabled, and Git joins the
+  Integrations catalogue.
 - **Datacore card.** Dataview is winding down in favour of
   [Datacore](https://github.com/blacksmithgu/datacore), so Hearth now has a card
   for it, in the same shape as the Dataview card: pick a query type, write a
@@ -79,7 +107,7 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   joins the Integrations catalogue.
 - **Every integration in one place.** **Settings → Integrations** now opens with
   a complete catalogue of everything Hearth works with — community plugins
-  (Omnisearch, TaskNotes, Dataview, Iconic, Iconize, Excalidraw), Obsidian's own
+  (Omnisearch, TaskNotes, Dataview, Git, Iconic, Iconize, Excalidraw), Obsidian's own
   core plugins (Bases, Canvas, Daily notes, Bookmarks, Search, File explorer,
   Workspaces, Audio recorder, plus any plugin whose side panel a Plugin view
   card can host) and the external services some cards fetch from (Jira, RSS and Atom

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ launchers — on desktop and mobile.
 Think of it as a new-tab dashboard, start page and command launcher in one.
 
 - 🔍 **Search everything** — fuzzy, full-text, tags, frontmatter and commands
-- 🧩 **25+ card types** — embeds, tasks, calendars, Dataview, Jira, and more
+- 🧩 **25+ card types** — embeds, tasks, calendars, Dataview, Git, Jira, and more
 - 🎛️ **Free-form layout** — drag, resize and snap cards anywhere
 - 🪟 **Frosted glass** — per-card opacity, blur, color and corner radius
 - 🗂️ **Multiple dashboards** — switch with a click or a hotkey
@@ -130,6 +130,14 @@ Add cards from the **Arrange** toolbar; configure each one from the card itself
   strip and a daily forecast.
 - **Clock & greeting** — digital or analogue face, custom date formats, and an
   optional playful greeting.
+- **Git** *(requires [Git](https://github.com/Vinzent03/obsidian-git))* — your
+  vault's repository at a glance: branch, staged and changed files, unpushed
+  commits and the recent log, with buttons that commit, sync, push, pull,
+  stage and discard. Every one of those is the Git plugin doing the work
+  through its own task queue, so your remote, credentials and commit-message
+  template apply unchanged — and right-clicking a changed file offers its diff,
+  staging and discard. Choose which sections and which buttons the card shows,
+  and what a commit from it covers.
 
 **Launchers & utilities**
 

--- a/src/cards/git.ts
+++ b/src/cards/git.ts
@@ -1,0 +1,751 @@
+import { Component, Menu, Notice, setIcon, Setting, TFile } from "obsidian";
+import { emptyState, moment } from "../cardbodies";
+import { addResetButton, moveItem } from "../editors";
+import {
+	GIT_ACTION_DEFS,
+	GIT_ACTION_STYLES,
+	GIT_ACTIONS,
+	GIT_COMMIT_SCOPES,
+	GIT_SECTIONS,
+	commitSummary,
+	gitActionAvailable,
+	gitActions,
+	gitChangeCounts,
+	gitChangeRows,
+	gitSections,
+	getGitPlugin,
+	isGitAvailable,
+	onlyStagedFor,
+	openGitDiff,
+	openGitView,
+	parseCommitDate,
+	queueGitAction,
+	queueGitFileAction,
+	readGitSnapshot,
+	shortHash,
+	type GitAction,
+	type GitActionStyle,
+	type GitChangeRow,
+	type GitCommitScope,
+	type GitPlugin,
+	type GitSnapshot,
+} from "../git";
+import { t } from "../i18n";
+import { openFile } from "../opener";
+import { effectiveAutoRefreshMinutes, type DashboardCard } from "../types";
+import { confirmAction, makeClickable } from "../ui";
+import { type HomeView } from "../view";
+import { type CardDefinition, type CardEditorContext } from "./definition";
+
+
+// ---- Git (obsidian-git) -------------------------------------------------
+
+/**
+ * A card showing the state of the vault's git repository — branch, ahead
+ * count, what has changed, recent commits — with buttons that commit, sync,
+ * push, pull and stage.
+ *
+ * Every one of those is a call into the obsidian-git plugin (see `src/git.ts`),
+ * queued on that plugin's own task queue: the card is a view onto obsidian-git,
+ * not a second git client. That is also why it needs no settings of its own for
+ * remotes, credentials or commit-message templates — those live in obsidian-git
+ * and apply here unchanged.
+ *
+ * It stays current by following obsidian-git's workspace events rather than
+ * polling, so it updates in step with that plugin's own source-control view,
+ * including after an automatic backup. Optional polling exists for the rare
+ * case of a repo changed from outside Obsidian.
+ */
+export function renderGit(
+	view: HomeView,
+	card: DashboardCard,
+	body: HTMLElement,
+	component: Component,
+): void {
+	const plugin = getGitPlugin(view.app);
+	if (!plugin) {
+		emptyState(body, "git-branch", t().cards.empty.gitEnable);
+		return;
+	}
+
+	const cfg = card.git ?? {};
+	const sections = gitSections(cfg.sections);
+	const wantsLog = sections.includes("log");
+	const logLimit = wantsLog ? Math.max(1, cfg.logLimit ?? 5) : 0;
+	// The ahead-count and last-commit time are only drawn by the status line, and
+	// both cost a git call, so a card without it doesn't pay for them.
+	const includeSync = sections.includes("status");
+	const changeLimit = cfg.changeLimit ?? 8;
+
+	// Async reads can land after the card was torn down and rebuilt; drop them.
+	let destroyed = false;
+	component.register(() => {
+		destroyed = true;
+	});
+
+	const wrap = body.createDiv("hearth-git");
+	let snapshot: GitSnapshot = { status: plugin.cachedStatus };
+	let loading = false;
+	let busy = false;
+	/** Bumped per read so a slow one that finishes after a newer one is dropped. */
+	let readToken = 0;
+
+	/** Re-read the repo through obsidian-git, then repaint. */
+	const refresh = (): void => {
+		const token = ++readToken;
+		loading = true;
+		paint();
+		void readGitSnapshot(plugin, { logLimit, includeSync }).then((next) => {
+			if (destroyed || token !== readToken) return;
+			snapshot = next;
+			loading = false;
+			paint();
+		});
+	};
+
+	/** Run an action, then re-read. `busy` disables the buttons meanwhile, so a
+	 * double-click can't queue the same commit twice. */
+	const run = (action: GitAction): void => {
+		const def = GIT_ACTION_DEFS[action];
+		if (def.view) {
+			void openGitView(view.app, def.view);
+			return;
+		}
+		const start = (): void => {
+			busy = true;
+			paint();
+			const queued = queueGitAction(
+				plugin,
+				action,
+				{
+					commitMessage: cfg.commitMessage?.trim() || undefined,
+					requestCustomMessage: cfg.askForMessage,
+					onlyStaged: onlyStagedFor(cfg.commitScope, snapshot.status),
+				},
+				() => {
+					if (destroyed) return;
+					busy = false;
+					refresh();
+				},
+			);
+			if (!queued) {
+				busy = false;
+				new Notice(t().cards.git.unsupported);
+				paint();
+			}
+		};
+		if (def.destructive && !cfg.skipConfirm) {
+			confirmAction(view.app, {
+				title: t().cards.git.confirmTitle,
+				message: t().cards.git.confirmDiscard,
+				confirmText: t().cards.git.confirmDiscardButton,
+				onConfirm: start,
+			});
+			return;
+		}
+		start();
+	};
+
+	/** Rebuild the whole body from the current snapshot. */
+	const paint = (): void => {
+		wrap.empty();
+		wrap.toggleClass("is-busy", busy || loading);
+
+		if (!plugin.gitReady) {
+			// The plugin is loaded but has no repository open — either it is still
+			// starting up, or this vault isn't a repo. Both are worth saying, and
+			// both are fixed from obsidian-git's own view.
+			const empty = wrap.createDiv("hearth-git-notready");
+			emptyState(empty, "git-branch", t().cards.empty.gitNotReady);
+			const button = empty.createEl("button", {
+				cls: "hearth-git-notready-button",
+				text: t().cards.git.openSourceControl,
+			});
+			button.addEventListener("click", () => void openGitView(view.app, "sourceControl"));
+			return;
+		}
+
+		for (const section of sections) {
+			switch (section) {
+				case "status":
+					paintStatus(wrap, snapshot, loading, () => run("switchBranch"), refresh);
+					break;
+				case "actions":
+					paintActions(wrap, plugin, cfg.actions, cfg.actionStyle, busy, run);
+					break;
+				case "changes":
+					paintChanges(view, plugin, wrap, snapshot, changeLimit, cfg.showPaths, refresh);
+					break;
+				case "log":
+					paintLog(view, wrap, snapshot, logLimit);
+					break;
+			}
+		}
+	};
+
+	paint();
+	refresh();
+
+	// Follow obsidian-git rather than poll it: it refreshes after every
+	// operation of its own (including the automatic backup), and repainting
+	// from the status it hands us costs nothing.
+	/** When the plugin last handed us a status, so the `refreshed` handler below
+	 * can tell "the plugin already read it" from "the plugin skipped the read". */
+	let statusEventAt = 0;
+	component.registerEvent(
+		view.app.workspace.on("obsidian-git:status-changed", (status) => {
+			if (destroyed) return;
+			statusEventAt = Date.now();
+			snapshot = { ...snapshot, status };
+			paint();
+		}),
+	);
+	// The plugin finished a refresh cycle — but it only re-reads the status
+	// during one when its own status bar or one of its views needs it, and a
+	// Hearth card is neither. So when that cycle produced no status event, the
+	// card reads for itself; when it did, the paint above already happened and
+	// there is nothing left to do.
+	component.registerEvent(
+		view.app.workspace.on("obsidian-git:refreshed", () => {
+			if (destroyed || busy) return;
+			if (Date.now() - statusEventAt < 2000) return;
+			refresh();
+		}),
+	);
+	// HEAD moved (a commit, a checkout, a pull): the branch, the ahead count and
+	// the log are all stale, so this one needs a full re-read.
+	component.registerEvent(
+		view.app.workspace.on("obsidian-git:head-change", () => {
+			if (!destroyed) refresh();
+		}),
+	);
+
+	// Polling is off by default; the events above already cover everything done
+	// inside Obsidian. It earns its keep for a repo also being changed from a
+	// terminal or another device. Low power mode suppresses the timer entirely.
+	const refreshMin = effectiveAutoRefreshMinutes(view.plugin.settings, cfg.refreshMin ?? 0);
+	if (refreshMin > 0) {
+		component.registerInterval(
+			window.setInterval(() => {
+				if (!destroyed && !busy) refresh();
+			}, refreshMin * 60_000),
+		);
+	}
+}
+
+
+/** The status line: branch, what it tracks, how far ahead, and the size of the
+ * working tree's changes. */
+function paintStatus(
+	wrap: HTMLElement,
+	snapshot: GitSnapshot,
+	loading: boolean,
+	onBranch: () => void,
+	onRefresh: () => void,
+): void {
+	const strings = t().cards.git;
+	const row = wrap.createDiv("hearth-git-status");
+
+	const branchName = snapshot.branch?.current;
+	const branch = row.createDiv("hearth-git-branch");
+	setIcon(branch.createDiv("hearth-git-branch-icon"), "git-branch");
+	branch.createSpan({
+		cls: "hearth-git-branch-name",
+		text: branchName || strings.noBranch,
+	});
+	if (branchName) {
+		branch.setAttribute("title", snapshot.branch?.tracking ?? strings.noUpstream);
+		makeClickable(branch, onBranch, strings.actions.switchBranch);
+		branch.addEventListener("click", onBranch);
+	}
+
+	const counts = gitChangeCounts(snapshot.status);
+	const chips = row.createDiv("hearth-git-chips");
+	/** One count chip; drawn only when it has something to say. */
+	const chip = (
+		value: number,
+		icon: string,
+		label: string,
+		cls: string,
+	): void => {
+		if (value <= 0) return;
+		const el = chips.createDiv(`hearth-git-chip ${cls}`);
+		setIcon(el.createSpan("hearth-git-chip-icon"), icon);
+		el.createSpan({ cls: "hearth-git-chip-value", text: String(value) });
+		el.setAttribute("title", label);
+		el.setAttribute("aria-label", `${value} ${label}`);
+	};
+	chip(counts.conflicted, "alert-triangle", strings.conflicted, "is-conflicted");
+	chip(counts.staged, "check", strings.staged, "is-staged");
+	chip(counts.unstaged, "pencil", strings.unstaged, "is-unstaged");
+	chip(snapshot.unpushed ?? 0, "upload", strings.unpushed, "is-unpushed");
+
+	if (counts.total === 0 && !(snapshot.unpushed ?? 0)) {
+		chips.createSpan({ cls: "hearth-git-clean", text: strings.clean });
+	}
+
+	const last = snapshot.lastCommit;
+	if (last) {
+		row.createDiv({
+			cls: "hearth-git-lastcommit",
+			text: strings.lastCommit(relativeTime(last)),
+		});
+	}
+	// The refresh control doubles as the busy indicator: it spins while a read is
+	// in flight, which is also when pressing it again would be pointless.
+	const refresh = row.createEl("button", {
+		cls: "hearth-git-refresh",
+		attr: { "aria-label": strings.refresh },
+		title: strings.refresh,
+	});
+	setIcon(refresh, "refresh-cw");
+	if (loading) refresh.addClass("is-loading");
+	refresh.addEventListener("click", onRefresh);
+}
+
+
+/** The button row. Unavailable actions are drawn disabled rather than hidden,
+ * so a card configured against a newer obsidian-git doesn't silently lose the
+ * button the user put there. */
+function paintActions(
+	wrap: HTMLElement,
+	plugin: GitPlugin,
+	configured: readonly GitAction[] | undefined,
+	style: GitActionStyle | undefined,
+	busy: boolean,
+	run: (action: GitAction) => void,
+): void {
+	const actions = gitActions(configured);
+	if (actions.length === 0) return;
+	const labelled = style === "labelled";
+	const row = wrap.createDiv("hearth-git-actions");
+	row.toggleClass("is-labelled", labelled);
+	for (const action of actions) {
+		const def = GIT_ACTION_DEFS[action];
+		const label = t().cards.git.actions[action];
+		const button = row.createEl("button", { cls: "hearth-git-action" });
+		button.addClass(`is-${action}`);
+		if (def.destructive) button.addClass("is-destructive");
+		setIcon(button.createSpan("hearth-git-action-icon"), def.icon);
+		if (labelled) button.createSpan({ cls: "hearth-git-action-label", text: label });
+		button.setAttribute("aria-label", label);
+		button.setAttribute("title", label);
+		const available = gitActionAvailable(plugin, action);
+		button.disabled = busy || !available;
+		if (!available) button.setAttribute("title", t().cards.git.unsupported);
+		button.addEventListener("click", () => run(action));
+	}
+}
+
+
+/** The changed-files list. */
+function paintChanges(
+	view: HomeView,
+	plugin: GitPlugin,
+	wrap: HTMLElement,
+	snapshot: GitSnapshot,
+	limit: number,
+	showPaths: boolean | undefined,
+	refresh: () => void,
+): void {
+	const rows = gitChangeRows(snapshot.status);
+	const section = wrap.createDiv("hearth-git-changes");
+	if (rows.length === 0) {
+		section.createDiv({ cls: "hearth-git-none", text: t().cards.git.noChanges });
+		return;
+	}
+	const shown = limit > 0 ? rows.slice(0, limit) : rows;
+	const list = section.createDiv("hearth-list hearth-git-list");
+	for (const row of shown) paintChangeRow(view, plugin, list, row, showPaths, refresh);
+	if (rows.length > shown.length) {
+		const more = section.createDiv({
+			cls: "hearth-git-more",
+			text: t().cards.git.more(rows.length - shown.length),
+		});
+		const open = (): void => void openGitView(view.app, "sourceControl");
+		makeClickable(more, open, t().cards.git.openSourceControl);
+		more.addEventListener("click", open);
+	}
+}
+
+
+/** One file row: status letter, name, and (optionally) its folder. Clicking
+ * opens the note; the context menu offers what obsidian-git can do to it. */
+function paintChangeRow(
+	view: HomeView,
+	plugin: GitPlugin,
+	list: HTMLElement,
+	row: GitChangeRow,
+	showPaths: boolean | undefined,
+	refresh: () => void,
+): void {
+	const el = list.createDiv("hearth-list-item hearth-git-file");
+	el.addClass(`is-${row.kind}`);
+	if (row.staged) el.addClass("is-staged");
+	el.createDiv({ cls: "hearth-git-letter", text: row.letter });
+
+	const main = el.createDiv("hearth-git-file-main");
+	main.createDiv({ cls: "hearth-list-label", text: row.name });
+	if (showPaths) {
+		const folder = row.path.includes("/")
+			? row.path.slice(0, row.path.lastIndexOf("/"))
+			: "";
+		if (folder) main.createDiv({ cls: "hearth-git-file-path", text: folder });
+	}
+	el.setAttribute("title", row.path);
+
+	/** Open the note the row points at, when the vault still has it — a deleted
+	 * file has nothing to open, so its diff is the only useful destination. */
+	const open = (evt?: MouseEvent): void => {
+		const file = view.app.vault.getAbstractFileByPath(row.vaultPath);
+		if (file instanceof TFile) {
+			void openFile(view, file, "card", evt);
+			return;
+		}
+		openGitDiff(plugin, row.path, evt);
+	};
+	el.addEventListener("click", (evt) => open(evt));
+	makeClickable(el, () => open(), row.name);
+
+	el.addEventListener("contextmenu", (evt) => {
+		evt.preventDefault();
+		const menu = new Menu();
+		const strings = t().cards.git;
+		if (plugin.tools?.openDiff) {
+			menu.addItem((item) =>
+				item
+					.setTitle(strings.openDiff)
+					.setIcon("diff")
+					.onClick(() => openGitDiff(plugin, row.path)),
+			);
+		}
+		if (row.staged) {
+			menu.addItem((item) =>
+				item
+					.setTitle(strings.unstageFile)
+					.setIcon("minus")
+					.onClick(() => {
+						queueGitFileAction(plugin, "unstage", row.path, refresh);
+					}),
+			);
+		}
+		if (row.unstaged || !row.staged) {
+			menu.addItem((item) =>
+				item
+					.setTitle(strings.stageFile)
+					.setIcon("plus")
+					.onClick(() => {
+						queueGitFileAction(plugin, "stage", row.path, refresh);
+					}),
+			);
+		}
+		menu.addItem((item) =>
+			item
+				.setTitle(strings.discardFile)
+				.setIcon("undo")
+				.onClick(() => {
+					confirmAction(view.app, {
+						title: t().cards.git.confirmTitle,
+						message: t().cards.git.confirmDiscardFile(row.name),
+						confirmText: t().cards.git.confirmDiscardButton,
+						onConfirm: () => {
+							queueGitFileAction(plugin, "discard", row.path, refresh);
+						},
+					});
+				}),
+		);
+		menu.showAtMouseEvent(evt);
+	});
+}
+
+
+/** The recent-commits list. */
+function paintLog(
+	view: HomeView,
+	wrap: HTMLElement,
+	snapshot: GitSnapshot,
+	limit: number,
+): void {
+	const entries = (snapshot.log ?? []).slice(0, limit);
+	const section = wrap.createDiv("hearth-git-log");
+	if (entries.length === 0) {
+		section.createDiv({ cls: "hearth-git-none", text: t().cards.git.noCommits });
+		return;
+	}
+	for (const entry of entries) {
+		const el = section.createDiv("hearth-git-commit");
+		el.createDiv({ cls: "hearth-git-commit-hash", text: shortHash(entry.hash) });
+		const main = el.createDiv("hearth-git-commit-main");
+		main.createDiv({
+			cls: "hearth-git-commit-message",
+			text: commitSummary(entry.message) || t().cards.git.noMessage,
+		});
+		const when = parseCommitDate(entry.date);
+		const meta = [entry.author?.name, when ? relativeTime(when) : ""].filter(Boolean);
+		if (meta.length) {
+			main.createDiv({ cls: "hearth-git-commit-meta", text: meta.join(" · ") });
+		}
+		const open = (): void => void openGitView(view.app, "history");
+		el.setAttribute("title", entry.hash ?? "");
+		makeClickable(el, open, t().cards.git.openHistory);
+		el.addEventListener("click", open);
+	}
+}
+
+
+/** "3 minutes ago", in the user's locale — the same moment shim the rest of the
+ * card bodies use. */
+function relativeTime(ms: number): string {
+	return (moment(new Date(ms)) as unknown as { fromNow(): string }).fromNow();
+}
+
+
+// ---- Editor -------------------------------------------------------------
+
+export function gitEditor(ctx: CardEditorContext, containerEl: HTMLElement): void {
+	const cfg = (ctx.card.git ??= {});
+	const strings = t().editors.git;
+
+	if (!isGitAvailable(ctx.app)) {
+		new Setting(containerEl).setName(strings.missing).setDesc(strings.missingDesc);
+	}
+
+	// ---- Sections ----
+	new Setting(containerEl).setName(strings.sections).setHeading();
+	const sections = gitSections(cfg.sections);
+	for (const section of GIT_SECTIONS) {
+		new Setting(containerEl)
+			.setName(t().cards.git.sections[section])
+			.addToggle((toggle) =>
+				toggle.setValue(sections.includes(section)).onChange((on) => {
+					const next = on
+						? [...sections, section]
+						: sections.filter((id) => id !== section);
+					// Persist in canonical order so the card always stacks the same
+					// way regardless of the order the toggles were flipped in.
+					cfg.sections = GIT_SECTIONS.filter((id) => next.includes(id));
+					ctx.opts.save();
+					ctx.opts.rerender();
+					ctx.requestRender();
+				}),
+			);
+	}
+
+	// ---- Buttons ----
+	new Setting(containerEl).setName(strings.actions).setHeading();
+	const actions = gitActions(cfg.actions);
+	actions.forEach((action, index) => {
+		const row = new Setting(containerEl).setName(t().cards.git.actions[action]);
+		if (GIT_ACTION_DEFS[action].destructive) row.setDesc(strings.destructive);
+		row.addExtraButton((b) =>
+			b
+				.setIcon("chevron-up")
+				.setTooltip(t().editors.links.moveUp)
+				.setDisabled(index === 0)
+				.onClick(() => {
+					cfg.actions = [...actions];
+					moveItem(ctx, cfg.actions, index, index - 1);
+				}),
+		);
+		row.addExtraButton((b) =>
+			b
+				.setIcon("chevron-down")
+				.setTooltip(t().editors.links.moveDown)
+				.setDisabled(index === actions.length - 1)
+				.onClick(() => {
+					cfg.actions = [...actions];
+					moveItem(ctx, cfg.actions, index, index + 1);
+				}),
+		);
+		row.addExtraButton((b) =>
+			b
+				.setIcon("trash-2")
+				.setTooltip(strings.removeAction)
+				.onClick(() => {
+					cfg.actions = actions.filter((id) => id !== action);
+					ctx.opts.save();
+					ctx.opts.rerender();
+					ctx.requestRender();
+				}),
+		);
+	});
+
+	const remaining = GIT_ACTIONS.filter((action) => !actions.includes(action));
+	if (remaining.length > 0) {
+		new Setting(containerEl).setName(strings.addAction).addDropdown((d) => {
+			d.addOption("", strings.addActionPlaceholder);
+			for (const action of remaining) d.addOption(action, t().cards.git.actions[action]);
+			d.setValue("").onChange((value) => {
+				if (!value) return;
+				cfg.actions = [...actions, value as GitAction];
+				ctx.opts.save();
+				ctx.opts.rerender();
+				ctx.requestRender();
+			});
+		});
+	}
+
+	new Setting(containerEl)
+		.setName(strings.actionStyle)
+		.setDesc(strings.actionStyleDesc)
+		.addDropdown((d) => {
+			for (const style of GIT_ACTION_STYLES) {
+				d.addOption(style, t().editors.git.actionStyles[style]);
+			}
+			d.setValue(cfg.actionStyle ?? "icon").onChange((value) => {
+				cfg.actionStyle = value === "icon" ? undefined : (value as GitActionStyle);
+				ctx.opts.save();
+				ctx.opts.rerender();
+			});
+		});
+
+	// ---- Committing ----
+	new Setting(containerEl).setName(strings.committing).setHeading();
+
+	new Setting(containerEl)
+		.setName(strings.commitScope)
+		.setDesc(strings.commitScopeDesc)
+		.addDropdown((d) => {
+			for (const scope of GIT_COMMIT_SCOPES) {
+				d.addOption(scope, strings.commitScopes[scope]);
+			}
+			d.setValue(cfg.commitScope ?? "smart").onChange((value) => {
+				cfg.commitScope = value === "smart" ? undefined : (value as GitCommitScope);
+				ctx.opts.save();
+			});
+		});
+
+	new Setting(containerEl)
+		.setName(strings.askForMessage)
+		.setDesc(strings.askForMessageDesc)
+		.addToggle((toggle) =>
+			toggle.setValue(cfg.askForMessage ?? false).onChange((on) => {
+				cfg.askForMessage = on || undefined;
+				ctx.opts.save();
+				ctx.requestRender();
+			}),
+		);
+
+	if (!cfg.askForMessage) {
+		new Setting(containerEl)
+			.setName(strings.commitMessage)
+			.setDesc(strings.commitMessageDesc)
+			.addText((txt) =>
+				txt
+					.setPlaceholder(strings.commitMessagePlaceholder)
+					.setValue(cfg.commitMessage ?? "")
+					.onChange((value) => {
+						cfg.commitMessage = value.trim() || undefined;
+						ctx.opts.save();
+					}),
+			);
+	}
+
+	new Setting(containerEl)
+		.setName(strings.skipConfirm)
+		.setDesc(strings.skipConfirmDesc)
+		.addToggle((toggle) =>
+			toggle.setValue(cfg.skipConfirm ?? false).onChange((on) => {
+				cfg.skipConfirm = on || undefined;
+				ctx.opts.save();
+			}),
+		);
+
+	// ---- Display ----
+	new Setting(containerEl).setName(strings.display).setHeading();
+
+	const changeLimit = new Setting(containerEl)
+		.setName(strings.changeLimit)
+		.setDesc(strings.changeLimitDesc);
+	changeLimit.addSlider((s) =>
+		s
+			.setLimits(0, 50, 1)
+			.setValue(cfg.changeLimit ?? 8)
+			.setDynamicTooltip()
+			.onChange((value) => {
+				cfg.changeLimit = value === 8 ? undefined : value;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			}),
+	);
+	addResetButton(ctx, changeLimit, t().settings.resetSlider, () => {
+		cfg.changeLimit = undefined;
+	});
+
+	new Setting(containerEl)
+		.setName(strings.showPaths)
+		.setDesc(strings.showPathsDesc)
+		.addToggle((toggle) =>
+			toggle.setValue(cfg.showPaths ?? false).onChange((on) => {
+				cfg.showPaths = on || undefined;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			}),
+		);
+
+	if (gitSections(cfg.sections).includes("log")) {
+		const logLimit = new Setting(containerEl)
+			.setName(strings.logLimit)
+			.setDesc(strings.logLimitDesc);
+		logLimit.addSlider((s) =>
+			s
+				.setLimits(1, 25, 1)
+				.setValue(cfg.logLimit ?? 5)
+				.setDynamicTooltip()
+				.onChange((value) => {
+					cfg.logLimit = value === 5 ? undefined : value;
+					ctx.opts.save();
+					ctx.opts.rerender();
+				}),
+		);
+		addResetButton(ctx, logLimit, t().settings.resetSlider, () => {
+			cfg.logLimit = undefined;
+		});
+	}
+
+	const refresh = new Setting(containerEl)
+		.setName(strings.refresh)
+		.setDesc(strings.refreshDesc);
+	refresh.addSlider((s) =>
+		s
+			.setLimits(0, 60, 5)
+			.setValue(cfg.refreshMin ?? 0)
+			.setDynamicTooltip()
+			.onChange((value) => {
+				cfg.refreshMin = value > 0 ? value : undefined;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			}),
+	);
+	addResetButton(ctx, refresh, t().settings.resetSlider, () => {
+		cfg.refreshMin = undefined;
+	});
+}
+
+
+/** The repository's state and controls, driven by the obsidian-git plugin. */
+export const gitCard: CardDefinition<"git"> = {
+	kind: "git",
+	templates: [
+		{
+			id: "git",
+			name: "Git",
+			icon: "git-branch",
+			build: () => ({ kind: "git", title: "Git", git: {}, w: 4, h: 4 }),
+			available: (app) => isGitAvailable(app),
+		},
+	],
+	render: (view, card, body, component) => renderGit(view, card, body, component),
+	renderEditor: (container, ctx) => gitEditor(ctx, container),
+	cloneConfig: (source, copy) => {
+		if (source.git)
+			copy.git = {
+				...source.git,
+				sections: source.git.sections ? [...source.git.sections] : undefined,
+				actions: source.git.actions ? [...source.git.actions] : undefined,
+			};
+	},
+	// The card drives its own updates off obsidian-git's events, which say far
+	// more precisely than a vault event whether anything git-visible changed.
+	liveness: { mode: "static" },
+};

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -23,6 +23,7 @@ import { datacoreCard } from "./datacore";
 import { rssCard } from "./rss";
 import { jiraCard } from "./jira";
 import { weatherCard } from "./weather";
+import { gitCard } from "./git";
 import { leafCard } from "./leaf";
 
 export type {
@@ -61,6 +62,7 @@ export const CARD_DEFINITIONS: { [K in CardKind]: CardDefinition<K> } = {
 	rss: rssCard,
 	jira: jiraCard,
 	weather: weatherCard,
+	git: gitCard,
 	leaf: leafCard,
 };
 
@@ -121,6 +123,7 @@ export const TEMPLATE_MENU_ORDER: string[] = [
 	"rss",
 	"jira",
 	"weather",
+	"git",
 	"leaf",
 ];
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,793 @@
+/**
+ * The Git integration: everything Hearth knows about the
+ * [obsidian-git](https://github.com/Vinzent03/obsidian-git) community plugin.
+ *
+ * The rule here is the same one the Dataview, Datacore and Omnisearch modules
+ * follow: **Hearth never does the work itself.** It does not shell out to
+ * `git`, it does not bundle a git implementation, and it does not read
+ * `.git/`. Every operation the card offers is a call into the running
+ * obsidian-git plugin instance, so whichever backend the user has configured
+ * (`SimpleGit` on desktop, `isomorphic-git` on mobile), whichever remote,
+ * credentials, commit-message template, submodule and line-author settings they
+ * have — all of it applies exactly as it does everywhere else in that plugin.
+ * The card is a window onto obsidian-git, not a second implementation of it.
+ *
+ * Two consequences shape this file:
+ *
+ * 1. **Everything is optional.** obsidian-git exposes no versioned `api`
+ *    object the way Omnisearch and Datacore do; what Hearth calls are the
+ *    plugin instance's own public members. They are stable in practice (its
+ *    own commands and views call the same ones) but they are not a contract,
+ *    so every member is declared optional and every call site checks for the
+ *    function before using it. A build of obsidian-git that renamed something
+ *    disables one button; it never throws inside a dashboard render.
+ * 2. **Writes go through obsidian-git's own queue.** The plugin serializes
+ *    every repo-touching operation on `promiseQueue` so an automatic backup
+ *    can't interleave with a manual commit. Hearth pushes its actions onto the
+ *    same queue rather than calling the methods directly, which is why a card
+ *    button behaves identically to the matching command in the palette —
+ *    including its error reporting, which `promiseQueue` routes to the
+ *    plugin's own `displayError`.
+ *
+ * The pure helpers at the bottom (status classification, commit formatting)
+ * carry no Obsidian dependency and are unit-tested in `test/git.test.ts`.
+ */
+import type { App } from "obsidian";
+
+/** The community-plugin id obsidian-git registers itself under. */
+export const GIT_PLUGIN_ID = "obsidian-git";
+
+/** obsidian-git's source-control view type (its "Source control" side panel). */
+export const GIT_SOURCE_CONTROL_VIEW = "git-view";
+
+/** obsidian-git's history view type (its commit log side panel). */
+export const GIT_HISTORY_VIEW = "git-history-view";
+
+/*
+ * The workspace events obsidian-git fires (typed for listening in
+ * `src/obsidian-ext.d.ts`). Hearth follows them rather than polling: the plugin
+ * already watches the vault, runs the automatic-backup timer and refreshes
+ * after every operation of its own, so listening keeps a card in step with its
+ * source-control view for free.
+ *
+ * - `obsidian-git:refresh` — *ask* the plugin to refresh (Hearth triggers this
+ *   one when revealing a view, exactly as its own commands do).
+ * - `obsidian-git:refreshed` — the plugin finished a refresh cycle.
+ * - `obsidian-git:status-changed` — a fresh Status was computed; the status is
+ *   the event's payload, so a listener needs no read of its own.
+ * - `obsidian-git:head-change` — HEAD moved (commit, checkout, pull), which
+ *   invalidates the branch, the ahead count and the log.
+ * - `obsidian-git:loading-status` — a status read started.
+ */
+
+
+// ---- The slice of obsidian-git Hearth talks to --------------------------
+
+/** One entry of obsidian-git's status: a file with its index (staged) and
+ * working-directory state as single letters. `path` is relative to the repo
+ * root, `vaultPath` to the vault root — they differ when the repo sits above
+ * the vault. */
+export interface GitFileStatus {
+	path: string;
+	vaultPath: string;
+	/** Original path of a rename, when the backend reports one. */
+	from?: string;
+	/** Index state: " " unchanged, "M", "A", "D", "R", or "U" for untracked. */
+	index: string;
+	/** Working-directory state, same letters. */
+	workingDir: string;
+}
+
+/** obsidian-git's status snapshot. `conflicted` is only populated by the
+ * desktop (SimpleGit) backend; the mobile one always reports none. */
+export interface GitStatus {
+	all: GitFileStatus[];
+	changed: GitFileStatus[];
+	staged: GitFileStatus[];
+	conflicted: string[];
+}
+
+/** The current branch and what it tracks. */
+export interface GitBranchInfo {
+	current?: string;
+	tracking?: string;
+	branches: string[];
+}
+
+/** One commit from obsidian-git's log. */
+export interface GitLogEntry {
+	hash: string;
+	/** ISO-ish on desktop, a `Date.toDateString()` on mobile — parse leniently
+	 * with {@link parseCommitDate}. */
+	date: string;
+	message: string;
+	refs: string[];
+	author: { name: string; email: string };
+}
+
+/** The read side of obsidian-git's git backend. Every member is optional: a
+ * given backend or plugin version may not have it, and the card degrades
+ * rather than throwing. */
+interface GitManagerLike {
+	status?(opts?: { path?: string }): Promise<GitStatus>;
+	branchInfo?(): Promise<GitBranchInfo>;
+	getUnpushedCommits?(): Promise<number>;
+	log?(
+		file: string | undefined,
+		relativeToVault?: boolean,
+		limit?: number,
+		ref?: string,
+	): Promise<GitLogEntry[]>;
+	stageAll?(opts: { dir?: string; status?: GitStatus }): Promise<void>;
+	unstageAll?(opts: { dir?: string; status?: GitStatus }): Promise<void>;
+	stage?(filepath: string, relativeToVault: boolean): Promise<void>;
+	unstage?(filepath: string, relativeToVault: boolean): Promise<void>;
+	discard?(filepath: string): Promise<void>;
+	getLastCommitTime?(): Promise<Date | undefined>;
+}
+
+/**
+ * The obsidian-git plugin instance, as far as Hearth is concerned. Reachable
+ * at `app.plugins.plugins["obsidian-git"]` once the plugin is enabled.
+ *
+ * Only `gitReady` and `gitManager` are required to consider the plugin usable
+ * — everything else is probed per call.
+ */
+export interface GitPlugin {
+	/** False until the plugin has found and opened a repository. */
+	gitReady: boolean;
+	/** The last status the plugin computed, if any. */
+	cachedStatus?: GitStatus;
+	gitManager: GitManagerLike;
+	/** obsidian-git's serial task queue; see the file header. */
+	promiseQueue?: {
+		addTask<T>(task: () => Promise<T>, onFinished?: (res: T | undefined) => void): void;
+	};
+	tools?: {
+		/** Open obsidian-git's own diff view for a repo-relative path. `aRef`
+		 * empty means "the working tree against HEAD". */
+		openDiff(opts: {
+			aFile: string;
+			bFile?: string;
+			aRef: string;
+			bRef?: string;
+			event?: MouseEvent;
+		}): void;
+	};
+	/** Recompute the status and fire `obsidian-git:status-changed`. */
+	updateCachedStatus?(): Promise<GitStatus>;
+	commit?(opts: {
+		fromAuto: boolean;
+		requestCustomMessage?: boolean;
+		onlyStaged?: boolean;
+		commitMessage?: string;
+		amend?: boolean;
+	}): Promise<boolean>;
+	commitAndSync?(opts: {
+		fromAutoBackup: boolean;
+		requestCustomMessage?: boolean;
+		commitMessage?: string;
+		onlyStaged?: boolean;
+	}): Promise<void>;
+	push?(): Promise<boolean>;
+	pullChangesFromRemote?(): Promise<void>;
+	fetch?(): Promise<void>;
+	discardAll?(path?: string): Promise<unknown>;
+	switchBranch?(): Promise<string | undefined>;
+	displayError?(data: unknown, timeout?: number): void;
+}
+
+/**
+ * Reach the obsidian-git plugin instance, or null when it isn't installed,
+ * isn't enabled, or is too old to look like the plugin Hearth knows.
+ *
+ * Note this returns the plugin even when `gitReady` is false — "the plugin is
+ * there but has no repository yet" is a state the card reports rather than one
+ * it hides, since it usually means the repo is still being found on startup.
+ */
+export function getGitPlugin(app: App): GitPlugin | null {
+	const plugin = app.plugins.plugins[GIT_PLUGIN_ID] as
+		| { gitManager?: unknown; gitReady?: unknown }
+		| undefined;
+	if (!plugin) return null;
+	if (typeof plugin.gitReady !== "boolean") return null;
+	if (!plugin.gitManager || typeof plugin.gitManager !== "object") return null;
+	return plugin as GitPlugin;
+}
+
+/** Whether obsidian-git is enabled and reachable right now. Used to gate the
+ * Git card in the "Add card" picker. */
+export function isGitAvailable(app: App): boolean {
+	return getGitPlugin(app) !== null;
+}
+
+
+// ---- Card configuration vocabulary --------------------------------------
+
+/** A stacked section of the Git card, in the order they are drawn. */
+export type GitSection = "status" | "actions" | "changes" | "log";
+
+/** Every section, in the order the editor lists them. Doubles as the
+ * allow-list an imported layout is validated against. */
+export const GIT_SECTIONS: readonly GitSection[] = ["status", "actions", "changes", "log"];
+
+/** The sections a fresh card shows: the state of the repo, the buttons, and
+ * what's currently changed. The log is opt-in — it costs an extra `git log`
+ * per refresh and most dashboards want "is my vault saved?", not history. */
+export const GIT_DEFAULT_SECTIONS: readonly GitSection[] = ["status", "actions", "changes"];
+
+/** One button the Git card can offer. Each maps to a single obsidian-git
+ * entry point — see {@link gitActionTask} and {@link openGitView}. */
+export type GitAction =
+	| "commitAndSync"
+	| "commit"
+	| "push"
+	| "pull"
+	| "fetch"
+	| "stageAll"
+	| "unstageAll"
+	| "discardAll"
+	| "switchBranch"
+	| "sourceControl"
+	| "history";
+
+/** Every action, in the order the editor lists them. */
+export const GIT_ACTIONS: readonly GitAction[] = [
+	"commitAndSync",
+	"commit",
+	"push",
+	"pull",
+	"fetch",
+	"stageAll",
+	"unstageAll",
+	"discardAll",
+	"switchBranch",
+	"sourceControl",
+	"history",
+];
+
+/** The buttons a fresh card offers: the one-click "save my vault" action, plus
+ * the three halves of it for anyone who wants the steps apart. Staging,
+ * discarding and branch switching are opt-in — they are either destructive or
+ * better served by obsidian-git's own source-control view. */
+export const GIT_DEFAULT_ACTIONS: readonly GitAction[] = [
+	"commitAndSync",
+	"commit",
+	"push",
+	"pull",
+];
+
+/** Which files a commit from this card includes.
+ *
+ * - `smart` — staged files only if anything is staged, otherwise everything.
+ *   This is what obsidian-git's own "Commit" command does, and it is the
+ *   default here for the same reason: it does what you meant.
+ * - `all` — always commit every change, staged or not.
+ * - `staged` — only ever commit what is staged. */
+export type GitCommitScope = "smart" | "all" | "staged";
+
+/** Every commit scope, in editor order. */
+export const GIT_COMMIT_SCOPES: readonly GitCommitScope[] = ["smart", "all", "staged"];
+
+/** How the action buttons are drawn. */
+export type GitActionStyle = "icon" | "labelled";
+
+/** Every button style, in editor order. */
+export const GIT_ACTION_STYLES: readonly GitActionStyle[] = ["icon", "labelled"];
+
+/** How an action is dispatched and drawn. */
+interface GitActionDef {
+	/** Lucide icon id. Chosen from the set obsidian-git's own UI uses, so they
+	 * read as the same vocabulary. */
+	icon: string;
+	/** Opens one of obsidian-git's views instead of touching the repo — never
+	 * queued, never confirmed. */
+	view?: "sourceControl" | "history";
+	/** Irreversible: the card asks before running it. */
+	destructive?: boolean;
+}
+
+/** The static description of every action. */
+export const GIT_ACTION_DEFS: Record<GitAction, GitActionDef> = {
+	commitAndSync: { icon: "arrow-up-circle" },
+	commit: { icon: "check" },
+	push: { icon: "upload" },
+	pull: { icon: "download" },
+	fetch: { icon: "refresh-cw" },
+	stageAll: { icon: "plus" },
+	unstageAll: { icon: "minus" },
+	discardAll: { icon: "undo", destructive: true },
+	switchBranch: { icon: "git-branch" },
+	sourceControl: { icon: "git-pull-request", view: "sourceControl" },
+	history: { icon: "history", view: "history" },
+};
+
+
+// ---- Running actions ----------------------------------------------------
+
+/** What a commit from this card should say and cover. */
+export interface GitCommitOptions {
+	/** The message to commit with. Undefined hands the decision back to
+	 * obsidian-git, which applies its own commit-message template (date
+	 * placeholders, changed-file counts and all). */
+	commitMessage?: string;
+	/** Let obsidian-git prompt for a message, exactly as its "…with specific
+	 * message" commands do. Wins over `commitMessage`. */
+	requestCustomMessage?: boolean;
+	/** Commit only what is staged. Resolved from the card's scope by
+	 * {@link onlyStagedFor}. */
+	onlyStaged?: boolean;
+}
+
+/**
+ * Build the thunk that performs `action`, or null when this obsidian-git build
+ * doesn't expose what it needs — which is how the card knows to disable the
+ * button rather than fail on click.
+ *
+ * View-opening actions return null here on purpose: they aren't repo work and
+ * are handled by {@link openGitView}.
+ */
+export function gitActionTask(
+	plugin: GitPlugin,
+	action: GitAction,
+	opts: GitCommitOptions = {},
+): (() => Promise<void>) | null {
+	const manager = plugin.gitManager;
+	switch (action) {
+		case "commitAndSync":
+			if (typeof plugin.commitAndSync !== "function") return null;
+			return async () => {
+				await plugin.commitAndSync?.({
+					fromAutoBackup: false,
+					requestCustomMessage: opts.requestCustomMessage,
+					commitMessage: opts.commitMessage,
+					onlyStaged: opts.onlyStaged,
+				});
+			};
+		case "commit":
+			if (typeof plugin.commit !== "function") return null;
+			return async () => {
+				await plugin.commit?.({
+					fromAuto: false,
+					requestCustomMessage: opts.requestCustomMessage,
+					commitMessage: opts.commitMessage,
+					onlyStaged: opts.onlyStaged,
+				});
+			};
+		case "push":
+			if (typeof plugin.push !== "function") return null;
+			return async () => {
+				await plugin.push?.();
+			};
+		case "pull":
+			if (typeof plugin.pullChangesFromRemote !== "function") return null;
+			return async () => {
+				await plugin.pullChangesFromRemote?.();
+			};
+		case "fetch":
+			if (typeof plugin.fetch !== "function") return null;
+			return async () => {
+				await plugin.fetch?.();
+			};
+		case "stageAll":
+			if (typeof manager.stageAll !== "function") return null;
+			return async () => {
+				await manager.stageAll?.({ status: plugin.cachedStatus });
+			};
+		case "unstageAll":
+			if (typeof manager.unstageAll !== "function") return null;
+			return async () => {
+				await manager.unstageAll?.({ status: plugin.cachedStatus });
+			};
+		case "discardAll":
+			if (typeof plugin.discardAll !== "function") return null;
+			return async () => {
+				await plugin.discardAll?.();
+			};
+		case "switchBranch":
+			if (typeof plugin.switchBranch !== "function") return null;
+			return async () => {
+				await plugin.switchBranch?.();
+			};
+		default:
+			return null;
+	}
+}
+
+/** Whether `action` can run against the plugin as it is right now. Drives the
+ * disabled state of the card's buttons. */
+export function gitActionAvailable(plugin: GitPlugin, action: GitAction): boolean {
+	if (GIT_ACTION_DEFS[action]?.view) return true;
+	return gitActionTask(plugin, action) !== null;
+}
+
+/**
+ * Queue `action` on obsidian-git's own task queue and call `onFinished` when it
+ * settles (successfully or not — the queue reports failures through the
+ * plugin's error handling, which is where a user expects to see them).
+ *
+ * Returns false when the action isn't available, so a caller can leave the UI
+ * untouched instead of showing a spinner that never ends.
+ */
+export function queueGitAction(
+	plugin: GitPlugin,
+	action: GitAction,
+	opts: GitCommitOptions,
+	onFinished?: () => void,
+): boolean {
+	const task = gitActionTask(plugin, action, opts);
+	if (!task) return false;
+	const queue = plugin.promiseQueue;
+	if (queue && typeof queue.addTask === "function") {
+		queue.addTask(task, () => onFinished?.());
+		return true;
+	}
+	// No queue on this build: still run the action, just unserialized.
+	task()
+		.catch((err: unknown) => plugin.displayError?.(err))
+		.finally(() => onFinished?.());
+	return true;
+}
+
+/**
+ * Reveal one of obsidian-git's side-panel views, reusing an open one if there
+ * is one — the same sequence its own "Open source control view" command runs,
+ * including the closing refresh so an already-open panel updates too.
+ */
+export async function openGitView(
+	app: App,
+	which: "sourceControl" | "history",
+): Promise<void> {
+	const type = which === "history" ? GIT_HISTORY_VIEW : GIT_SOURCE_CONTROL_VIEW;
+	const open = app.workspace.getLeavesOfType(type);
+	const leaf = open[0] ?? app.workspace.getRightLeaf(false);
+	if (!leaf) return;
+	if (open.length === 0) await leaf.setViewState({ type, active: true });
+	await app.workspace.revealLeaf(leaf);
+	app.workspace.trigger("obsidian-git:refresh");
+}
+
+/** Open obsidian-git's diff view for one repo-relative path, comparing the
+ * working tree against HEAD. No-op on a build without `tools.openDiff`. */
+export function openGitDiff(plugin: GitPlugin, path: string, event?: MouseEvent): void {
+	plugin.tools?.openDiff({ aFile: path, aRef: "", event });
+}
+
+/** Stage or unstage a single file through the plugin's queue. Returns false
+ * when this build can't (the caller then hides the menu item). */
+export function queueGitFileAction(
+	plugin: GitPlugin,
+	action: "stage" | "unstage" | "discard",
+	path: string,
+	onFinished?: () => void,
+): boolean {
+	const manager = plugin.gitManager;
+	// Checked in place rather than by pulling the method off the manager: these
+	// are bound methods on obsidian-git's own object, and detaching one to probe
+	// it loses that binding.
+	const supported =
+		action === "stage"
+			? typeof manager.stage === "function"
+			: action === "unstage"
+				? typeof manager.unstage === "function"
+				: typeof manager.discard === "function";
+	if (!supported) return false;
+	const task = async (): Promise<void> => {
+		// Paths come straight from the status, so they are repo-relative.
+		if (action === "discard") await manager.discard?.(path);
+		else if (action === "stage") await manager.stage?.(path, false);
+		else await manager.unstage?.(path, false);
+	};
+	const queue = plugin.promiseQueue;
+	if (queue && typeof queue.addTask === "function") {
+		queue.addTask(task, () => onFinished?.());
+		return true;
+	}
+	task()
+		.catch((err: unknown) => plugin.displayError?.(err))
+		.finally(() => onFinished?.());
+	return true;
+}
+
+
+// ---- Reading the repo ---------------------------------------------------
+
+/** Everything the card draws in one round. Each field is independently
+ * optional: one failing read (an old backend without `getUnpushedCommits`, a
+ * repo with no upstream) must not blank the rest of the card. */
+export interface GitSnapshot {
+	status?: GitStatus;
+	branch?: GitBranchInfo;
+	/** Commits on the local branch that the remote doesn't have. */
+	unpushed?: number;
+	log?: GitLogEntry[];
+	lastCommit?: number;
+}
+
+/** What a snapshot read should include, so a card that shows no log never
+ * pays for `git log`. */
+export interface GitSnapshotOptions {
+	/** Read the commit log, at most this many entries. */
+	logLimit?: number;
+	/** Read the ahead-count and the last commit time. */
+	includeSync?: boolean;
+}
+
+/**
+ * Read the repo through obsidian-git.
+ *
+ * The status goes through `updateCachedStatus()` rather than
+ * `gitManager.status()` so the plugin's own cache — and every other listener,
+ * including its source-control view and status bar — is updated by the same
+ * read, instead of Hearth running a second `git status` alongside it.
+ *
+ * Every individual read is caught: the result is "what could be read", and the
+ * card shows what it got.
+ */
+export async function readGitSnapshot(
+	plugin: GitPlugin,
+	opts: GitSnapshotOptions = {},
+): Promise<GitSnapshot> {
+	const snapshot: GitSnapshot = {};
+	if (!plugin.gitReady) return snapshot;
+	const manager = plugin.gitManager;
+
+	if (typeof plugin.updateCachedStatus === "function") {
+		try {
+			snapshot.status = await plugin.updateCachedStatus();
+		} catch {
+			snapshot.status = plugin.cachedStatus;
+		}
+	} else if (typeof manager.status === "function") {
+		try {
+			snapshot.status = await manager.status();
+		} catch {
+			snapshot.status = plugin.cachedStatus;
+		}
+	} else {
+		snapshot.status = plugin.cachedStatus;
+	}
+
+	if (typeof manager.branchInfo === "function") {
+		try {
+			snapshot.branch = await manager.branchInfo();
+		} catch {
+			// A repo with no commits yet has no branch to report.
+		}
+	}
+
+	if (opts.includeSync !== false && typeof manager.getUnpushedCommits === "function") {
+		try {
+			snapshot.unpushed = await manager.getUnpushedCommits();
+		} catch {
+			// No upstream configured: there is nothing to be ahead of.
+		}
+	}
+
+	if (opts.includeSync !== false && typeof manager.getLastCommitTime === "function") {
+		try {
+			snapshot.lastCommit = (await manager.getLastCommitTime())?.getTime();
+		} catch {
+			// Empty repo.
+		}
+	}
+
+	const limit = opts.logLimit ?? 0;
+	if (limit > 0 && typeof manager.log === "function") {
+		try {
+			snapshot.log = await manager.log(undefined, false, limit);
+		} catch {
+			// Empty repo, or a backend that can't log without a file.
+		}
+	}
+
+	return snapshot;
+}
+
+
+// ---- Pure helpers (unit-tested) -----------------------------------------
+
+/** What happened to a file, as the card labels it. */
+export type GitChangeKind =
+	| "conflicted"
+	| "untracked"
+	| "added"
+	| "modified"
+	| "deleted"
+	| "renamed";
+
+/** One row of the card's changed-files list. */
+export interface GitChangeRow {
+	/** Repo-relative path — what obsidian-git's own APIs take. */
+	path: string;
+	/** Vault-relative path, for opening the note in Obsidian. */
+	vaultPath: string;
+	/** File name, for the row's label. */
+	name: string;
+	kind: GitChangeKind;
+	/** Single-letter badge: U, A, M, D, R, or ! for a conflict. */
+	letter: string;
+	/** The index has changes for this file. */
+	staged: boolean;
+	/** The working tree has changes the index doesn't. */
+	unstaged: boolean;
+}
+
+/** The badge letter for each kind. */
+const KIND_LETTERS: Record<GitChangeKind, string> = {
+	conflicted: "!",
+	untracked: "U",
+	added: "A",
+	modified: "M",
+	deleted: "D",
+	renamed: "R",
+};
+
+/** Classify one status letter. `" "` and anything unrecognized read as a
+ * modification, which is what git means by an unlabelled change. */
+function kindForLetter(letter: string): GitChangeKind {
+	switch (letter) {
+		case "U":
+			return "untracked";
+		case "A":
+			return "added";
+		case "D":
+			return "deleted";
+		case "R":
+			return "renamed";
+		default:
+			return "modified";
+	}
+}
+
+/**
+ * Classify one file from a status.
+ *
+ * A conflict wins over everything: obsidian-git reports an unmerged file with
+ * the same `"U"` it uses for untracked ones, so the conflicted list — not the
+ * letters — is what tells them apart.
+ *
+ * Otherwise the *staged* letter is preferred when there is one, because that is
+ * the change that would go into the next commit; the working-tree letter is the
+ * fallback for a file that is only changed on disk.
+ */
+export function gitChangeKind(file: GitFileStatus, conflicted: ReadonlySet<string>): GitChangeKind {
+	if (conflicted.has(file.path)) return "conflicted";
+	const staged = file.index !== " " && file.index !== "U" ? file.index : "";
+	if (staged) return kindForLetter(staged);
+	return kindForLetter(file.workingDir);
+}
+
+/** The last path segment of a repo path, for a readable row label. */
+export function gitFileName(path: string): string {
+	const parts = path.split("/");
+	return parts[parts.length - 1] || path;
+}
+
+/**
+ * Turn a status into the card's rows: conflicts first, then staged changes,
+ * then everything else, each group keeping git's own ordering.
+ *
+ * Built from `status.all` rather than by concatenating `staged` and `changed`,
+ * which overlap — a file edited, staged, then edited again appears in both, and
+ * that must be one row flagged as both, not two rows.
+ */
+export function gitChangeRows(status: GitStatus | undefined): GitChangeRow[] {
+	if (!status) return [];
+	const conflicted = new Set(status.conflicted ?? []);
+	const rows: GitChangeRow[] = (status.all ?? []).map((file) => {
+		const kind = gitChangeKind(file, conflicted);
+		return {
+			path: file.path,
+			vaultPath: file.vaultPath || file.path,
+			name: gitFileName(file.path),
+			kind,
+			letter: KIND_LETTERS[kind],
+			staged: file.index !== " " && file.index !== "U",
+			unstaged: file.workingDir !== " ",
+		};
+	});
+	const rank = (row: GitChangeRow): number =>
+		row.kind === "conflicted" ? 0 : row.staged ? 1 : 2;
+	// Stable sort: rows within a group keep the order git listed them in.
+	return rows
+		.map((row, index) => ({ row, index }))
+		.sort((a, b) => rank(a.row) - rank(b.row) || a.index - b.index)
+		.map((entry) => entry.row);
+}
+
+/** The headline numbers of a status: how many files are staged, how many are
+ * only changed on disk, and how many are conflicted. */
+export interface GitChangeCounts {
+	staged: number;
+	unstaged: number;
+	conflicted: number;
+	total: number;
+}
+
+/** Count a status by group. `total` counts files, not changes, so a file that
+ * is both staged and dirty counts once. */
+export function gitChangeCounts(status: GitStatus | undefined): GitChangeCounts {
+	const rows = gitChangeRows(status);
+	let staged = 0;
+	let unstaged = 0;
+	let conflicted = 0;
+	for (const row of rows) {
+		if (row.kind === "conflicted") conflicted++;
+		else if (row.staged) staged++;
+		if (row.unstaged && row.kind !== "conflicted") unstaged++;
+	}
+	return { staged, unstaged, conflicted, total: rows.length };
+}
+
+/** Resolve a card's commit scope against the status at the moment of the
+ * click. `smart` mirrors obsidian-git's own "Commit" command: staged files if
+ * anything is staged, everything otherwise. */
+export function onlyStagedFor(
+	scope: GitCommitScope | undefined,
+	status: GitStatus | undefined,
+): boolean {
+	if (scope === "all") return false;
+	if (scope === "staged") return true;
+	return (status?.staged?.length ?? 0) > 0;
+}
+
+/**
+ * Parse a commit date from either backend.
+ *
+ * The desktop backend hands through git's own ISO-8601 string; the mobile one
+ * formats a `Date.toDateString()` ("Mon Aug 04 2025"). Both parse with the
+ * platform `Date`, so this is really about returning null instead of `NaN` for
+ * the third case: a backend that returned something else entirely.
+ */
+export function parseCommitDate(raw: string | undefined): number | null {
+	if (!raw) return null;
+	const ms = new Date(raw).getTime();
+	return Number.isNaN(ms) ? null : ms;
+}
+
+/** The abbreviated commit hash git itself shows. */
+export function shortHash(hash: string | undefined, length = 7): string {
+	return (hash ?? "").slice(0, length);
+}
+
+/** A commit's subject: its first non-empty line, whitespace-trimmed. Commit
+ * bodies are frequently several paragraphs, and a row shows one line. */
+export function commitSummary(message: string | undefined): string {
+	if (!message) return "";
+	for (const line of message.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed) return trimmed;
+	}
+	return "";
+}
+
+/** Normalize a persisted section list: known ids only, no duplicates, and the
+ * defaults when nothing usable survives. Shared by the card and the layout
+ * importer so a hand-edited layout can't produce an empty card. */
+export function gitSections(raw: readonly string[] | undefined): GitSection[] {
+	if (!raw) return [...GIT_DEFAULT_SECTIONS];
+	const seen = new Set<string>();
+	const out: GitSection[] = [];
+	for (const id of raw) {
+		if (!GIT_SECTIONS.includes(id as GitSection) || seen.has(id)) continue;
+		seen.add(id);
+		out.push(id as GitSection);
+	}
+	// An explicitly empty list is a real choice (a card that is only a title);
+	// only a list with nothing recognizable falls back to the defaults.
+	return raw.length > 0 && out.length === 0 ? [...GIT_DEFAULT_SECTIONS] : out;
+}
+
+/** The same for the action list. */
+export function gitActions(raw: readonly string[] | undefined): GitAction[] {
+	if (!raw) return [...GIT_DEFAULT_ACTIONS];
+	const seen = new Set<string>();
+	const out: GitAction[] = [];
+	for (const id of raw) {
+		if (!GIT_ACTIONS.includes(id as GitAction) || seen.has(id)) continue;
+		seen.add(id);
+		out.push(id as GitAction);
+	}
+	return raw.length > 0 && out.length === 0 ? [...GIT_DEFAULT_ACTIONS] : out;
+}

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -24,6 +24,7 @@ import { DATACORE_PLUGIN_ID } from "./datacore";
 import { DATAVIEW_PLUGIN_ID } from "./dataview";
 import { ICONIC_PLUGIN_ID, ICONIZE_PLUGIN_ID } from "./fileicons";
 import { EXCALIDRAW_PLUGIN_ID } from "./filetypes";
+import { GIT_PLUGIN_ID } from "./git";
 import { OMNISEARCH_PLUGIN_ID } from "./omnisearch";
 import { TASKNOTES_PLUGIN_ID } from "./tasknotes";
 
@@ -72,6 +73,7 @@ export type IntegrationId =
 	| "tasknotes"
 	| "dataview"
 	| "datacore"
+	| "git"
 	| "iconic"
 	| "iconize"
 	| "excalidraw"
@@ -132,6 +134,12 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
 		id: "datacore",
 		group: "plugin",
 		pluginId: DATACORE_PLUGIN_ID,
+		where: { kind: "card" },
+	},
+	{
+		id: "git",
+		group: "plugin",
+		pluginId: GIT_PLUGIN_ID,
 		where: { kind: "card" },
 	},
 	{

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -10,6 +10,7 @@ import {
 	type DashboardCard,
 	type DatacoreConfig,
 	type DataviewConfig,
+	type GitConfig,
 	type HeatmapConfig,
 	type HomeSettings,
 	type LeafViewConfig,
@@ -39,6 +40,14 @@ import {
 import { CARD_KINDS } from "./cards";
 import { isEmbeddableBaseViewName } from "./bases";
 import { DATACORE_LANGUAGES, type DatacoreLanguage } from "./datacore";
+import {
+	GIT_ACTION_STYLES,
+	GIT_COMMIT_SCOPES,
+	gitActions,
+	gitSections,
+	type GitActionStyle,
+	type GitCommitScope,
+} from "./git";
 import { t } from "./i18n";
 
 /** Current dashboard-layout export schema version. v2 carries every dashboard
@@ -353,6 +362,9 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 	}
 	if (r.datacore && typeof r.datacore === "object") {
 		card.datacore = sanitizeDatacore(r.datacore as Record<string, unknown>);
+	}
+	if (r.git && typeof r.git === "object") {
+		card.git = sanitizeGit(r.git as Record<string, unknown>);
 	}
 	if (r.leafView && typeof r.leafView === "object") {
 		card.leafView = sanitizeLeafView(r.leafView as Record<string, unknown>);
@@ -797,6 +809,40 @@ function sanitizeDatacore(r: Record<string, unknown>): DatacoreConfig {
 	if (typeof r.pageSize === "number" && Number.isFinite(r.pageSize)) {
 		cfg.pageSize = Math.max(0, Math.min(100, Math.round(r.pageSize)));
 	}
+	return cfg;
+}
+
+/** An imported Git card. The section and action lists are run through the same
+ * normalizers the card uses, so an unknown id from a newer Hearth (or a hand
+ * edit) is dropped rather than rendered as a dead button. */
+function sanitizeGit(r: Record<string, unknown>): GitConfig {
+	const cfg: GitConfig = {};
+	if (Array.isArray(r.sections)) {
+		cfg.sections = gitSections(r.sections.filter((v): v is string => typeof v === "string"));
+	}
+	if (Array.isArray(r.actions)) {
+		cfg.actions = gitActions(r.actions.filter((v): v is string => typeof v === "string"));
+	}
+	if (GIT_ACTION_STYLES.includes(r.actionStyle as GitActionStyle)) {
+		cfg.actionStyle = r.actionStyle as GitActionStyle;
+	}
+	if (GIT_COMMIT_SCOPES.includes(r.commitScope as GitCommitScope)) {
+		cfg.commitScope = r.commitScope as GitCommitScope;
+	}
+	if (typeof r.changeLimit === "number" && Number.isFinite(r.changeLimit)) {
+		cfg.changeLimit = Math.max(0, Math.min(50, Math.round(r.changeLimit)));
+	}
+	if (typeof r.logLimit === "number" && Number.isFinite(r.logLimit)) {
+		cfg.logLimit = Math.max(1, Math.min(25, Math.round(r.logLimit)));
+	}
+	if (typeof r.refreshMin === "number" && Number.isFinite(r.refreshMin)) {
+		cfg.refreshMin = Math.max(0, Math.min(180, Math.round(r.refreshMin)));
+	}
+	const message = str(r.commitMessage);
+	if (message !== undefined) cfg.commitMessage = message;
+	if (typeof r.showPaths === "boolean") cfg.showPaths = r.showPaths;
+	if (typeof r.askForMessage === "boolean") cfg.askForMessage = r.askForMessage;
+	if (typeof r.skipConfirm === "boolean") cfg.skipConfirm = r.skipConfirm;
 	return cfg;
 }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -596,6 +596,14 @@ export const en = {
 						"Dataview's successor. The Datacore card runs a Datacore query — or a " +
 						"JS/JSX/TS/TSX script — and renders it with Datacore's own live views.",
 				},
+				git: {
+					name: "Git",
+					desc:
+						"The Git card shows your repository's branch, changes and recent " +
+						"commits, and commits, syncs, pushes and pulls through the Git " +
+						"plugin itself — its remote, credentials and commit-message " +
+						"template all apply unchanged.",
+				},
 				iconic: {
 					name: "Iconic",
 					desc:
@@ -868,6 +876,7 @@ export const en = {
 			rss: "RSS feed",
 			jira: "Jira filter",
 			weather: "Weather",
+			git: "Git",
 			leaf: "Plugin view (beta)",
 		},
 		linkTypes: {
@@ -1444,6 +1453,58 @@ export const en = {
 			pageSize: "Rows per page",
 			pageSizeDesc: "Page the generated list at this many rows. 0 shows every match at once.",
 		},
+		git: {
+			missing: "The Git plugin isn't enabled",
+			missingDesc:
+				"This card is a window onto the Git community plugin — install and enable " +
+				"it, and point it at a repository, for the card to show anything.",
+			sections: "Sections",
+			actions: "Buttons",
+			destructive: "Cannot be undone.",
+			removeAction: "Remove this button",
+			addAction: "Add a button",
+			addActionPlaceholder: "Choose…",
+			actionStyle: "Button style",
+			actionStyleDesc: "Icons alone are compact; labels make a wide card readable.",
+			actionStyles: {
+				icon: "Icon only",
+				labelled: "Icon and label",
+			},
+			committing: "Committing",
+			commitScope: "What to commit",
+			commitScopeDesc:
+				"Which files the Commit and Commit-and-sync buttons include.",
+			commitScopes: {
+				smart: "Staged if anything is staged, otherwise everything",
+				all: "Everything",
+				staged: "Only staged files",
+			},
+			askForMessage: "Ask for a message",
+			askForMessageDesc:
+				"Have the Git plugin prompt for a commit message each time, exactly as its " +
+				"“…with specific message” commands do.",
+			commitMessage: "Commit message",
+			commitMessageDesc:
+				"Used by this card's commit buttons. Leave empty to use the Git plugin's " +
+				"own commit-message template.",
+			commitMessagePlaceholder: "vault backup: {{date}}",
+			skipConfirm: "Skip confirmations",
+			skipConfirmDesc:
+				"Run discarding actions immediately instead of asking first. Discarded " +
+				"changes cannot be recovered.",
+			display: "Display",
+			changeLimit: "Changed files shown",
+			changeLimitDesc: "0 lists every changed file.",
+			showPaths: "Show folders",
+			showPathsDesc: "Print each changed file's folder under its name.",
+			logLimit: "Commits shown",
+			logLimitDesc: "How many recent commits the log section lists.",
+			refresh: "Re-read every",
+			refreshDesc:
+				"Minutes between extra reads of the repository, on top of following the " +
+				"Git plugin's own updates. 0 — the default — follows those updates only, " +
+				"which already covers everything done inside Obsidian.",
+		},
 		rss: {
 			feeds: "Feeds",
 			namePlaceholder: "Name (optional)",
@@ -1684,6 +1745,8 @@ export const en = {
 			datacoreOneQuery:
 				"A card runs one query — this looks like several. Keep just the one you want, with no comment after it.",
 			datacoreFailed: "Datacore couldn't run this card",
+			gitEnable: "Enable the Git plugin to manage your vault's repository",
+			gitNotReady: "No repository open yet — set one up in the Git plugin",
 			rssNoSources: "Add a feed in card settings",
 			weatherNoLocation: "Pick a location in card settings",
 			renderFailed: "This card couldn't be drawn — see the console for details",
@@ -1777,6 +1840,53 @@ export const en = {
 			empty: "No issues match these filters",
 			disabled: "Jira is off (external calls disabled)",
 			notConfigured: "Configure a Jira host, token, and saved filter in card settings",
+		},
+		git: {
+			sections: {
+				status: "Repository status",
+				actions: "Buttons",
+				changes: "Changed files",
+				log: "Recent commits",
+			},
+			actions: {
+				commitAndSync: "Commit and sync",
+				commit: "Commit",
+				push: "Push",
+				pull: "Pull",
+				fetch: "Fetch",
+				stageAll: "Stage all",
+				unstageAll: "Unstage all",
+				discardAll: "Discard all changes",
+				switchBranch: "Switch branch",
+				sourceControl: "Open source control",
+				history: "Open history",
+			},
+			refresh: "Re-read the repository",
+			noBranch: "No branch",
+			noUpstream: "No upstream branch",
+			staged: "staged",
+			unstaged: "changed",
+			conflicted: "conflicted",
+			unpushed: "unpushed commits",
+			clean: "Everything is committed",
+			noChanges: "Nothing has changed",
+			noCommits: "No commits yet",
+			noMessage: "(no message)",
+			lastCommit: (when: string) => `Last commit ${when}`,
+			more: (count: number) => `${count} more…`,
+			openSourceControl: "Open source control",
+			openHistory: "Open history",
+			openDiff: "Open diff",
+			stageFile: "Stage",
+			unstageFile: "Unstage",
+			discardFile: "Discard changes",
+			confirmTitle: "Discard changes?",
+			confirmDiscard:
+				"Every uncommitted change in the vault will be thrown away. This cannot be undone.",
+			confirmDiscardFile: (name: string) =>
+				`Uncommitted changes to "${name}" will be thrown away. This cannot be undone.`,
+			confirmDiscardButton: "Discard",
+			unsupported: "This version of the Git plugin doesn't support that",
 		},
 		daily: {
 			createToday: "Create today's note",
@@ -2050,6 +2160,7 @@ export const en = {
 		rss: "RSS feed",
 		jira: "Jira filter",
 		weather: "Weather",
+		git: "Git",
 		leaf: "Plugin view (beta)",
 	},
 

--- a/src/obsidian-ext.d.ts
+++ b/src/obsidian-ext.d.ts
@@ -1,5 +1,6 @@
 import "obsidian";
-import { Command, TFile, TFolder } from "obsidian";
+import { Command, EventRef, TFile, TFolder } from "obsidian";
+import type { GitStatus } from "./git";
 
 // Minimal typings for Obsidian internals that aren't part of the public API
 // but are stable and widely used by community plugins.
@@ -32,6 +33,28 @@ declare module "obsidian" {
 		viewRegistry?: {
 			viewByType?: Record<string, unknown>;
 		};
+	}
+
+	/**
+	 * The events the obsidian-git community plugin fires on the workspace.
+	 *
+	 * `Workspace` redeclares `on` with one overload per built-in event, which
+	 * hides the `on(name: string, …)` signature it inherits from `Events` — so
+	 * a plugin-defined event needs its own overload to be listenable at all.
+	 * (`trigger` is untyped by name and needs nothing.) Declared here rather
+	 * than cast at the call site so the callback payloads stay typed.
+	 *
+	 * See `src/git.ts` for what each one means.
+	 */
+	interface Workspace {
+		on(name: "obsidian-git:refreshed", callback: () => unknown, ctx?: unknown): EventRef;
+		on(
+			name: "obsidian-git:status-changed",
+			callback: (status: GitStatus) => unknown,
+			ctx?: unknown,
+		): EventRef;
+		on(name: "obsidian-git:head-change", callback: () => unknown, ctx?: unknown): EventRef;
+		on(name: "obsidian-git:loading-status", callback: () => unknown, ctx?: unknown): EventRef;
 	}
 
 	/** WorkspaceLeaf's constructor isn't part of the public typings, but a

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,11 @@
 import type { DatacoreLanguage } from "./datacore";
 import type { EventNoteConfig } from "./eventnote";
+import type {
+	GitAction,
+	GitActionStyle,
+	GitCommitScope,
+	GitSection,
+} from "./git";
 
 /** The kind of content a dashboard card renders. */
 export type CardKind =
@@ -24,6 +30,7 @@ export type CardKind =
 	| "rss"
 	| "jira"
 	| "weather"
+	| "git"
 	| "leaf";
 
 /** A refinement control available on a Jira saved-filter card. */
@@ -586,6 +593,47 @@ export interface DatacoreConfig {
 	pageSize?: number;
 }
 
+/**
+ * Per-card configuration for a "git" card, which shows the state of the vault's
+ * repository and runs git operations through the obsidian-git community plugin.
+ *
+ * Hearth performs no git work of its own — every button is a call into that
+ * plugin, so its remote, credentials and commit-message template all apply. See
+ * `src/git.ts`. Only offered by the "Add card" picker when obsidian-git is
+ * installed and enabled.
+ */
+export interface GitConfig {
+	/** Which sections the card stacks, top to bottom. Absent means the defaults
+	 * (status, actions, changes); an explicitly empty list means none. */
+	sections?: GitSection[];
+	/** Which action buttons the "actions" section offers, in order. Absent means
+	 * the defaults (commit-and-sync, commit, push, pull). */
+	actions?: GitAction[];
+	/** Whether buttons show their label next to the icon. Default: icon only. */
+	actionStyle?: GitActionStyle;
+	/** Max rows in the changed-files list; 0 shows every changed file. Default 8. */
+	changeLimit?: number;
+	/** Max commits in the log section. Default 5. */
+	logLimit?: number;
+	/** Show each changed file's folder under its name. Default: name only. */
+	showPaths?: boolean;
+	/** Which files a commit from this card includes. Default: "smart". */
+	commitScope?: GitCommitScope;
+	/** The message the card's commit buttons use. Empty hands the decision to
+	 * obsidian-git's own commit-message template. */
+	commitMessage?: string;
+	/** Have obsidian-git prompt for a message on every commit, as its
+	 * "…with specific message" commands do. Wins over `commitMessage`. */
+	askForMessage?: boolean;
+	/** Re-read the repo every N minutes on top of following obsidian-git's own
+	 * events. 0 (the default) means events only — the plugin already refreshes
+	 * after every change, so polling mostly costs `git status` calls. */
+	refreshMin?: number;
+	/** Skip the confirmation dialog before a destructive action (discard all).
+	 * Off by default: the confirmation is there for a reason. */
+	skipConfirm?: boolean;
+}
+
 /** Per-card configuration for a "leaf" card, which hosts another plugin's (or a
  * core) registered side-panel view inside the dashboard. Beta. */
 export interface LeafViewConfig {
@@ -897,6 +945,8 @@ export interface DashboardCard {
 	jira?: JiraConfig;
 	/** kind === "weather": place, style, units and what to display. */
 	weather?: WeatherConfig;
+	/** kind === "git": sections, action buttons and commit behaviour. */
+	git?: GitConfig;
 	/** kind === "leaf": the registered view type to host. */
 	leafView?: LeafViewConfig;
 

--- a/styles.css
+++ b/styles.css
@@ -6885,3 +6885,386 @@ body.hearth-dv-resizing {
 	outline: none !important;
 	box-shadow: none !important;
 }
+
+/* ---------------------------------------------------------------------------
+   Git card
+
+   A window onto the obsidian-git plugin: a status line, a button row, the
+   changed files, and optionally the recent commits. The sections are stacked
+   in the order the card's settings list them, and any of them can be off, so
+   nothing here assumes a neighbour exists — each section owns its own spacing
+   and the flex column does the rest.
+   --------------------------------------------------------------------------- */
+.hearth-git {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+	gap: 8px;
+}
+
+/* A queued operation is running (or the repo is being re-read). The card stays
+   readable and interactive-looking rather than greying out — the buttons
+   disable themselves, which is the part that matters. */
+.hearth-git.is-busy .hearth-git-status {
+	opacity: 0.7;
+}
+
+/* ---- Status line ---- */
+
+.hearth-git-status {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 6px 10px;
+	flex: 0 0 auto;
+}
+
+.hearth-git-branch {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	max-width: 100%;
+	padding: 3px 9px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 999px;
+	background: var(--background-primary-alt);
+	color: var(--text-normal);
+	font-size: 0.8rem;
+	cursor: pointer;
+}
+
+.hearth-git-branch:hover {
+	border-color: var(--interactive-accent);
+}
+
+.hearth-git-branch:focus-visible,
+.hearth-git-action:focus-visible,
+.hearth-git-commit:focus-visible,
+.hearth-git-more:focus-visible {
+	outline: 2px solid var(--interactive-accent);
+	outline-offset: 2px;
+}
+
+.hearth-git-branch-icon {
+	display: flex;
+	color: var(--text-muted);
+	flex-shrink: 0;
+}
+
+.hearth-git-branch-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-family: var(--font-monospace);
+	font-size: 0.75rem;
+}
+
+.hearth-git-chips {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.hearth-git-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+	color: var(--text-muted);
+	font-size: 0.78rem;
+	font-variant-numeric: tabular-nums;
+}
+
+.hearth-git-chip-icon {
+	display: flex;
+}
+
+.hearth-git-chip-icon .svg-icon {
+	width: 13px;
+	height: 13px;
+}
+
+/* The three states worth colouring: a conflict is a stop sign, staged work is
+   about to be committed, unpushed commits are the "you are not backed up yet"
+   signal. Unstaged changes stay muted — they are the normal state of a vault
+   you are working in. */
+.hearth-git-chip.is-conflicted {
+	color: var(--text-error);
+}
+
+.hearth-git-chip.is-staged {
+	color: var(--text-success, var(--interactive-accent));
+}
+
+.hearth-git-chip.is-unpushed {
+	color: var(--text-accent);
+}
+
+.hearth-git-clean {
+	color: var(--text-muted);
+	font-size: 0.78rem;
+}
+
+.hearth-git-lastcommit {
+	margin-left: auto;
+	color: var(--text-faint);
+	font-size: 0.72rem;
+	white-space: nowrap;
+}
+
+/* The manual re-read, which doubles as the busy indicator — it spins while a
+   read is in flight. Last in the row, and pushed to the end unless the
+   last-commit line already took the margin. */
+.hearth-git-refresh {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	margin-left: auto;
+	padding: 3px;
+	border: none;
+	border-radius: 5px;
+	background: transparent;
+	color: var(--text-faint);
+	cursor: pointer;
+	box-shadow: none;
+}
+
+.hearth-git-lastcommit + .hearth-git-refresh {
+	margin-left: 0;
+}
+
+.hearth-git-refresh:hover {
+	color: var(--text-normal);
+	background: var(--background-modifier-hover);
+}
+
+.hearth-git-refresh:focus-visible {
+	outline: 2px solid var(--interactive-accent);
+	outline-offset: 2px;
+}
+
+.hearth-git-refresh .svg-icon {
+	width: 14px;
+	height: 14px;
+}
+
+.hearth-git-refresh.is-loading {
+	animation: hearth-rss-spin 0.9s linear infinite;
+}
+
+/* ---- Buttons ---- */
+
+.hearth-git-actions {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 6px;
+	flex: 0 0 auto;
+}
+
+.hearth-git-action {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	height: 30px;
+	min-width: 30px;
+	padding: 0 8px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 7px;
+	background: var(--background-primary-alt);
+	color: var(--text-normal);
+	font-size: 0.78rem;
+	cursor: pointer;
+	box-shadow: none;
+}
+
+.hearth-git-action:hover:not(:disabled) {
+	background: var(--background-modifier-hover);
+	border-color: var(--interactive-accent);
+}
+
+.hearth-git-action:disabled {
+	opacity: 0.45;
+	cursor: default;
+}
+
+/* Labelled buttons need room for the text and read better a touch wider; icon
+   buttons stay square. */
+.hearth-git-actions.is-labelled .hearth-git-action {
+	padding: 0 11px;
+}
+
+.hearth-git-action-icon {
+	display: flex;
+}
+
+.hearth-git-action-icon .svg-icon {
+	width: 15px;
+	height: 15px;
+}
+
+/* Commit-and-sync is the one-click "save my vault" action, so it reads as the
+   primary one of the row. */
+.hearth-git-action.is-commitAndSync {
+	color: var(--text-accent);
+	border-color: var(--background-modifier-border-hover);
+}
+
+.hearth-git-action.is-destructive:hover:not(:disabled) {
+	color: var(--text-error);
+	border-color: var(--text-error);
+}
+
+/* ---- Changed files ---- */
+
+.hearth-git-changes {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+}
+
+.hearth-git-list {
+	gap: 0;
+}
+
+.hearth-git-file {
+	gap: 8px;
+	padding: 4px 6px;
+}
+
+/* The single-letter status badge. Monospaced and boxed so a column of them
+   lines up and reads as a gutter rather than as part of the file name. */
+.hearth-git-letter {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	width: 17px;
+	height: 17px;
+	border-radius: 4px;
+	background: var(--background-modifier-border);
+	color: var(--text-muted);
+	font-family: var(--font-monospace);
+	font-size: 0.66rem;
+	line-height: 1;
+}
+
+.hearth-git-file.is-conflicted .hearth-git-letter {
+	background: var(--background-modifier-error);
+	color: var(--text-error);
+}
+
+.hearth-git-file.is-untracked .hearth-git-letter,
+.hearth-git-file.is-added .hearth-git-letter {
+	color: var(--text-success, var(--interactive-accent));
+}
+
+.hearth-git-file.is-deleted .hearth-git-letter {
+	color: var(--text-error);
+}
+
+/* Staged files carry a rail on the left: the same "this is going into the next
+   commit" cue the status chip uses, without a second badge per row. */
+.hearth-git-file.is-staged {
+	box-shadow: inset 2px 0 0 0 var(--text-success, var(--interactive-accent));
+}
+
+.hearth-git-file-main {
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
+.hearth-git-file .hearth-list-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 0.85rem;
+}
+
+.hearth-git-file-path {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--text-faint);
+	font-size: 0.7rem;
+}
+
+.hearth-git-none {
+	padding: 6px 2px;
+	color: var(--text-muted);
+	font-size: 0.8rem;
+}
+
+.hearth-git-more {
+	padding: 4px 6px;
+	color: var(--text-accent);
+	font-size: 0.76rem;
+	cursor: pointer;
+}
+
+/* ---- Recent commits ---- */
+
+.hearth-git-log {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+}
+
+.hearth-git-commit {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	padding: 4px 6px;
+	border-radius: 6px;
+	cursor: pointer;
+}
+
+.hearth-git-commit:hover {
+	background: var(--background-modifier-hover);
+}
+
+.hearth-git-commit-hash {
+	flex: 0 0 auto;
+	color: var(--text-faint);
+	font-family: var(--font-monospace);
+	font-size: 0.68rem;
+}
+
+.hearth-git-commit-main {
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
+.hearth-git-commit-message {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--text-normal);
+	font-size: 0.82rem;
+}
+
+.hearth-git-commit-meta {
+	color: var(--text-faint);
+	font-size: 0.7rem;
+}
+
+/* ---- No repository yet ---- */
+
+.hearth-git-notready {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	height: 100%;
+}
+
+.hearth-git-notready-button {
+	font-size: 0.78rem;
+	cursor: pointer;
+}

--- a/test/cards-registry.test.ts
+++ b/test/cards-registry.test.ts
@@ -79,6 +79,12 @@ describe("CARD_TEMPLATES (add-card menu)", () => {
 				gated: false,
 				build: { kind: "weather", title: "Weather", weather: {}, w: 4, h: 3 },
 			},
+			{
+				id: "git",
+				icon: "git-branch",
+				gated: true,
+				build: { kind: "git", title: "Git", git: {}, w: 4, h: 4 },
+			},
 			{ id: "leaf", icon: "layout-panel-left", gated: true, build: { kind: "leaf", title: "Plugin view", leafView: {}, w: 5, h: 4 } },
 		]);
 	});
@@ -137,6 +143,7 @@ function maximalCard(): DashboardCard {
 			selections: { status: ["Open"] },
 		} as never,
 		weather: { place: { name: "Prague", lat: 50.08, lon: 14.44 } },
+		git: { sections: ["status", "actions"], actions: ["commit", "push"] },
 	};
 }
 
@@ -171,6 +178,8 @@ describe("cloneCard deep-clone independence", () => {
 		copy.jira!.controls!.push("assignee");
 		copy.jira!.selections!.status!.push("Closed");
 		copy.weather!.place!.name = "Brno";
+		copy.git!.sections!.push("log");
+		copy.git!.actions!.push("pull");
 
 		// ...and confirm none of it reached the original.
 		const pristine = maximalCard();
@@ -189,6 +198,7 @@ describe("cloneCard deep-clone independence", () => {
 		expect(orig.rss).toEqual(pristine.rss);
 		expect(orig.jira).toEqual(pristine.jira);
 		expect(orig.weather).toEqual(pristine.weather);
+		expect(orig.git).toEqual(pristine.git);
 	});
 });
 
@@ -223,6 +233,7 @@ describe("liveness classification", () => {
 			rss: "static",
 			jira: "static",
 			weather: "static",
+			git: "static",
 			leaf: "static",
 		});
 	});

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,0 +1,419 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	GIT_DEFAULT_ACTIONS,
+	GIT_DEFAULT_SECTIONS,
+	commitSummary,
+	gitActionAvailable,
+	gitActionTask,
+	gitActions,
+	gitChangeCounts,
+	gitChangeKind,
+	gitChangeRows,
+	gitFileName,
+	gitSections,
+	onlyStagedFor,
+	parseCommitDate,
+	queueGitAction,
+	queueGitFileAction,
+	readGitSnapshot,
+	shortHash,
+	type GitFileStatus,
+	type GitPlugin,
+	type GitStatus,
+} from "../src/git";
+
+/**
+ * The Git card is a window onto the obsidian-git plugin, so the logic worth
+ * testing here is the part that stands between the two: how obsidian-git's raw
+ * status letters become the card's rows, and how carefully the card treats a
+ * plugin whose methods it cannot assume exist.
+ *
+ * Running git itself needs the plugin, which tests don't have; every plugin
+ * below is a hand-built stand-in shaped like the real one.
+ */
+
+/** One status entry, defaulting to "unchanged" on both sides. */
+function file(path: string, index = " ", workingDir = " "): GitFileStatus {
+	return { path, vaultPath: path, index, workingDir };
+}
+
+/** A status built from its files, with the derived groups obsidian-git fills
+ * in — the same rules its two backends use. */
+function status(files: GitFileStatus[], conflicted: string[] = []): GitStatus {
+	return {
+		all: files,
+		changed: files.filter((f) => f.workingDir !== " "),
+		staged: files.filter((f) => f.index !== " " && f.index !== "U"),
+		conflicted,
+	};
+}
+
+describe("gitChangeKind", () => {
+	it("prefers the staged letter, which is what the next commit would carry", () => {
+		// Added to the index, then deleted on disk: what is staged is the addition.
+		expect(gitChangeKind(file("a.md", "A", "D"), new Set())).toBe("added");
+		expect(gitChangeKind(file("b.md", "M", " "), new Set())).toBe("modified");
+		expect(gitChangeKind(file("c.md", "R", " "), new Set())).toBe("renamed");
+	});
+
+	it("falls back to the working-tree letter for an unstaged change", () => {
+		expect(gitChangeKind(file("a.md", " ", "M"), new Set())).toBe("modified");
+		expect(gitChangeKind(file("b.md", " ", "D"), new Set())).toBe("deleted");
+	});
+
+	it("reads obsidian-git's 'U' as untracked", () => {
+		// Both backends rewrite git's "?" to "U" before Hearth ever sees it.
+		expect(gitChangeKind(file("new.md", "U", "U"), new Set())).toBe("untracked");
+	});
+
+	it("lets the conflicted list win over the letters", () => {
+		// An unmerged file also carries "U", so the letters alone cannot tell a
+		// conflict from an untracked file — only the conflicted list can.
+		const conflict = file("both.md", "U", "U");
+		expect(gitChangeKind(conflict, new Set(["both.md"]))).toBe("conflicted");
+	});
+
+	it("treats an unknown letter as a modification", () => {
+		expect(gitChangeKind(file("x.md", " ", "Z"), new Set())).toBe("modified");
+	});
+});
+
+describe("gitChangeRows", () => {
+	it("lists a file staged and then edited again exactly once", () => {
+		// This file is in both status.staged and status.changed; concatenating the
+		// two groups (the obvious implementation) would show it twice.
+		const rows = gitChangeRows(status([file("note.md", "M", "M")]));
+		expect(rows).toHaveLength(1);
+		expect(rows[0].staged).toBe(true);
+		expect(rows[0].unstaged).toBe(true);
+	});
+
+	it("orders conflicts first, then staged, then the rest", () => {
+		const rows = gitChangeRows(
+			status(
+				[
+					file("dirty.md", " ", "M"),
+					file("staged.md", "A", " "),
+					file("clash.md", "U", "U"),
+					file("new.md", "U", "U"),
+				],
+				["clash.md"],
+			),
+		);
+		expect(rows.map((r) => r.path)).toEqual([
+			"clash.md",
+			"staged.md",
+			"dirty.md",
+			"new.md",
+		]);
+	});
+
+	it("keeps git's own ordering within a group", () => {
+		const rows = gitChangeRows(
+			status([file("b.md", " ", "M"), file("a.md", " ", "M"), file("c.md", " ", "M")]),
+		);
+		expect(rows.map((r) => r.path)).toEqual(["b.md", "a.md", "c.md"]);
+	});
+
+	it("carries the badge letter, the file name and both paths", () => {
+		const entry = file("notes/deep/one.md", " ", "D");
+		entry.vaultPath = "vault/notes/deep/one.md";
+		const [row] = gitChangeRows(status([entry]));
+		expect(row).toMatchObject({
+			path: "notes/deep/one.md",
+			vaultPath: "vault/notes/deep/one.md",
+			name: "one.md",
+			kind: "deleted",
+			letter: "D",
+		});
+	});
+
+	it("falls back to the repo path when a backend reports no vault path", () => {
+		const entry = { ...file("a.md", " ", "M"), vaultPath: "" };
+		expect(gitChangeRows(status([entry]))[0].vaultPath).toBe("a.md");
+	});
+
+	it("is empty for a missing status rather than throwing", () => {
+		expect(gitChangeRows(undefined)).toEqual([]);
+	});
+});
+
+describe("gitChangeCounts", () => {
+	it("counts each file once per group it belongs to", () => {
+		const counts = gitChangeCounts(
+			status(
+				[
+					file("staged.md", "M", " "),
+					file("both.md", "M", "M"),
+					file("dirty.md", " ", "M"),
+					file("clash.md", "U", "U"),
+				],
+				["clash.md"],
+			),
+		);
+		// both.md is staged *and* dirty, so it shows in two counts but once in the
+		// total, which counts files rather than changes.
+		expect(counts).toEqual({ staged: 2, unstaged: 2, conflicted: 1, total: 4 });
+	});
+
+	it("reports nothing for a clean tree", () => {
+		expect(gitChangeCounts(status([]))).toEqual({
+			staged: 0,
+			unstaged: 0,
+			conflicted: 0,
+			total: 0,
+		});
+	});
+});
+
+describe("onlyStagedFor", () => {
+	const staged = status([file("a.md", "M", " ")]);
+	const dirty = status([file("a.md", " ", "M")]);
+
+	it("commits only what is staged when something is (smart, the default)", () => {
+		expect(onlyStagedFor(undefined, staged)).toBe(true);
+		expect(onlyStagedFor("smart", staged)).toBe(true);
+	});
+
+	it("commits everything when nothing is staged", () => {
+		expect(onlyStagedFor(undefined, dirty)).toBe(false);
+		expect(onlyStagedFor("smart", undefined)).toBe(false);
+	});
+
+	it("honours the explicit scopes regardless of the status", () => {
+		expect(onlyStagedFor("all", staged)).toBe(false);
+		expect(onlyStagedFor("staged", dirty)).toBe(true);
+	});
+});
+
+describe("commit formatting", () => {
+	it("takes the first non-empty line as a commit's subject", () => {
+		expect(commitSummary("\n\n  vault backup  \n\nlong body here")).toBe("vault backup");
+		expect(commitSummary("")).toBe("");
+		expect(commitSummary(undefined)).toBe("");
+	});
+
+	it("abbreviates a hash like git does", () => {
+		expect(shortHash("0123456789abcdef")).toBe("0123456");
+		expect(shortHash(undefined)).toBe("");
+	});
+
+	it("parses dates from both obsidian-git backends", () => {
+		// Desktop (SimpleGit) hands through git's ISO string...
+		expect(parseCommitDate("2025-08-04T10:30:00+02:00")).toBe(
+			new Date("2025-08-04T10:30:00+02:00").getTime(),
+		);
+		// ...while mobile (isomorphic-git) formats a Date.toDateString().
+		expect(parseCommitDate("Mon Aug 04 2025")).toBe(new Date("Mon Aug 04 2025").getTime());
+	});
+
+	it("returns null rather than NaN for something unparseable", () => {
+		expect(parseCommitDate("not a date")).toBeNull();
+		expect(parseCommitDate(undefined)).toBeNull();
+		expect(parseCommitDate("")).toBeNull();
+	});
+});
+
+describe("gitFileName", () => {
+	it("takes the last path segment", () => {
+		expect(gitFileName("a/b/c.md")).toBe("c.md");
+		expect(gitFileName("c.md")).toBe("c.md");
+		expect(gitFileName("")).toBe("");
+	});
+});
+
+describe("section and action normalization", () => {
+	it("uses the defaults when nothing is configured", () => {
+		expect(gitSections(undefined)).toEqual([...GIT_DEFAULT_SECTIONS]);
+		expect(gitActions(undefined)).toEqual([...GIT_DEFAULT_ACTIONS]);
+	});
+
+	it("keeps the configured order and drops duplicates", () => {
+		expect(gitActions(["push", "commit", "push"])).toEqual(["push", "commit"]);
+		expect(gitSections(["log", "status", "log"])).toEqual(["log", "status"]);
+	});
+
+	it("drops ids this build doesn't know", () => {
+		// A layout exported by a newer Hearth, or hand-edited.
+		expect(gitActions(["push", "teleport"])).toEqual(["push"]);
+		expect(gitSections(["changes", "graph"])).toEqual(["changes"]);
+	});
+
+	it("respects an explicitly empty list but not an all-junk one", () => {
+		// Turning every section off is a real choice; a list where nothing survives
+		// validation is a broken import and falls back to the defaults.
+		expect(gitSections([])).toEqual([]);
+		expect(gitSections(["graph"])).toEqual([...GIT_DEFAULT_SECTIONS]);
+		expect(gitActions([])).toEqual([]);
+		expect(gitActions(["teleport"])).toEqual([...GIT_DEFAULT_ACTIONS]);
+	});
+});
+
+/** A plugin stand-in with only the members a test asks for. */
+function fakePlugin(overrides: Partial<GitPlugin> = {}): GitPlugin {
+	return {
+		gitReady: true,
+		gitManager: {},
+		...overrides,
+	};
+}
+
+describe("gitActionTask / gitActionAvailable", () => {
+	it("refuses an action this obsidian-git build doesn't expose", () => {
+		// The whole point of the optional-member typing: a renamed or removed
+		// method disables one button instead of throwing on click.
+		const bare = fakePlugin();
+		expect(gitActionTask(bare, "commit")).toBeNull();
+		expect(gitActionAvailable(bare, "push")).toBe(false);
+	});
+
+	it("treats the view-opening actions as always available", () => {
+		expect(gitActionAvailable(fakePlugin(), "sourceControl")).toBe(true);
+		expect(gitActionAvailable(fakePlugin(), "history")).toBe(true);
+	});
+
+	it("passes the card's commit options straight through to the plugin", async () => {
+		const commit = vi.fn().mockResolvedValue(true);
+		const plugin = fakePlugin({ commit });
+		await gitActionTask(plugin, "commit", {
+			commitMessage: "vault backup",
+			onlyStaged: true,
+		})?.();
+		expect(commit).toHaveBeenCalledWith({
+			fromAuto: false,
+			requestCustomMessage: undefined,
+			commitMessage: "vault backup",
+			onlyStaged: true,
+		});
+	});
+
+	it("marks a card commit as manual, never as an automatic backup", () => {
+		// fromAuto/fromAutoBackup change how obsidian-git reports and messages the
+		// commit; a button press is a manual one.
+		const commitAndSync = vi.fn().mockResolvedValue(undefined);
+		void gitActionTask(fakePlugin({ commitAndSync }), "commitAndSync", {})?.();
+		expect(commitAndSync).toHaveBeenCalledWith(
+			expect.objectContaining({ fromAutoBackup: false }),
+		);
+	});
+
+	it("hands the cached status to a stage-all so the backend needn't re-read it", async () => {
+		const stageAll = vi.fn().mockResolvedValue(undefined);
+		const cached = status([file("a.md", " ", "M")]);
+		const plugin = fakePlugin({ gitManager: { stageAll }, cachedStatus: cached });
+		await gitActionTask(plugin, "stageAll")?.();
+		expect(stageAll).toHaveBeenCalledWith({ status: cached });
+	});
+});
+
+describe("queueGitAction", () => {
+	it("goes through obsidian-git's own queue, so it serializes with its backups", () => {
+		const addTask = vi.fn();
+		const push = vi.fn().mockResolvedValue(true);
+		const queued = queueGitAction(
+			fakePlugin({ push, promiseQueue: { addTask } }),
+			"push",
+			{},
+		);
+		expect(queued).toBe(true);
+		expect(addTask).toHaveBeenCalledTimes(1);
+		// The task itself is deferred to the queue rather than run here.
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("reports failure for an unsupported action instead of queueing a no-op", () => {
+		const addTask = vi.fn();
+		expect(
+			queueGitAction(fakePlugin({ promiseQueue: { addTask } }), "push", {}),
+		).toBe(false);
+		expect(addTask).not.toHaveBeenCalled();
+	});
+
+	it("still runs when a build has no queue", async () => {
+		const push = vi.fn().mockResolvedValue(true);
+		expect(queueGitAction(fakePlugin({ push }), "push", {})).toBe(true);
+		await vi.waitFor(() => expect(push).toHaveBeenCalled());
+	});
+});
+
+describe("queueGitFileAction", () => {
+	it("stages one file by its repo-relative path", () => {
+		const stage = vi.fn().mockResolvedValue(undefined);
+		const addTask = vi.fn((task: () => Promise<unknown>) => void task());
+		const plugin = fakePlugin({ gitManager: { stage }, promiseQueue: { addTask } });
+		expect(queueGitFileAction(plugin, "stage", "notes/a.md")).toBe(true);
+		// `false` is "this path is relative to the repo, not the vault" — status
+		// paths already are, so no conversion should happen on the way in.
+		expect(stage).toHaveBeenCalledWith("notes/a.md", false);
+	});
+
+	it("reports failure when the backend can't do it", () => {
+		expect(queueGitFileAction(fakePlugin(), "discard", "a.md")).toBe(false);
+	});
+});
+
+describe("readGitSnapshot", () => {
+	it("reads nothing at all before the plugin has a repository", async () => {
+		const updateCachedStatus = vi.fn();
+		const snapshot = await readGitSnapshot(
+			fakePlugin({ gitReady: false, updateCachedStatus }),
+		);
+		expect(snapshot).toEqual({});
+		expect(updateCachedStatus).not.toHaveBeenCalled();
+	});
+
+	it("refreshes through the plugin's cache, so its own views update too", async () => {
+		const fresh = status([file("a.md", " ", "M")]);
+		const updateCachedStatus = vi.fn().mockResolvedValue(fresh);
+		const gitStatus = vi.fn();
+		const snapshot = await readGitSnapshot(
+			fakePlugin({ updateCachedStatus, gitManager: { status: gitStatus } }),
+		);
+		expect(snapshot.status).toBe(fresh);
+		// Never a second `git status` alongside the plugin's own.
+		expect(gitStatus).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the last cached status when the read fails", async () => {
+		const cached = status([file("old.md", " ", "M")]);
+		const snapshot = await readGitSnapshot(
+			fakePlugin({
+				cachedStatus: cached,
+				updateCachedStatus: vi.fn().mockRejectedValue(new Error("locked")),
+			}),
+		);
+		expect(snapshot.status).toBe(cached);
+	});
+
+	it("survives a repo with no branch, no upstream and no commits", async () => {
+		// A freshly initialized repo fails all three of these reads; the card must
+		// still get a usable snapshot rather than an exception.
+		const snapshot = await readGitSnapshot(
+			fakePlugin({
+				updateCachedStatus: vi.fn().mockResolvedValue(status([])),
+				gitManager: {
+					branchInfo: vi.fn().mockRejectedValue(new Error("no HEAD")),
+					getUnpushedCommits: vi.fn().mockRejectedValue(new Error("no upstream")),
+					getLastCommitTime: vi.fn().mockRejectedValue(new Error("no commits")),
+				},
+			}),
+			{ logLimit: 5 },
+		);
+		expect(snapshot.status?.all).toEqual([]);
+		expect(snapshot.branch).toBeUndefined();
+		expect(snapshot.unpushed).toBeUndefined();
+		expect(snapshot.lastCommit).toBeUndefined();
+	});
+
+	it("only runs git log for a card that shows the log", async () => {
+		const log = vi.fn().mockResolvedValue([]);
+		const plugin = fakePlugin({
+			updateCachedStatus: vi.fn().mockResolvedValue(status([])),
+			gitManager: { log },
+		});
+		await readGitSnapshot(plugin);
+		expect(log).not.toHaveBeenCalled();
+		await readGitSnapshot(plugin, { logLimit: 3 });
+		expect(log).toHaveBeenCalledWith(undefined, false, 3);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds a **Git card** for vaults kept in a git repository by the [obsidian-git](https://github.com/Vinzent03/obsidian-git) plugin — the same integration shape as Omnisearch, Dataview and Datacore.

The card shows the branch, staged and changed files, the unpushed commit count, the last commit time, and optionally the recent log. It offers buttons for **commit-and-sync, commit, push, pull, fetch, stage all, unstage all, discard all** and **switch branch**, plus one-click ways into obsidian-git's own source-control and history panels. Clicking a changed file opens the note; right-clicking offers its diff, staging, unstaging and discard.

**It uses obsidian-git's API rather than mirroring it.** Hearth never shells out to `git`, bundles a git implementation, or reads `.git/`. Every operation is a call into the running plugin instance, pushed onto that plugin's own `promiseQueue` — the same queue its commands use. A card button therefore behaves identically to the matching command in the palette: same remote, credentials, commit-message template and error reporting, and no chance of interleaving with an automatic backup.

Two design notes worth review attention:

- **obsidian-git publishes no versioned `api` object** the way Omnisearch and Datacore do; what's available is the plugin instance's public members. Stable in practice (its own views and commands call them), but not a contract — so every member is typed optional in `GitPlugin` and probed before use. A renamed method disables one button rather than throwing inside a dashboard render.
- **Liveness follows the plugin's workspace events, not a poll.** The subtlety: obsidian-git only recomputes status during a refresh cycle when its own status bar or one of its views needs it, and a Hearth card is neither. So the card repaints for free off `obsidian-git:status-changed`, and re-reads for itself only when a `refreshed` cycle produced no status event. `head-change` forces a full re-read (branch, ahead count and log are all stale). Optional timed re-reads cover a repo also changed outside Obsidian.

**Customization with defaults that already work:** which of the four sections stack (status / buttons / changed files / log) and which buttons appear, in what order, as icons or icons with labels; what a commit covers (staged-if-anything-is-staged — matching obsidian-git's own "Commit" — vs. everything vs. staged only); a fixed commit message or the plugin's own prompt; list caps; folder paths. Discarding confirms first unless turned off. The card is gated on the plugin being enabled, and Git joins the Integrations catalogue.

**Files:** `src/git.ts` (integration + pure helpers), `src/cards/git.ts` (card + editor), plus registration in `types.ts` / `cards/index.ts` / `layout.ts` / `integrations.ts` / `locales/en.ts`, styles, and `test/git.test.ts` (40 tests).

## Related issue

None — happy to open one and align first if you'd rather this were discussed before merging.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (also `npm run typecheck`, `npm run lint` with 0 errors, and all 515 tests)
- [x] I've tested this in an actual vault

> Not vault-tested: this was written in a headless environment with no Obsidian and no obsidian-git install. The pure logic is unit-tested (status classification, commit formatting, the section/action normalizers, and the plugin-probing paths against hand-built stand-ins), but the rendering, the event wiring and every real call into obsidian-git have not been exercised against the running plugin. Worth a pass in a real repo before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SAEtp3sDJmew3ETxYfUPtE)_