### PR TITLE
feat(cards): add a Pet card — a pixel-art companion fed by vault activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,15 +70,25 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   the outline, shading and belly are derived from the body color, and the whole
   sprite is drawn from a 16×16 character grid, so the card ships no images at
   all. Its mood comes from the vault, not from a timer: notes edited (or
-  created) today against a goal you set make it content, happy or bouncing with
-  joy, and a quiet day leaves it a little bored and eventually asleep, with
-  drifting z's. That is the entire ladder — there is no hunger, no age, no
-  illness and no way to lose it, so a fortnight away from the vault costs
-  nothing but a nap. Click the pet to pet it: hearts, and half an hour of
-  guaranteed happiness. Everything is recomputed from file timestamps on each
-  draw, so a synced `data.json`, a closed laptop or a device you have not opened
-  in a month can never leave it out of step. Low power mode and a reduced-motion
-  preference keep the pet perfectly still — the mood is in its face.
+  created) today against thresholds you set make it content, happy or bouncing
+  with joy, and a quiet day leaves it slouched and bored and eventually curled
+  up asleep, draining of color, with drifting z's. That is the entire ladder —
+  there is no hunger, no age, no illness and no way to lose it, so a fortnight
+  away from the vault costs nothing but a nap. Click the pet to pet it: hearts,
+  and a stretch of guaranteed happiness.
+
+  **Every rung is yours to set.** Where excited, happy and content begin, how
+  long the vault must stay quiet before the pet sleeps, and how long a petting
+  lasts. Set them however you like — they are always read back in climbing
+  order, so no combination leaves a mood the pet can't reach.
+
+  Each mood is drawn animation, not one picture being wobbled: the pet blinks,
+  glances aside, wags its head, squashes as it lands from a hop and breathes in
+  its sleep, from frames generated out of that single drawing. Everything is
+  recomputed from file timestamps on each draw, so a synced `data.json`, a
+  closed laptop or a device you have not opened in a month can never leave the
+  pet out of step. Low power mode and a reduced-motion preference keep the pet
+  perfectly still — the mood is in its posture and its face.
 - **Git card.** If your vault is a repository kept by the
   [Git](https://github.com/Vinzent03/obsidian-git) plugin, the dashboard can now
   show and drive it. The card puts the branch, the staged and changed files, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,20 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   than blanking the card, the sky stops animating in low power mode, and the
   whole thing goes quiet under **Settings → Behaviour → Disable external
   calls**. Open-Meteo joins the Integrations catalogue.
+- **Pet card.** A pixel-art companion that follows how much you write. Pick an
+  animal — cat, dog, bird, fox, frog or blob — name it, and set its two colors;
+  the outline, shading and belly are derived from the body color, and the whole
+  sprite is drawn from a 16×16 character grid, so the card ships no images at
+  all. Its mood comes from the vault, not from a timer: notes edited (or
+  created) today against a goal you set make it content, happy or bouncing with
+  joy, and a quiet day leaves it a little bored and eventually asleep, with
+  drifting z's. That is the entire ladder — there is no hunger, no age, no
+  illness and no way to lose it, so a fortnight away from the vault costs
+  nothing but a nap. Click the pet to pet it: hearts, and half an hour of
+  guaranteed happiness. Everything is recomputed from file timestamps on each
+  draw, so a synced `data.json`, a closed laptop or a device you have not opened
+  in a month can never leave it out of step. Low power mode and a reduced-motion
+  preference keep the pet perfectly still — the mood is in its face.
 - **Git card.** If your vault is a repository kept by the
   [Git](https://github.com/Vinzent03/obsidian-git) plugin, the dashboard can now
   show and drive it. The card puts the branch, the staged and changed files, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,15 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   lasts. Set them however you like — they are always read back in climbing
   order, so no combination leaves a mood the pet can't reach.
 
+  **It looks at you, and it knows what time it is.** The pet's eyes follow
+  your pointer — over its own card, or anywhere on the dashboard, or not at
+  all, as you like — by shifting under a pixel, snapped to the grid, with the
+  face drawn whole underneath so nothing tears. A sleeping pet keeps its eyes
+  shut. And a quiet small hour now reads as the hour rather than as neglect:
+  in the night window you set, a *bored* pet goes to sleep under a moon
+  instead of its z's, or sleeps through the window whatever the day held, or
+  ignores the clock entirely. Petting always wakes it, in every mode.
+
   Each mood is drawn animation, not one picture being wobbled: the pet blinks,
   glances aside, wags its head, squashes as it lands from a hop and breathes in
   its sleep, from frames generated out of that single drawing. Everything is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,9 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   sprite is drawn from a 16×16 character grid, so the card ships no images at
   all. Its mood comes from the vault, not from a timer: notes edited (or
   created) today against thresholds you set make it content, happy or bouncing
-  with joy, and a quiet day leaves it slouched and bored and eventually curled
-  up asleep, draining of color, with drifting z's. That is the entire ladder —
+  with joy, and a quiet day leaves it slouched and bored, then curled up
+  asleep once the vault has been still for a while, draining of color, with
+  drifting z's. That is the entire ladder —
   there is no hunger, no age, no illness and no way to lose it, so a fortnight
   away from the vault costs nothing but a nap. Click the pet to pet it: hearts,
   and a stretch of guaranteed happiness.
@@ -87,9 +88,15 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   all, as you like — by shifting under a pixel, snapped to the grid, with the
   face drawn whole underneath so nothing tears. A sleeping pet keeps its eyes
   shut. And a quiet small hour now reads as the hour rather than as neglect:
-  in the night window you set, a *bored* pet goes to sleep under a moon
-  instead of its z's, or sleeps through the window whatever the day held, or
-  ignores the clock entirely. Petting always wakes it, in every mode.
+  in the night window you set, a bored or merely content pet goes to sleep
+  under a moon instead of its z's, or the pet sleeps through the window
+  whatever the day held, or the clock is ignored entirely. A good day still
+  shows as a good day at midnight, and petting always wakes the pet.
+
+  **And it sleeps when the vault does.** After a stretch with nothing touched
+  anywhere in the vault — yours to set — the pet falls asleep whatever its
+  mood and however good the day was, and any activity at all wakes it back to
+  the rung the day earned.
 
   Each mood is drawn animation, not one picture being wobbled: the pet blinks,
   glances aside, wags its head, squashes as it lands from a hop and breathes in

--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ Add cards from the **Arrange** toolbar; configure each one from the card itself
 - **Pet** — a pixel-art companion (cat, dog, bird, fox, frog or blob) whose
   mood follows your vault: content, happy or bouncing with joy as you write,
   slouched and bored and then curled up asleep on a quiet day. Each mood is
-  drawn animation — blinking, head-wagging, hopping, breathing. No hunger, no
-  age, nothing to lose — and clicking it earns hearts. Name it, color it, and
-  set where every mood begins.
+  drawn animation — blinking, head-wagging, hopping, breathing — and its eyes
+  follow your pointer. Set a night window and a quiet small hour reads as the
+  hour, not as neglect. No hunger, no age, nothing to lose — and clicking it
+  earns hearts. Name it, color it, and set where every mood begins.
 
 Everything is **live**: embeds and editable notes follow vault events without
 losing your cursor, data cards redraw on vault and metadata changes, and web

--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ Add cards from the **Arrange** toolbar; configure each one from the card itself
   queries (`20% of 150`). Optional on-screen keypad.
 - **Pet** — a pixel-art companion (cat, dog, bird, fox, frog or blob) whose
   mood follows your vault: content, happy or bouncing with joy as you write,
-  a little bored and then asleep on a quiet day. No hunger, no age, nothing to
-  lose — and clicking it earns hearts. Name it, color it, and set what counts
-  as a good day.
+  slouched and bored and then curled up asleep on a quiet day. Each mood is
+  drawn animation — blinking, head-wagging, hopping, breathing. No hunger, no
+  age, nothing to lose — and clicking it earns hearts. Name it, color it, and
+  set where every mood begins.
 
 Everything is **live**: embeds and editable notes follow vault events without
 losing your cursor, data cards redraw on vault and metadata changes, and web

--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ Add cards from the **Arrange** toolbar; configure each one from the card itself
 - **Calculator** — evaluates as you type: math, unit conversions, live currency
   ([Frankfurter](https://www.frankfurter.app/), ECB rates) and plain-language
   queries (`20% of 150`). Optional on-screen keypad.
+- **Pet** — a pixel-art companion (cat, dog, bird, fox, frog or blob) whose
+  mood follows your vault: content, happy or bouncing with joy as you write,
+  a little bored and then asleep on a quiet day. No hunger, no age, nothing to
+  lose — and clicking it earns hearts. Name it, color it, and set what counts
+  as a good day.
 
 Everything is **live**: embeds and editable notes follow vault events without
 losing your cursor, data cards redraw on vault and metadata changes, and web

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -25,6 +25,7 @@ import { jiraCard } from "./jira";
 import { weatherCard } from "./weather";
 import { gitCard } from "./git";
 import { leafCard } from "./leaf";
+import { petCard } from "./pet";
 
 export type {
 	CardDefinition,
@@ -64,6 +65,7 @@ export const CARD_DEFINITIONS: { [K in CardKind]: CardDefinition<K> } = {
 	weather: weatherCard,
 	git: gitCard,
 	leaf: leafCard,
+	pet: petCard,
 };
 
 /** Every registered kind, in registry order. Used for layout-import validation
@@ -125,6 +127,7 @@ export const TEMPLATE_MENU_ORDER: string[] = [
 	"weather",
 	"git",
 	"leaf",
+	"pet",
 ];
 
 const TEMPLATES_BY_ID = new Map<string, CardTemplateDef>();

--- a/src/cards/pet.ts
+++ b/src/cards/pet.ts
@@ -1,0 +1,734 @@
+import { Component, Setting } from "obsidian";
+import { localDayKey } from "../dates";
+import { t } from "../i18n";
+import { type DashboardCard, type PetConfig, type PetSpecies, lowPowerActive } from "../types";
+import { makeClickable } from "../ui";
+import { type HomeView } from "../view";
+import { type CardDefinition, type CardEditorContext } from "./definition";
+
+
+// ---- Pet ----------------------------------------------------------------
+//
+// A pixel-art companion that reacts to how much you write. Deliberately a
+// one-way mood ladder: there is no hunger, no age, no illness and no way to
+// lose the pet — a quiet vault only makes it bored and then sleepy, and any
+// activity wakes it straight back up. Every mood is *derived* on render from
+// vault timestamps rather than simulated on a timer, so closing Obsidian for a
+// month, or syncing data.json between machines, cannot desynchronise anything.
+//
+// The sprites are 16×16 character grids (no image assets): one shared body plus
+// a per-species head, painted with a face for the current mood and emitted as a
+// run-length-encoded SVG of at most a few dozen rects.
+
+
+/** The mood ladder, quietest first. Nothing below "sleepy" exists. */
+export type PetMood = "sleepy" | "bored" | "content" | "happy" | "excited";
+
+/** Every species, in the order the editor offers them. */
+export const PET_SPECIES: PetSpecies[] = ["cat", "dog", "bird", "fox", "frog", "blob"];
+
+/** Notes touched today that count as a good day, when the card doesn't say. */
+export const PET_DEFAULT_GOAL = 3;
+
+/** How long a petting keeps the pet at least happy. */
+export const PET_PETTED_MS = 30 * 60 * 1000;
+
+/** With nothing written today, the pet dozes off once the freshest note in the
+ * vault is this old; until then it is merely bored. */
+export const PET_SLEEPY_AFTER_MS = 6 * 60 * 60 * 1000;
+
+/** How often the card re-derives its mood without a vault event, so a pet left
+ * on screen still drifts from bored to sleepy (and out of a petting). */
+const PET_TICK_MS = 5 * 60 * 1000;
+
+
+// ---- Mood ---------------------------------------------------------------
+
+/** Everything the mood is derived from. Pure input, so the ladder below can be
+ * unit-tested without a vault. */
+export interface PetPulse {
+	/** Notes touched (edited or created) today. */
+	today: number;
+	/** Notes a day that count as a good day. */
+	goal: number;
+	/** Age of the freshest note in the vault, or null for an empty vault. */
+	sinceLastMs: number | null;
+	/** Time since the pet was last petted, or null if it never was. */
+	pettedMsAgo: number | null;
+}
+
+/**
+ * The mood ladder. Activity today is the whole story: at the goal the pet is
+ * happy, at twice it excited, at anything above zero content. With nothing
+ * today it is bored while the vault is still warm and asleep once the freshest
+ * note is `PET_SLEEPY_AFTER_MS` old. A recent petting floors the mood at happy
+ * — it can only ever lift the pet, never lower it.
+ */
+export function moodFor(pulse: PetPulse): PetMood {
+	const goal = pulse.goal > 0 ? pulse.goal : PET_DEFAULT_GOAL;
+	const petted = pulse.pettedMsAgo != null && pulse.pettedMsAgo >= 0 && pulse.pettedMsAgo < PET_PETTED_MS;
+	let mood: PetMood;
+	if (pulse.today >= goal * 2) mood = "excited";
+	else if (pulse.today >= goal) mood = "happy";
+	else if (pulse.today > 0) mood = "content";
+	else if (pulse.sinceLastMs != null && pulse.sinceLastMs < PET_SLEEPY_AFTER_MS) mood = "bored";
+	else mood = "sleepy";
+	if (petted && mood !== "excited") mood = "happy";
+	return mood;
+}
+
+/**
+ * Consecutive days with any activity, ending today. A day with nothing on it
+ * yet doesn't break the streak — the count then runs back from yesterday, so
+ * the number only ever drops once a whole day has passed unwritten.
+ */
+export function activityStreak(counts: Map<string, number>, today: Date): number {
+	const day = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+	// Skip today when it is still empty, so a morning with no notes yet doesn't
+	// read as a broken streak.
+	if (!counts.get(localDayKey(day.getTime()))) day.setDate(day.getDate() - 1);
+	let streak = 0;
+	// Bounded: a decade of daily writing is already an absurd streak, and the
+	// cap keeps a corrupt clock from spinning here forever.
+	for (let i = 0; i < 3660; i++) {
+		if (!counts.get(localDayKey(day.getTime()))) break;
+		streak++;
+		day.setDate(day.getDate() - 1);
+	}
+	return streak;
+}
+
+/** What the vault says about today, in one pass over the markdown files. */
+interface VaultPulse {
+	today: number;
+	streak: number;
+	sinceLastMs: number | null;
+}
+
+function readVaultPulse(view: HomeView, metric: "modified" | "created"): VaultPulse {
+	const counts = new Map<string, number>();
+	let newest = 0;
+	for (const file of view.app.vault.getMarkdownFiles()) {
+		const ts = metric === "created" ? file.stat.ctime : file.stat.mtime;
+		const key = localDayKey(ts);
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+		if (ts > newest) newest = ts;
+	}
+	const now = new Date();
+	return {
+		today: counts.get(localDayKey(now.getTime())) ?? 0,
+		streak: activityStreak(counts, now),
+		// A file timestamped in the future (bad clock, odd sync) would otherwise
+		// read as negative age and count as "warm" forever; clamp at zero.
+		sinceLastMs: newest > 0 ? Math.max(0, now.getTime() - newest) : null,
+	};
+}
+
+
+// ---- Colors -------------------------------------------------------------
+
+/** Body and accent color each species starts with. */
+const SPECIES_COLORS: Record<PetSpecies, { body: string; accent: string }> = {
+	cat: { body: "#e8a33d", accent: "#f7d9b8" },
+	dog: { body: "#c08552", accent: "#f2ded0" },
+	bird: { body: "#4fa3d9", accent: "#f2c14e" },
+	fox: { body: "#e2703a", accent: "#f7efe6" },
+	frog: { body: "#6fbf5a", accent: "#f4b8c4" },
+	blob: { body: "#9b7bd4", accent: "#ffe08a" },
+};
+
+/** Parse `#rgb` / `#rrggbb` into 0–255 channels, or null if it isn't one. */
+export function parseHex(hex: string): [number, number, number] | null {
+	const text = hex.trim().replace(/^#/, "");
+	const full = text.length === 3 ? text.replace(/./g, (c) => c + c) : text;
+	if (!/^[0-9a-fA-F]{6}$/.test(full)) return null;
+	return [
+		parseInt(full.slice(0, 2), 16),
+		parseInt(full.slice(2, 4), 16),
+		parseInt(full.slice(4, 6), 16),
+	];
+}
+
+function toHex(r: number, g: number, b: number): string {
+	const clamp = (n: number) => Math.max(0, Math.min(255, Math.round(n)));
+	return `#${[r, g, b].map((n) => clamp(n).toString(16).padStart(2, "0")).join("")}`;
+}
+
+/**
+ * Move a color towards black (`amount` < 0) or white (`amount` > 0), by that
+ * fraction of the distance. Used to derive the outline, the shading and the
+ * belly from the one body color the user picks, so the palette always hangs
+ * together whatever they choose. An unparseable color is returned untouched.
+ */
+export function shadeHex(hex: string, amount: number): string {
+	const rgb = parseHex(hex);
+	if (!rgb) return hex;
+	const target = amount < 0 ? 0 : 255;
+	const f = Math.min(1, Math.abs(amount));
+	return toHex(...(rgb.map((c) => c + (target - c) * f) as [number, number, number]));
+}
+
+/** The four derived colors a sprite is drawn with. */
+export interface PetPalette {
+	outline: string;
+	body: string;
+	light: string;
+	accent: string;
+}
+
+export function paletteFor(cfg: PetConfig): PetPalette {
+	const species = cfg.species ?? "cat";
+	const defaults = SPECIES_COLORS[species] ?? SPECIES_COLORS.cat;
+	const body = parseHex(cfg.bodyColor ?? "") ? cfg.bodyColor! : defaults.body;
+	const accent = parseHex(cfg.accentColor ?? "") ? cfg.accentColor! : defaults.accent;
+	return { outline: shadeHex(body, -0.62), body, light: shadeHex(body, 0.45), accent };
+}
+
+/** The default colors offered when a species is picked or the colors reset. */
+export function defaultColors(species: PetSpecies): { body: string; accent: string } {
+	return SPECIES_COLORS[species] ?? SPECIES_COLORS.cat;
+}
+
+
+// ---- Sprites ------------------------------------------------------------
+//
+// Palette characters: `.` transparent, `o` outline, `b` body, `l` belly/light,
+// `a` accent, `e` eye, `w` eye shine. Every row is exactly 16 characters (a
+// unit test pins that, and that no stray character sneaks into the art).
+
+export const PET_SPRITE_SIZE = 16;
+
+/** The sitting body every species shares — rows 9–15. */
+const PET_BODY: string[] = [
+	"..obbbbbbbbbbo..",
+	".obbllllllllbbo.",
+	".obbllllllllbbo.",
+	".obbllllllllbbo.",
+	".obbbllllllbbbo.",
+	".obaaobbbboaabo.",
+	"..oooooooooooo..",
+];
+
+/** Where a species' face is painted. Eyes are drawn from their top-left pixel;
+ * the mouth is centred on `mouthCol` and `mouthWidth` pixels wide. */
+interface SpeciesArt {
+	/** Rows 0–8: the head. */
+	head: string[];
+	eyeRow: number;
+	eyeCols: [number, number];
+	mouthRow: number;
+	mouthCol: number;
+	mouthWidth: number;
+	/** Draw an accent nose just above the mouth (the muzzled species). */
+	nose: boolean;
+	/** Species whose beak is already in the art take no drawn mouth. */
+	mouth: boolean;
+}
+
+const SPECIES_ART: Record<PetSpecies, SpeciesArt> = {
+	cat: {
+		head: [
+			"...o........o...",
+			"..oao......oao..",
+			"..obao....oabo..",
+			"..obbo....obbo..",
+			"..obbboooobbbo..",
+			"..obbbbbbbbbbo..",
+			"..obbbbbbbbbbo..",
+			"..obbbbbbbbbbo..",
+			"...obbbbbbbbo...",
+		],
+		eyeRow: 5,
+		eyeCols: [4, 9],
+		mouthRow: 8,
+		mouthCol: 7,
+		mouthWidth: 2,
+		nose: true,
+		mouth: true,
+	},
+	dog: {
+		head: [
+			"....oooooooo....",
+			"...obbbbbbbbo...",
+			"...obbbbbbbbo...",
+			"obaobbbbbbbboabo",
+			"obaobbbbbbbboabo",
+			"obaobbbbbbbboabo",
+			".obobbbbbbbbobo.",
+			"...obbbbbbbbo...",
+			"....obbbbbbo....",
+		],
+		eyeRow: 4,
+		eyeCols: [5, 9],
+		mouthRow: 7,
+		mouthCol: 7,
+		mouthWidth: 2,
+		nose: true,
+		mouth: true,
+	},
+	bird: {
+		head: [
+			".....oooooo.....",
+			"....obbbbbbo....",
+			"...obbbbbbbbo...",
+			"..obbbbbbbbbbo..",
+			"..obbbbbbbbbbo..",
+			"..obbbbbbbbbbo..",
+			"..obbbbaabbbbo..",
+			"...obbbaabbbo...",
+			"....obbbbbbo....",
+		],
+		eyeRow: 3,
+		eyeCols: [4, 9],
+		mouthRow: 6,
+		mouthCol: 7,
+		mouthWidth: 2,
+		nose: false,
+		mouth: false,
+	},
+	fox: {
+		head: [
+			"..oo........oo..",
+			"..oao......oao..",
+			"..oabo....obao..",
+			"..obbboooobbbo..",
+			".obbbbbbbbbbbbo.",
+			".obbbbbbbbbbbbo.",
+			".obllbbbbbbllbo.",
+			"..obbllllllbbo..",
+			"...obllllllbo...",
+		],
+		eyeRow: 4,
+		eyeCols: [4, 10],
+		mouthRow: 7,
+		mouthCol: 7,
+		mouthWidth: 2,
+		nose: true,
+		mouth: true,
+	},
+	frog: {
+		head: [
+			"..oooo....oooo..",
+			".obbbbo..obbbbo.",
+			".obbbbboobbbbbo.",
+			".obbbbbbbbbbbbo.",
+			".obbbbbbbbbbbbo.",
+			".obbbbbbbbbbbbo.",
+			".obbbbbbbbbbbbo.",
+			"..obbbbbbbbbbo..",
+			"...obbbbbbbbo...",
+		],
+		eyeRow: 1,
+		eyeCols: [3, 11],
+		mouthRow: 6,
+		mouthCol: 5,
+		mouthWidth: 6,
+		nose: false,
+		mouth: true,
+	},
+	blob: {
+		head: [
+			"....oooooooo....",
+			"..oobbbbbbbboo..",
+			".obbbbbbbbbbbbo.",
+			".obbbbbbbbbbbbo.",
+			".obbbbbbbbbbbbo.",
+			".obbbbbbbbbbbbo.",
+			".obbbbbbbbbbbbo.",
+			"..obbbbbbbbbbo..",
+			"...obbbbbbbbo...",
+		],
+		eyeRow: 4,
+		eyeCols: [4, 10],
+		mouthRow: 7,
+		mouthCol: 7,
+		mouthWidth: 2,
+		nose: false,
+		mouth: true,
+	},
+};
+
+
+/** Write one pixel, ignoring anything that would fall off the grid. */
+function put(grid: string[][], row: number, col: number, ch: string): void {
+	const line = grid[row];
+	if (!line || col < 0 || col >= line.length) return;
+	line[col] = ch;
+}
+
+/** Paint one eye in the style the mood calls for. `col` is its left pixel.
+ *
+ * - happy / excited — a `^` two rows tall;
+ * - content — a 2×2 eye with a shine in the corner;
+ * - bored — only the lower half, so the lids read as heavy;
+ * - sleepy — a flat closed line. */
+function paintEye(grid: string[][], row: number, col: number, mood: PetMood): void {
+	if (mood === "happy" || mood === "excited") {
+		put(grid, row + 1, col, "e");
+		put(grid, row, col + 1, "e");
+		put(grid, row + 1, col + 2, "e");
+		return;
+	}
+	if (mood === "sleepy") {
+		for (let i = 0; i < 3; i++) put(grid, row + 1, col + i, "e");
+		return;
+	}
+	if (mood === "bored") {
+		put(grid, row + 1, col, "e");
+		put(grid, row + 1, col + 1, "e");
+		return;
+	}
+	put(grid, row, col, "e");
+	put(grid, row, col + 1, "e");
+	put(grid, row + 1, col, "e");
+	put(grid, row + 1, col + 1, "e");
+	put(grid, row, col, "w");
+}
+
+function paintMouth(grid: string[][], art: SpeciesArt, mood: PetMood): void {
+	if (mood === "sleepy") return;
+	const { mouthRow: row, mouthCol: col, mouthWidth: width } = art;
+	if (!art.mouth) {
+		// The beak is already drawn in the art, so it takes no mouth — except
+		// when excited, where a dark line splits it into an open beak.
+		if (mood === "excited") for (let i = 0; i < width; i++) put(grid, row + 1, col + i, "o");
+		return;
+	}
+	for (let i = 0; i < width; i++) put(grid, row, col + i, "o");
+	// A smile turns the corners up one row.
+	if (mood === "happy" || mood === "excited") {
+		put(grid, row - 1, col - 1, "o");
+		put(grid, row - 1, col + width, "o");
+	}
+	// An excited pet opens its mouth.
+	if (mood === "excited") for (let i = 0; i < width; i++) put(grid, row + 1, col + i, "o");
+}
+
+/**
+ * The finished 16×16 grid for a species in a mood: the shared body under the
+ * species head, with the face painted on top.
+ */
+export function spriteFor(species: PetSpecies, mood: PetMood): string[] {
+	const art = SPECIES_ART[species] ?? SPECIES_ART.cat;
+	const grid = [...art.head, ...PET_BODY].map((row) => row.split(""));
+	for (const col of art.eyeCols) paintEye(grid, art.eyeRow, col, mood);
+	if (art.nose && mood !== "sleepy") {
+		put(grid, art.mouthRow - 1, art.mouthCol, "a");
+		put(grid, art.mouthRow - 1, art.mouthCol + 1, "a");
+	}
+	paintMouth(grid, art, mood);
+	return grid.map((row) => row.join(""));
+}
+
+/** One horizontal run of same-colored pixels. */
+export interface SpriteRun {
+	row: number;
+	col: number;
+	len: number;
+	ch: string;
+}
+
+/** Collapse a sprite into horizontal runs, so a 256-pixel grid draws as a few
+ * dozen `<rect>`s instead of one per pixel. */
+export function spriteRuns(rows: string[]): SpriteRun[] {
+	const runs: SpriteRun[] = [];
+	rows.forEach((row, y) => {
+		let start = -1;
+		let ch = "";
+		const flush = (end: number) => {
+			if (start >= 0) runs.push({ row: y, col: start, len: end - start, ch });
+			start = -1;
+			ch = "";
+		};
+		for (let x = 0; x < row.length; x++) {
+			const c = row[x];
+			if (c === ".") {
+				flush(x);
+				continue;
+			}
+			if (c !== ch) {
+				flush(x);
+				start = x;
+				ch = c;
+			}
+		}
+		flush(row.length);
+	});
+	return runs;
+}
+
+const RUN_FILL: Record<string, string> = {
+	o: "var(--hearth-pet-outline)",
+	b: "var(--hearth-pet-body)",
+	l: "var(--hearth-pet-light)",
+	a: "var(--hearth-pet-accent)",
+	e: "var(--hearth-pet-eye)",
+	w: "var(--hearth-pet-shine)",
+};
+
+function drawSprite(parent: HTMLElement, species: PetSpecies, mood: PetMood): void {
+	const svg = parent.createSvg("svg", {
+		cls: "hearth-pet-sprite",
+		attr: {
+			viewBox: `0 0 ${PET_SPRITE_SIZE} ${PET_SPRITE_SIZE}`,
+			"shape-rendering": "crispEdges",
+			focusable: "false",
+			"aria-hidden": "true",
+		},
+	});
+	for (const run of spriteRuns(spriteFor(species, mood))) {
+		svg.createSvg("rect", {
+			attr: {
+				x: String(run.col),
+				y: String(run.row),
+				width: String(run.len),
+				height: "1",
+				fill: RUN_FILL[run.ch] ?? RUN_FILL.b,
+			},
+		});
+	}
+}
+
+
+// ---- Render -------------------------------------------------------------
+
+/** The pet's display name: what it was called, or the species' own name. */
+export function petName(cfg: PetConfig): string {
+	const named = cfg.name?.trim();
+	if (named) return named;
+	return t().cards.pet.species[cfg.species ?? "cat"];
+}
+
+function moodLabel(mood: PetMood): string {
+	const s = t().cards.pet;
+	switch (mood) {
+		case "excited":
+			return s.moodExcited;
+		case "happy":
+			return s.moodHappy;
+		case "content":
+			return s.moodContent;
+		case "bored":
+			return s.moodBored;
+		default:
+			return s.moodSleepy;
+	}
+}
+
+/** A short burst of hearts when the pet is petted. Each element removes itself
+ * when its animation ends, so nothing accumulates however often it's clicked. */
+function burstHearts(stage: HTMLElement): void {
+	for (let i = 0; i < 3; i++) {
+		const heart = stage.createDiv("hearth-pet-heart");
+		heart.setText("♥");
+		heart.style.setProperty("--i", String(i));
+		heart.addEventListener("animationend", () => heart.remove());
+	}
+}
+
+export function renderPet(
+	view: HomeView,
+	card: DashboardCard,
+	body: HTMLElement,
+	component: Component,
+): void {
+	const cfg = (card.pet ??= {});
+	const species = cfg.species ?? "cat";
+	const palette = paletteFor(cfg);
+	const still = lowPowerActive(view.plugin.settings);
+
+	const wrap = body.createDiv("hearth-pet");
+	wrap.addClass(`is-${cfg.size ?? "md"}`);
+	wrap.style.setProperty("--hearth-pet-outline", palette.outline);
+	wrap.style.setProperty("--hearth-pet-body", palette.body);
+	wrap.style.setProperty("--hearth-pet-light", palette.light);
+	wrap.style.setProperty("--hearth-pet-accent", palette.accent);
+
+	const stage = wrap.createDiv("hearth-pet-stage");
+	const name = wrap.createDiv("hearth-pet-name");
+	const moodEl = wrap.createDiv("hearth-pet-mood");
+	const activity = wrap.createDiv("hearth-pet-activity");
+
+	/** Re-derive everything from the vault and repaint. Cheap enough to run on
+	 * every vault event: one pass over the file list plus a few dozen rects. */
+	const paint = () => {
+		const pulse = readVaultPulse(view, cfg.metric ?? "modified");
+		const goal = cfg.dailyGoal && cfg.dailyGoal > 0 ? cfg.dailyGoal : PET_DEFAULT_GOAL;
+		const mood = moodFor({
+			today: pulse.today,
+			goal,
+			sinceLastMs: pulse.sinceLastMs,
+			pettedMsAgo: cfg.lastPlayedAt ? Date.now() - cfg.lastPlayedAt : null,
+		});
+
+		stage.empty();
+		for (const m of ["sleepy", "bored", "content", "happy", "excited"]) stage.removeClass(`is-${m}`);
+		stage.addClass(`is-${mood}`);
+		stage.toggleClass("is-still", still);
+		drawSprite(stage, species, mood);
+		// Sleeping pets get their z's — but not while animation is suppressed,
+		// since they are nothing but a float animation.
+		if (mood === "sleepy" && !still) {
+			const zzz = stage.createDiv("hearth-pet-zzz");
+			for (let i = 0; i < 3; i++) {
+				// The glyph itself is drawn in CSS (::after) — it is decoration,
+				// not text, and must not be picked up as a translatable string.
+				const z = zzz.createDiv("hearth-pet-z");
+				z.style.setProperty("--i", String(i));
+			}
+		}
+
+		name.setText(petName(cfg));
+		name.toggle(cfg.showName !== false);
+		moodEl.setText(moodLabel(mood));
+		moodEl.toggle(cfg.showMood !== false);
+		const parts = [t().cards.pet.todayCount(pulse.today, cfg.metric ?? "modified")];
+		if (pulse.streak > 1) parts.push(t().cards.pet.streak(pulse.streak));
+		activity.setText(parts.join(" · "));
+		activity.toggle(cfg.showActivity !== false);
+
+		stage.setAttribute("aria-label", `${petName(cfg)} — ${moodLabel(mood)}. ${t().cards.pet.petHint}`);
+		stage.setAttribute("title", t().cards.pet.petHint);
+	};
+
+	const pet = () => {
+		cfg.lastPlayedAt = Date.now();
+		void view.plugin.saveData(view.plugin.settings);
+		paint();
+		if (!still) burstHearts(stage);
+	};
+	makeClickable(stage, pet, t().cards.pet.petHint);
+	stage.addEventListener("click", pet);
+
+	paint();
+	// The vault-event redraw covers everything the pet reacts to *except* the
+	// passage of time (bored → sleepy, and a petting wearing off), so re-derive
+	// on a slow timer too. Low power mode keeps the first paint and drops the
+	// timer, like the web card's refresh.
+	if (!still) component.registerInterval(window.setInterval(paint, PET_TICK_MS));
+}
+
+
+// ---- Editor -------------------------------------------------------------
+
+export function petEditor(container: HTMLElement, ctx: CardEditorContext): void {
+	const cfg = (ctx.card.pet ??= {});
+	const strings = t().editors.pet;
+
+	new Setting(container).setName(strings.species).addDropdown((d) => {
+		for (const species of PET_SPECIES) d.addOption(species, t().cards.pet.species[species]);
+		d.setValue(cfg.species ?? "cat").onChange((v) => {
+			cfg.species = v as PetSpecies;
+			// The colors are per-species defaults until the user picks their own,
+			// so a species swap on untouched colors brings that animal's palette.
+			ctx.opts.save();
+			ctx.requestRender();
+		});
+	});
+
+	new Setting(container).setName(strings.name).setDesc(strings.nameDesc).addText((txt) =>
+		txt
+			.setPlaceholder(t().cards.pet.species[cfg.species ?? "cat"])
+			.setValue(cfg.name ?? "")
+			.onChange((v) => {
+				cfg.name = v.trim() || undefined;
+				ctx.opts.save();
+			}),
+	);
+
+	const colors = defaultColors(cfg.species ?? "cat");
+	new Setting(container)
+		.setName(strings.colors)
+		.setDesc(strings.colorsDesc)
+		.addColorPicker((picker) =>
+			picker.setValue(cfg.bodyColor ?? colors.body).onChange((v) => {
+				cfg.bodyColor = v;
+				ctx.opts.save();
+			}),
+		)
+		.addColorPicker((picker) =>
+			picker.setValue(cfg.accentColor ?? colors.accent).onChange((v) => {
+				cfg.accentColor = v;
+				ctx.opts.save();
+			}),
+		)
+		.addExtraButton((btn) =>
+			btn
+				.setIcon("rotate-ccw")
+				.setTooltip(strings.colorsReset)
+				.onClick(() => {
+					cfg.bodyColor = undefined;
+					cfg.accentColor = undefined;
+					ctx.opts.save();
+					ctx.requestRender();
+				}),
+		);
+
+	new Setting(container).setName(strings.size).addDropdown((d) => {
+		d.addOption("sm", strings.sizeSmall);
+		d.addOption("md", strings.sizeMedium);
+		d.addOption("lg", strings.sizeLarge);
+		d.setValue(cfg.size ?? "md").onChange((v) => {
+			cfg.size = v as NonNullable<PetConfig["size"]>;
+			ctx.opts.save();
+		});
+	});
+
+	new Setting(container).setName(strings.metric).setDesc(strings.metricDesc).addDropdown((d) => {
+		d.addOption("modified", strings.metricModified);
+		d.addOption("created", strings.metricCreated);
+		d.setValue(cfg.metric ?? "modified").onChange((v) => {
+			cfg.metric = v as NonNullable<PetConfig["metric"]>;
+			ctx.opts.save();
+		});
+	});
+
+	new Setting(container)
+		.setName(strings.goal)
+		.setDesc(strings.goalDesc)
+		.addSlider((slider) =>
+			slider
+				.setLimits(1, 20, 1)
+				.setValue(cfg.dailyGoal && cfg.dailyGoal > 0 ? cfg.dailyGoal : PET_DEFAULT_GOAL)
+				.onChange((v) => {
+					cfg.dailyGoal = v;
+					ctx.opts.save();
+				}),
+		);
+
+	new Setting(container).setName(strings.showName).addToggle((toggle) =>
+		toggle.setValue(cfg.showName !== false).onChange((v) => {
+			cfg.showName = v ? undefined : false;
+			ctx.opts.save();
+		}),
+	);
+	new Setting(container).setName(strings.showMood).addToggle((toggle) =>
+		toggle.setValue(cfg.showMood !== false).onChange((v) => {
+			cfg.showMood = v ? undefined : false;
+			ctx.opts.save();
+		}),
+	);
+	new Setting(container).setName(strings.showActivity).addToggle((toggle) =>
+		toggle.setValue(cfg.showActivity !== false).onChange((v) => {
+			cfg.showActivity = v ? undefined : false;
+			ctx.opts.save();
+		}),
+	);
+}
+
+
+/** A pixel-art companion whose mood follows how much you write. */
+export const petCard: CardDefinition<"pet"> = {
+	kind: "pet",
+	templates: [
+		{ id: "pet", name: "Pet", icon: "cat", build: () => ({ kind: "pet", title: "Pet", pet: {}, w: 3, h: 4 }) },
+	],
+	render: (view, card, body, component) => renderPet(view, card, body, component),
+	renderEditor: (container, ctx) => petEditor(container, ctx),
+	cloneConfig: (source, copy) => {
+		if (source.pet) copy.pet = { ...source.pet };
+	},
+	// Vault events are what the pet actually reacts to; the slow timer inside
+	// render covers the rest (bored → sleepy).
+	liveness: { mode: "vault" },
+};

--- a/src/cards/pet.ts
+++ b/src/cards/pet.ts
@@ -1,4 +1,4 @@
-import { Component, Setting } from "obsidian";
+import { Component, type DropdownComponent, Setting } from "obsidian";
 import { localDayKey } from "../dates";
 import { t } from "../i18n";
 import { type DashboardCard, type PetConfig, type PetSpecies, lowPowerActive } from "../types";
@@ -83,6 +83,31 @@ export function thresholdsFor(cfg: PetConfig): PetThresholds {
 	};
 }
 
+/** Default night window: 23:00 to 07:00. */
+export const PET_DEFAULT_NIGHT: [number, number] = [23, 7];
+
+/** Clamp an hour to a whole 0–23, falling back when it is missing or absurd. */
+function hourOr(value: number | undefined, fallback: number): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+	const hour = Math.floor(value);
+	return hour >= 0 && hour <= 23 ? hour : fallback;
+}
+
+/**
+ * Is `date`'s local hour inside the card's night window? The window wraps
+ * midnight (23 → 7 is the default and the normal case), and a window whose
+ * ends are equal is treated as no window at all rather than as all day —
+ * "from 9 to 9" is much more likely a half-set slider than a request for a pet
+ * that sleeps around the clock.
+ */
+export function inNightWindow(date: Date, cfg: PetConfig): boolean {
+	const from = hourOr(cfg.nightFrom, PET_DEFAULT_NIGHT[0]);
+	const to = hourOr(cfg.nightTo, PET_DEFAULT_NIGHT[1]);
+	if (from === to) return false;
+	const hour = date.getHours();
+	return from < to ? hour >= from && hour < to : hour >= from || hour < to;
+}
+
 /** Everything the mood is derived from. Pure input, so the ladder below can be
  * unit-tested without a vault. */
 export interface PetPulse {
@@ -94,6 +119,8 @@ export interface PetPulse {
 	sinceLastMs: number | null;
 	/** Time since the pet was last petted, or null if it never was. */
 	pettedMsAgo: number | null;
+	/** What the clock is allowed to do, and whether it is night right now. */
+	night?: { mode: NonNullable<PetConfig["nightSleep"]>; now: boolean };
 }
 
 /**
@@ -113,6 +140,14 @@ export function moodFor(pulse: PetPulse): PetMood {
 	else if (pulse.today >= limits.content) mood = "content";
 	else if (pulse.sinceLastMs != null && pulse.sinceLastMs < limits.sleepyAfterMs) mood = "bored";
 	else mood = "sleepy";
+	// The clock, if the card lets it speak. "quiet" only reaches a bored pet:
+	// at two in the morning an empty day is the hour, not neglect. "always"
+	// puts the pet to bed however the day went.
+	if (pulse.night?.now) {
+		if (pulse.night.mode === "always") mood = "sleepy";
+		else if (pulse.night.mode === "quiet" && mood === "bored") mood = "sleepy";
+	}
+	// Petting is the last word in every mode, so a pet is never unwakeable.
 	if (petted && mood !== "excited") mood = "happy";
 	return mood;
 }
@@ -621,11 +656,9 @@ function drawSprite(parent: HTMLElement, species: PetSpecies, mood: PetMood, sti
 			"aria-hidden": "true",
 		},
 	});
-	const frames = still ? spriteFrames(species, mood).slice(0, 1) : spriteFrames(species, mood);
-	frames.forEach((frame, index) => {
-		const group = svg.createSvg("g", { cls: "hearth-pet-frame", attr: { "data-f": String(index) } });
-		for (const run of spriteRuns(frame)) {
-			group.createSvg("rect", {
+	const paintRuns = (parent: SVGElement, runs: SpriteRun[]) => {
+		for (const run of runs) {
+			parent.createSvg("rect", {
 				attr: {
 					x: String(run.col),
 					y: String(run.row),
@@ -635,6 +668,21 @@ function drawSprite(parent: HTMLElement, species: PetSpecies, mood: PetMood, sti
 				},
 			});
 		}
+	};
+
+	const frames = still ? spriteFrames(species, mood).slice(0, 1) : spriteFrames(species, mood);
+	frames.forEach((frame, index) => {
+		const group = svg.createSvg("g", { cls: "hearth-pet-frame", attr: { "data-f": String(index) } });
+		// Two layers per frame. The face is drawn *whole* underneath, with the
+		// eye pixels filled in as skin, and the eyes go on top in their own
+		// group — so the stylesheet can shift them a pixel towards the pointer
+		// without leaving holes in the head where they used to be, and without
+		// the card being redrawn on every mouse move.
+		paintRuns(group, spriteRuns(frame.map((row) => row.replace(/[ew]/g, "b"))));
+		paintRuns(
+			group.createSvg("g", { cls: "hearth-pet-eyes" }),
+			spriteRuns(frame).filter((run) => run.ch === "e" || run.ch === "w"),
+		);
 	});
 }
 
@@ -700,25 +748,90 @@ export function renderPet(
 
 	/** Re-derive everything from the vault and repaint. Cheap enough to run on
 	 * every vault event: one pass over the file list plus a few dozen rects. */
+	/** The mood on screen right now, so the pointer tracking can tell whether
+	 * the eyes it would move are open. */
+	let shown: PetMood = "content";
+
+	/** Put the eyes back to centre. Called whenever the pointer leaves, and on
+	 * every repaint — the fresh sprite starts centred and the variables that
+	 * moved the old one must not outlive it. */
+	const lookAway = () => {
+		stage.style.removeProperty("--hearth-pet-look-x");
+		stage.style.removeProperty("--hearth-pet-look-y");
+	};
+
+	/**
+	 * Follow the pointer with the eyes. The whole effect is two custom
+	 * properties read by a transform on the eye group, so a mouse move costs a
+	 * compositor transform and nothing else — no redraw, no layout, and the
+	 * sprite's own animations keep running underneath. Coalesced into an
+	 * animation frame, since pointermove fires far faster than the screen.
+	 *
+	 * A sleeping pet has its eyes shut, so it never looks; low power mode and
+	 * a reduced-motion preference skip the listener entirely.
+	 */
+	const wireEyes = () => {
+		const follow = cfg.eyesFollow ?? "card";
+		if (follow === "off" || still) return;
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+		// "board" watches the whole dashboard, so the pet notices a pointer that
+		// never comes near it; "card" only looks up when you are on its card.
+		// "card" watches the card body rather than the sprite alone, so the pet
+		// looks up as soon as the pointer is anywhere on its card.
+		const surface: HTMLElement = follow === "board" ? (body.closest(".hearth-grid") ?? body) : body;
+
+		let queued = false;
+		let pending: { x: number; y: number } | null = null;
+		const apply = () => {
+			queued = false;
+			if (!pending) return;
+			const box = stage.getBoundingClientRect();
+			if (!box.width || !box.height) return;
+			// Normalised offset from the pet's centre, clamped to ±1, then scaled
+			// to a pixel of the 16×16 grid. crispEdges rounds the result, so the
+			// pupils snap between pixels the way pixel art should.
+			const dx = Math.max(-1, Math.min(1, (pending.x - (box.left + box.width / 2)) / (box.width / 2)));
+			const dy = Math.max(-1, Math.min(1, (pending.y - (box.top + box.height / 2)) / (box.height / 2)));
+			stage.style.setProperty("--hearth-pet-look-x", `${(dx * 0.9).toFixed(2)}px`);
+			stage.style.setProperty("--hearth-pet-look-y", `${(dy * 0.6).toFixed(2)}px`);
+		};
+		component.registerDomEvent(surface, "pointermove", (ev: PointerEvent) => {
+			if (shown === "sleepy") return;
+			pending = { x: ev.clientX, y: ev.clientY };
+			if (queued) return;
+			queued = true;
+			window.requestAnimationFrame(apply);
+		});
+		component.registerDomEvent(surface, "pointerleave", lookAway);
+	};
+
 	const paint = () => {
 		const pulse = readVaultPulse(view, cfg.metric ?? "modified");
+		const nightMode = cfg.nightSleep ?? "quiet";
+		const night = nightMode !== "off" && inNightWindow(new Date(), cfg);
 		const mood = moodFor({
 			today: pulse.today,
 			thresholds: thresholdsFor(cfg),
 			sinceLastMs: pulse.sinceLastMs,
 			pettedMsAgo: cfg.lastPlayedAt ? Date.now() - cfg.lastPlayedAt : null,
+			night: { mode: nightMode, now: night },
 		});
+		shown = mood;
 
 		stage.empty();
 		for (const m of ["sleepy", "bored", "content", "happy", "excited"]) stage.removeClass(`is-${m}`);
 		stage.addClass(`is-${mood}`);
 		stage.toggleClass("is-still", still);
+		// Asleep because of the hour rather than the vault: a moon instead of
+		// the z's, so the card says "it is night" and not "you did nothing".
+		stage.toggleClass("is-night", night && mood === "sleepy");
+		lookAway();
 		drawSprite(stage, species, mood, still);
 		// Sleeping pets get their z's — but not while animation is suppressed,
 		// since they are nothing but a float animation.
 		if (mood === "sleepy" && !still) {
-			const zzz = stage.createDiv("hearth-pet-zzz");
-			for (let i = 0; i < 3; i++) {
+			const zzz = stage.createDiv(night ? "hearth-pet-zzz is-moon" : "hearth-pet-zzz");
+			for (let i = 0; i < (night ? 1 : 3); i++) {
 				// The glyph itself is drawn in CSS (::after) — it is decoration,
 				// not text, and must not be picked up as a translatable string.
 				const z = zzz.createDiv("hearth-pet-z");
@@ -728,16 +841,18 @@ export function renderPet(
 
 		name.setText(petName(cfg));
 		name.toggle(cfg.showName !== false);
-		moodEl.setText(moodLabel(mood));
+		moodEl.setText(night && mood === "sleepy" ? t().cards.pet.moodNight : moodLabel(mood));
 		moodEl.toggle(cfg.showMood !== false);
 		const parts = [t().cards.pet.todayCount(pulse.today, cfg.metric ?? "modified")];
 		if (pulse.streak > 1) parts.push(t().cards.pet.streak(pulse.streak));
 		activity.setText(parts.join(" · "));
 		activity.toggle(cfg.showActivity !== false);
 
-		stage.setAttribute("aria-label", `${petName(cfg)} — ${moodLabel(mood)}. ${t().cards.pet.petHint}`);
+		stage.setAttribute("aria-label", `${petName(cfg)} — ${moodEl.getText()}. ${t().cards.pet.petHint}`);
 		stage.setAttribute("title", t().cards.pet.petHint);
 	};
+
+	wireEyes();
 
 	const pet = () => {
 		cfg.lastPlayedAt = Date.now();
@@ -906,6 +1021,44 @@ export function petEditor(container: HTMLElement, ctx: CardEditorContext): void 
 				ctx.requestRender();
 			}),
 	);
+
+	// ---- Night, and where the eyes look ----
+	new Setting(container).setName(strings.nightSleep).setDesc(strings.nightSleepDesc).addDropdown((d) => {
+		d.addOption("off", strings.nightOff);
+		d.addOption("quiet", strings.nightQuiet);
+		d.addOption("always", strings.nightAlways);
+		d.setValue(cfg.nightSleep ?? "quiet").onChange((v) => {
+			cfg.nightSleep = v as NonNullable<PetConfig["nightSleep"]>;
+			ctx.opts.save();
+			ctx.requestRender();
+			ctx.opts.rerender();
+		});
+	});
+
+	if ((cfg.nightSleep ?? "quiet") !== "off") {
+		const hours = new Setting(container).setName(strings.nightWindow).setDesc(strings.nightWindowDesc);
+		const hourPicker = (value: number, apply: (hour: number) => void) => (d: DropdownComponent) => {
+			for (let hour = 0; hour < 24; hour++) d.addOption(String(hour), `${String(hour).padStart(2, "0")}:00`);
+			d.setValue(String(value)).onChange((v) => {
+				apply(Number(v));
+				ctx.opts.save();
+				ctx.opts.rerender();
+			});
+		};
+		hours.addDropdown(hourPicker(cfg.nightFrom ?? PET_DEFAULT_NIGHT[0], (h) => (cfg.nightFrom = h)));
+		hours.addDropdown(hourPicker(cfg.nightTo ?? PET_DEFAULT_NIGHT[1], (h) => (cfg.nightTo = h)));
+	}
+
+	new Setting(container).setName(strings.eyesFollow).setDesc(strings.eyesFollowDesc).addDropdown((d) => {
+		d.addOption("off", strings.eyesOff);
+		d.addOption("card", strings.eyesCard);
+		d.addOption("board", strings.eyesBoard);
+		d.setValue(cfg.eyesFollow ?? "card").onChange((v) => {
+			cfg.eyesFollow = v as NonNullable<PetConfig["eyesFollow"]>;
+			ctx.opts.save();
+			ctx.opts.rerender();
+		});
+	});
 
 	new Setting(container).setName(strings.showName).addToggle((toggle) =>
 		toggle.setValue(cfg.showName !== false).onChange((v) => {

--- a/src/cards/pet.ts
+++ b/src/cards/pet.ts
@@ -36,8 +36,8 @@ export const PET_DEFAULT_CONTENT = 1;
 /** How long a petting keeps the pet at least happy, when the card doesn't say. */
 export const PET_PETTED_MS = 30 * 60 * 1000;
 
-/** With nothing written today, the pet dozes off once the freshest note in the
- * vault is this old; until then it is merely bored. */
+/** The pet dozes off once nothing in the vault has been touched for this long
+ * — whatever its mood — and any activity wakes it again. */
 export const PET_SLEEPY_AFTER_MS = 6 * 60 * 60 * 1000;
 
 /** How often the card re-derives its mood without a vault event, so a pet left
@@ -55,7 +55,7 @@ export interface PetThresholds {
 	happy: number;
 	/** Notes today for "excited". */
 	excited: number;
-	/** Quiet vault, on a day with no activity, before the pet falls asleep. */
+	/** Quiet vault, in any mood, before the pet falls asleep. */
 	sleepyAfterMs: number;
 	/** How long a petting holds the pet at happy. */
 	pettedMs: number;
@@ -124,11 +124,19 @@ export interface PetPulse {
 }
 
 /**
- * The mood ladder. Activity today is the whole story: the pet is excited,
- * happy or content at the thresholds the card sets. With nothing today it is
- * bored while the vault is still warm and asleep once the freshest note is
- * older than the card's quiet time. A recent petting floors the mood at happy
- * — it can only ever lift the pet, never lower it.
+ * The mood ladder.
+ *
+ * How the day went sets the rung: excited, happy or content at the thresholds
+ * the card holds, bored on a day with nothing on it yet.
+ *
+ * On top of that sits one rule that outranks the day entirely — the pet sleeps
+ * once the vault has been quiet for the card's idle time, however brilliant
+ * the day was, and any activity at all wakes it straight back up. A pet that
+ * wrote twenty notes this morning and nothing since is asleep by evening, and
+ * one keystroke in a note brings it back to the rung its day earned.
+ *
+ * Then the clock, if the card lets it speak, and finally a petting — which can
+ * only ever lift the pet, so it is never unwakeable.
  */
 export function moodFor(pulse: PetPulse): PetMood {
 	const limits = pulse.thresholds;
@@ -138,14 +146,19 @@ export function moodFor(pulse: PetPulse): PetMood {
 	if (pulse.today >= limits.excited) mood = "excited";
 	else if (pulse.today >= limits.happy) mood = "happy";
 	else if (pulse.today >= limits.content) mood = "content";
-	else if (pulse.sinceLastMs != null && pulse.sinceLastMs < limits.sleepyAfterMs) mood = "bored";
-	else mood = "sleepy";
-	// The clock, if the card lets it speak. "quiet" only reaches a bored pet:
-	// at two in the morning an empty day is the hour, not neglect. "always"
-	// puts the pet to bed however the day went.
+	else mood = "bored";
+	// Idleness beats the day: a quiet vault puts any pet to sleep, and only a
+	// vault that has been touched recently keeps one awake. An empty vault has
+	// no timestamp to be recent, so its pet sleeps.
+	if (pulse.sinceLastMs == null || pulse.sinceLastMs >= limits.sleepyAfterMs) mood = "sleepy";
+	// The clock, if the card lets it speak. "quiet" reaches a bored or content
+	// pet: at two in the morning a thin day is the hour, not neglect. A good
+	// day still shows as a good day. "always" puts the pet to bed regardless.
 	if (pulse.night?.now) {
 		if (pulse.night.mode === "always") mood = "sleepy";
-		else if (pulse.night.mode === "quiet" && mood === "bored") mood = "sleepy";
+		else if (pulse.night.mode === "quiet" && (mood === "bored" || mood === "content")) {
+			mood = "sleepy";
+		}
 	}
 	// Petting is the last word in every mode, so a pet is never unwakeable.
 	if (petted && mood !== "excited") mood = "happy";
@@ -187,7 +200,10 @@ function readVaultPulse(view: HomeView, metric: "modified" | "created"): VaultPu
 		const ts = metric === "created" ? file.stat.ctime : file.stat.mtime;
 		const key = localDayKey(ts);
 		counts.set(key, (counts.get(key) ?? 0) + 1);
-		if (ts > newest) newest = ts;
+		// What wakes the pet is always the last *touch*, whatever the card
+		// counts: a card scoring created notes should still wake when you spend
+		// the afternoon editing the ones you already have.
+		if (file.stat.mtime > newest) newest = file.stat.mtime;
 	}
 	const now = new Date();
 	return {

--- a/src/cards/pet.ts
+++ b/src/cards/pet.ts
@@ -30,7 +30,10 @@ export const PET_SPECIES: PetSpecies[] = ["cat", "dog", "bird", "fox", "frog", "
 /** Notes touched today that count as a good day, when the card doesn't say. */
 export const PET_DEFAULT_GOAL = 3;
 
-/** How long a petting keeps the pet at least happy. */
+/** Notes touched today for "content", when the card doesn't say: any at all. */
+export const PET_DEFAULT_CONTENT = 1;
+
+/** How long a petting keeps the pet at least happy, when the card doesn't say. */
 export const PET_PETTED_MS = 30 * 60 * 1000;
 
 /** With nothing written today, the pet dozes off once the freshest note in the
@@ -44,13 +47,49 @@ const PET_TICK_MS = 5 * 60 * 1000;
 
 // ---- Mood ---------------------------------------------------------------
 
+/** Where each rung of the ladder starts. Every one is settable per card. */
+export interface PetThresholds {
+	/** Notes today for "content". */
+	content: number;
+	/** Notes today for "happy". */
+	happy: number;
+	/** Notes today for "excited". */
+	excited: number;
+	/** Quiet vault, on a day with no activity, before the pet falls asleep. */
+	sleepyAfterMs: number;
+	/** How long a petting holds the pet at happy. */
+	pettedMs: number;
+}
+
+/**
+ * Resolve a card's thresholds, filling in defaults and forcing the rungs into
+ * order. Sliders can be dragged into nonsense (excited below happy, content
+ * above both) and a card can arrive from an older version or a hand-edited
+ * `data.json`; rather than produce an unreachable mood, each rung is raised to
+ * at least the one below it, so the ladder always climbs.
+ */
+export function thresholdsFor(cfg: PetConfig): PetThresholds {
+	const positive = (value: number | undefined, fallback: number) =>
+		typeof value === "number" && value > 0 ? Math.floor(value) : fallback;
+	const happy = positive(cfg.dailyGoal, PET_DEFAULT_GOAL);
+	const content = Math.min(positive(cfg.contentAt, PET_DEFAULT_CONTENT), happy);
+	const excited = Math.max(positive(cfg.excitedAt, happy * 2), happy);
+	return {
+		content,
+		happy,
+		excited,
+		sleepyAfterMs: positive(cfg.sleepyAfterMin, PET_SLEEPY_AFTER_MS / 60000) * 60000,
+		pettedMs: positive(cfg.pettedForMin, PET_PETTED_MS / 60000) * 60000,
+	};
+}
+
 /** Everything the mood is derived from. Pure input, so the ladder below can be
  * unit-tested without a vault. */
 export interface PetPulse {
 	/** Notes touched (edited or created) today. */
 	today: number;
-	/** Notes a day that count as a good day. */
-	goal: number;
+	/** Where the rungs of the ladder sit for this card. */
+	thresholds: PetThresholds;
 	/** Age of the freshest note in the vault, or null for an empty vault. */
 	sinceLastMs: number | null;
 	/** Time since the pet was last petted, or null if it never was. */
@@ -58,20 +97,21 @@ export interface PetPulse {
 }
 
 /**
- * The mood ladder. Activity today is the whole story: at the goal the pet is
- * happy, at twice it excited, at anything above zero content. With nothing
- * today it is bored while the vault is still warm and asleep once the freshest
- * note is `PET_SLEEPY_AFTER_MS` old. A recent petting floors the mood at happy
+ * The mood ladder. Activity today is the whole story: the pet is excited,
+ * happy or content at the thresholds the card sets. With nothing today it is
+ * bored while the vault is still warm and asleep once the freshest note is
+ * older than the card's quiet time. A recent petting floors the mood at happy
  * — it can only ever lift the pet, never lower it.
  */
 export function moodFor(pulse: PetPulse): PetMood {
-	const goal = pulse.goal > 0 ? pulse.goal : PET_DEFAULT_GOAL;
-	const petted = pulse.pettedMsAgo != null && pulse.pettedMsAgo >= 0 && pulse.pettedMsAgo < PET_PETTED_MS;
+	const limits = pulse.thresholds;
+	const petted =
+		pulse.pettedMsAgo != null && pulse.pettedMsAgo >= 0 && pulse.pettedMsAgo < limits.pettedMs;
 	let mood: PetMood;
-	if (pulse.today >= goal * 2) mood = "excited";
-	else if (pulse.today >= goal) mood = "happy";
-	else if (pulse.today > 0) mood = "content";
-	else if (pulse.sinceLastMs != null && pulse.sinceLastMs < PET_SLEEPY_AFTER_MS) mood = "bored";
+	if (pulse.today >= limits.excited) mood = "excited";
+	else if (pulse.today >= limits.happy) mood = "happy";
+	else if (pulse.today >= limits.content) mood = "content";
+	else if (pulse.sinceLastMs != null && pulse.sinceLastMs < limits.sleepyAfterMs) mood = "bored";
 	else mood = "sleepy";
 	if (petted && mood !== "excited") mood = "happy";
 	return mood;
@@ -404,20 +444,119 @@ function paintMouth(grid: string[][], art: SpeciesArt, mood: PetMood): void {
 	if (mood === "excited") for (let i = 0; i < width; i++) put(grid, row + 1, col + i, "o");
 }
 
+/** The rows the head occupies before any posture is applied. */
+const HEAD_ROWS = 9;
+
 /**
- * The finished 16×16 grid for a species in a mood: the shared body under the
- * species head, with the face painted on top.
+ * Move a block of rows, dropping whatever falls off the grid and leaving the
+ * rows it came from empty. Transparent pixels don't overwrite what they land
+ * on, so a head moved down sinks *into* the body instead of punching a hole in
+ * it — which is exactly the slouch the low moods want.
  */
-export function spriteFor(species: PetSpecies, mood: PetMood): string[] {
+function moveBlock(grid: string[][], from: number, to: number, dy: number, dx: number): void {
+	const block = grid.slice(from, to + 1).map((row) => [...row]);
+	for (let r = from; r <= to; r++) grid[r] = new Array<string>(PET_SPRITE_SIZE).fill(".");
+	block.forEach((row, i) => {
+		const target = grid[from + i + dy];
+		if (!target) return;
+		row.forEach((ch, c) => {
+			const col = c + dx;
+			if (ch !== "." && col >= 0 && col < PET_SPRITE_SIZE) target[col] = ch;
+		});
+	});
+}
+
+/** Compress the pet towards its feet by one pixel — the breath, and the squash
+ * of a hop. Everything above the paws slides down over the belly. */
+function squash(grid: string[][]): void {
+	moveBlock(grid, 0, PET_SPRITE_SIZE - 4, 1, 0);
+}
+
+/** One drawn pose: the sprite with a face, a posture and an offset. */
+function buildSprite(
+	species: PetSpecies,
+	face: PetMood,
+	opts: { slouch?: number; lean?: number; squash?: boolean } = {},
+): string[] {
 	const art = SPECIES_ART[species] ?? SPECIES_ART.cat;
 	const grid = [...art.head, ...PET_BODY].map((row) => row.split(""));
-	for (const col of art.eyeCols) paintEye(grid, art.eyeRow, col, mood);
-	if (art.nose && mood !== "sleepy") {
+	for (const col of art.eyeCols) paintEye(grid, art.eyeRow, col, face);
+	if (art.nose && face !== "sleepy") {
 		put(grid, art.mouthRow - 1, art.mouthCol, "a");
 		put(grid, art.mouthRow - 1, art.mouthCol + 1, "a");
 	}
-	paintMouth(grid, art, mood);
+	paintMouth(grid, art, face);
+	// The head is moved as a block, so a slouching pet keeps its proportions
+	// instead of needing a second set of drawings per species.
+	const slouch = opts.slouch ?? 0;
+	const lean = opts.lean ?? 0;
+	if (slouch || lean) moveBlock(grid, 0, HEAD_ROWS - 1, slouch, lean);
+	if (opts.squash) squash(grid);
 	return grid.map((row) => row.join(""));
+}
+
+/**
+ * The finished 16×16 grid for a species in a mood — the first frame of its
+ * animation, and the only one drawn when motion is suppressed.
+ */
+export function spriteFor(species: PetSpecies, mood: PetMood): string[] {
+	return spriteFrames(species, mood)[0];
+}
+
+/** How many frames every mood is drawn in. Fixed, so the stylesheet can
+ * schedule each mood's cycle without the two definitions drifting apart. */
+export const PET_FRAME_COUNT = 3;
+
+/**
+ * The frames a mood animates through. Real drawn animation rather than a
+ * transform on one picture: the pet blinks, wags its head, squashes as it
+ * lands and breathes in its sleep, because those are things a CSS transform on
+ * a single sprite cannot say. The stylesheet gives each mood the schedule that
+ * suits it — a blink is a sixteenth of the cycle, a hop is a third.
+ *
+ * Every frame is generated from the one drawing per species by moving the head
+ * block and repainting the face, so a new species is still a single 9-row head.
+ */
+export function spriteFrames(species: PetSpecies, mood: PetMood): string[][] {
+	switch (mood) {
+		case "excited":
+			// Mid-air, stretched, and squashed on the landing.
+			return [
+				buildSprite(species, "excited"),
+				buildSprite(species, "excited", { slouch: -1 }),
+				buildSprite(species, "excited", { squash: true }),
+			];
+		case "happy":
+			// A head wagging side to side.
+			return [
+				buildSprite(species, "happy"),
+				buildSprite(species, "happy", { lean: -1 }),
+				buildSprite(species, "happy", { lean: 1 }),
+			];
+		case "content":
+			// Mostly still, with a blink and a glance to one side.
+			return [
+				buildSprite(species, "content"),
+				buildSprite(species, "sleepy"),
+				buildSprite(species, "content", { lean: 1 }),
+			];
+		case "bored":
+			// Slouched, with a long slow blink and a head that lolls sideways.
+			return [
+				buildSprite(species, "bored", { slouch: 1 }),
+				buildSprite(species, "sleepy", { slouch: 1 }),
+				buildSprite(species, "bored", { slouch: 1, lean: -1 }),
+			];
+		default:
+			// Curled down into the body, breathing, with a slow roll of the head.
+			// The slouch stops at two: a third row would push the shorter-headed
+			// species (the frog's eye bumps) clean off the top of the grid.
+			return [
+				buildSprite(species, "sleepy", { slouch: 2 }),
+				buildSprite(species, "sleepy", { slouch: 2, squash: true }),
+				buildSprite(species, "sleepy", { slouch: 2, lean: 1 }),
+			];
+	}
 }
 
 /** One horizontal run of same-colored pixels. */
@@ -466,7 +605,13 @@ const RUN_FILL: Record<string, string> = {
 	w: "var(--hearth-pet-shine)",
 };
 
-function drawSprite(parent: HTMLElement, species: PetSpecies, mood: PetMood): void {
+/**
+ * Draw the sprite: every frame of the mood, stacked as sibling groups in one
+ * SVG. Which one shows is entirely the stylesheet's business — it fades all
+ * but one out on the mood's own schedule — so the card draws once per vault
+ * event and never again to animate. `still` collapses that to frame 0.
+ */
+function drawSprite(parent: HTMLElement, species: PetSpecies, mood: PetMood, still: boolean): void {
 	const svg = parent.createSvg("svg", {
 		cls: "hearth-pet-sprite",
 		attr: {
@@ -476,17 +621,21 @@ function drawSprite(parent: HTMLElement, species: PetSpecies, mood: PetMood): vo
 			"aria-hidden": "true",
 		},
 	});
-	for (const run of spriteRuns(spriteFor(species, mood))) {
-		svg.createSvg("rect", {
-			attr: {
-				x: String(run.col),
-				y: String(run.row),
-				width: String(run.len),
-				height: "1",
-				fill: RUN_FILL[run.ch] ?? RUN_FILL.b,
-			},
-		});
-	}
+	const frames = still ? spriteFrames(species, mood).slice(0, 1) : spriteFrames(species, mood);
+	frames.forEach((frame, index) => {
+		const group = svg.createSvg("g", { cls: "hearth-pet-frame", attr: { "data-f": String(index) } });
+		for (const run of spriteRuns(frame)) {
+			group.createSvg("rect", {
+				attr: {
+					x: String(run.col),
+					y: String(run.row),
+					width: String(run.len),
+					height: "1",
+					fill: RUN_FILL[run.ch] ?? RUN_FILL.b,
+				},
+			});
+		}
+	});
 }
 
 
@@ -553,10 +702,9 @@ export function renderPet(
 	 * every vault event: one pass over the file list plus a few dozen rects. */
 	const paint = () => {
 		const pulse = readVaultPulse(view, cfg.metric ?? "modified");
-		const goal = cfg.dailyGoal && cfg.dailyGoal > 0 ? cfg.dailyGoal : PET_DEFAULT_GOAL;
 		const mood = moodFor({
 			today: pulse.today,
-			goal,
+			thresholds: thresholdsFor(cfg),
 			sinceLastMs: pulse.sinceLastMs,
 			pettedMsAgo: cfg.lastPlayedAt ? Date.now() - cfg.lastPlayedAt : null,
 		});
@@ -565,7 +713,7 @@ export function renderPet(
 		for (const m of ["sleepy", "bored", "content", "happy", "excited"]) stage.removeClass(`is-${m}`);
 		stage.addClass(`is-${mood}`);
 		stage.toggleClass("is-still", still);
-		drawSprite(stage, species, mood);
+		drawSprite(stage, species, mood, still);
 		// Sleeping pets get their z's — but not while animation is suppressed,
 		// since they are nothing but a float animation.
 		if (mood === "sleepy" && !still) {
@@ -683,18 +831,81 @@ export function petEditor(container: HTMLElement, ctx: CardEditorContext): void 
 		});
 	});
 
+	// ---- Where each mood starts ----
+	//
+	// Every rung is settable. They are read back through thresholdsFor(), which
+	// forces them into order, so no combination of sliders can produce a mood
+	// the pet is unable to reach.
+	const limits = thresholdsFor(cfg);
+	new Setting(container).setName(strings.moods).setDesc(strings.moodsDesc).setHeading();
+
+	const rung = (
+		name: string,
+		desc: string,
+		value: number,
+		max: number,
+		apply: (v: number) => void,
+	) =>
+		new Setting(container)
+			.setName(name)
+			.setDesc(desc)
+			.addSlider((slider) =>
+				slider
+					.setLimits(1, max, 1)
+					.setValue(Math.min(value, max))
+					.onChange((v) => {
+						apply(v);
+						ctx.opts.save();
+						// Redraw the card, not the panel: a threshold change can move
+						// the pet to another mood, and seeing that happen is the whole
+						// point of setting it.
+						ctx.opts.rerender();
+					}),
+			);
+
+	rung(strings.excitedAt, strings.excitedAtDesc, limits.excited, 60, (v) => (cfg.excitedAt = v));
+	rung(strings.happyAt, strings.happyAtDesc, limits.happy, 40, (v) => (cfg.dailyGoal = v));
+	rung(strings.contentAt, strings.contentAtDesc, limits.content, 20, (v) => (cfg.contentAt = v));
 	new Setting(container)
-		.setName(strings.goal)
-		.setDesc(strings.goalDesc)
+		.setName(strings.sleepyAfter)
+		.setDesc(strings.sleepyAfterDesc)
 		.addSlider((slider) =>
 			slider
-				.setLimits(1, 20, 1)
-				.setValue(cfg.dailyGoal && cfg.dailyGoal > 0 ? cfg.dailyGoal : PET_DEFAULT_GOAL)
+				.setLimits(15, 1440, 15)
+				.setValue(Math.min(1440, Math.round(limits.sleepyAfterMs / 60000)))
 				.onChange((v) => {
-					cfg.dailyGoal = v;
+					cfg.sleepyAfterMin = v;
 					ctx.opts.save();
+					ctx.opts.rerender();
 				}),
 		);
+	new Setting(container)
+		.setName(strings.pettedFor)
+		.setDesc(strings.pettedForDesc)
+		.addSlider((slider) =>
+			slider
+				.setLimits(5, 240, 5)
+				.setValue(Math.min(240, Math.round(limits.pettedMs / 60000)))
+				.onChange((v) => {
+					cfg.pettedForMin = v;
+					ctx.opts.save();
+					ctx.opts.rerender();
+				}),
+		);
+	new Setting(container).addExtraButton((btn) =>
+		btn
+			.setIcon("rotate-ccw")
+			.setTooltip(strings.moodsReset)
+			.onClick(() => {
+				cfg.dailyGoal = undefined;
+				cfg.excitedAt = undefined;
+				cfg.contentAt = undefined;
+				cfg.sleepyAfterMin = undefined;
+				cfg.pettedForMin = undefined;
+				ctx.opts.save();
+				ctx.requestRender();
+			}),
+	);
 
 	new Setting(container).setName(strings.showName).addToggle((toggle) =>
 		toggle.setValue(cfg.showName !== false).onChange((v) => {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -878,6 +878,7 @@ export const en = {
 			weather: "Weather",
 			git: "Git",
 			leaf: "Plugin view (beta)",
+			pet: "Pet",
 		},
 		linkTypes: {
 			note: "Note",
@@ -1680,6 +1681,32 @@ export const en = {
 				"Hosts another plugin's view inside the card. Some views expect a " +
 				"sidebar and may render or size oddly here.",
 		},
+		pet: {
+			species: "Animal",
+			name: "Name",
+			nameDesc: "What to call it. Leave empty to use the animal's name.",
+			colors: "Colors",
+			colorsDesc:
+				"Body and accent. The outline, shading and belly are derived from " +
+				"the body color.",
+			colorsReset: "Back to this animal's colors",
+			size: "Size",
+			sizeSmall: "Small",
+			sizeMedium: "Medium",
+			sizeLarge: "Large",
+			metric: "Feed it with",
+			metricDesc: "Which vault activity the pet's mood follows.",
+			metricModified: "Notes edited",
+			metricCreated: "Notes created",
+			goal: "A good day is",
+			goalDesc:
+				"Notes a day. At this many the pet is happy, at twice it excited. " +
+				"Below it the pet is content, bored or asleep — it is never unwell " +
+				"and never lost.",
+			showName: "Show name",
+			showMood: "Show mood",
+			showActivity: "Show today's activity",
+		},
 		colors: {
 			heading: "Colors",
 			headingDesc: "Accent and background tint for this card.",
@@ -1753,6 +1780,27 @@ export const en = {
 			leafPickView: "Pick a plugin view in card settings",
 			leafViewMissing:
 				"This view isn't available — enable the plugin that provides it",
+		},
+		pet: {
+			species: {
+				cat: "Cat",
+				dog: "Dog",
+				bird: "Bird",
+				fox: "Fox",
+				frog: "Frog",
+				blob: "Blob",
+			},
+			moodExcited: "Bouncing with joy",
+			moodHappy: "Happy",
+			moodContent: "Content",
+			moodBored: "A little bored",
+			moodSleepy: "Fast asleep",
+			petHint: "Click to pet",
+			todayCount: (count: number, metric: "modified" | "created") =>
+				metric === "created"
+					? `${count} new note${count === 1 ? "" : "s"} today`
+					: `${count} note${count === 1 ? "" : "s"} today`,
+			streak: (days: number) => `${days}-day streak`,
 		},
 		embed: {
 			openFile: "Open this file",
@@ -2162,6 +2210,7 @@ export const en = {
 		weather: "Weather",
 		git: "Git",
 		leaf: "Plugin view (beta)",
+		pet: "Pet",
 	},
 
 	// ---- File-type filter labels ---------------------------------------

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1698,11 +1698,24 @@ export const en = {
 			metricDesc: "Which vault activity the pet's mood follows.",
 			metricModified: "Notes edited",
 			metricCreated: "Notes created",
-			goal: "A good day is",
-			goalDesc:
-				"Notes a day. At this many the pet is happy, at twice it excited. " +
-				"Below it the pet is content, bored or asleep — it is never unwell " +
-				"and never lost.",
+			moods: "Moods",
+			moodsDesc:
+				"Where each mood starts. Nothing here can make the pet unwell or " +
+				"lose it — a quiet vault only sends it to sleep, and any writing " +
+				"wakes it straight back up.",
+			moodsReset: "Back to the default moods",
+			excitedAt: "Bouncing with joy at",
+			excitedAtDesc: "Notes touched today, or more.",
+			happyAt: "Happy at",
+			happyAtDesc: "Notes touched today — your good day.",
+			contentAt: "Content at",
+			contentAtDesc: "Notes touched today. Below this the pet gets bored.",
+			sleepyAfter: "Falls asleep after",
+			sleepyAfterDesc:
+				"Minutes of a quiet vault, on a day with nothing written yet. " +
+				"Until then the pet is only bored.",
+			pettedFor: "A petting lasts",
+			pettedForDesc: "Minutes of guaranteed happiness after you click the pet.",
 			showName: "Show name",
 			showMood: "Show mood",
 			showActivity: "Show today's activity",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1716,6 +1716,20 @@ export const en = {
 				"Until then the pet is only bored.",
 			pettedFor: "A petting lasts",
 			pettedForDesc: "Minutes of guaranteed happiness after you click the pet.",
+			nightSleep: "At night",
+			nightSleepDesc:
+				"What the clock is allowed to do. A quiet small hour is the hour, " +
+				"not neglect — and petting still wakes the pet either way.",
+			nightOff: "Nothing — only the vault matters",
+			nightQuiet: "A bored pet sleeps instead",
+			nightAlways: "Always asleep at night",
+			nightWindow: "Night runs from",
+			nightWindowDesc: "Your local time. The window may cross midnight.",
+			eyesFollow: "Eyes follow the pointer",
+			eyesFollowDesc: "A sleeping pet keeps its eyes shut whatever you set here.",
+			eyesOff: "Never",
+			eyesCard: "On its own card",
+			eyesBoard: "Anywhere on the dashboard",
 			showName: "Show name",
 			showMood: "Show mood",
 			showActivity: "Show today's activity",
@@ -1808,6 +1822,7 @@ export const en = {
 			moodContent: "Content",
 			moodBored: "A little bored",
 			moodSleepy: "Fast asleep",
+			moodNight: "Asleep for the night",
 			petHint: "Click to pet",
 			todayCount: (count: number, metric: "modified" | "created") =>
 				metric === "created"

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1712,16 +1712,18 @@ export const en = {
 			contentAtDesc: "Notes touched today. Below this the pet gets bored.",
 			sleepyAfter: "Falls asleep after",
 			sleepyAfterDesc:
-				"Minutes of a quiet vault, on a day with nothing written yet. " +
-				"Until then the pet is only bored.",
+				"Minutes with nothing touched anywhere in the vault. The pet sleeps " +
+				"whatever its mood, however good the day was, and any activity wakes " +
+				"it again where the day left it.",
 			pettedFor: "A petting lasts",
 			pettedForDesc: "Minutes of guaranteed happiness after you click the pet.",
 			nightSleep: "At night",
 			nightSleepDesc:
-				"What the clock is allowed to do. A quiet small hour is the hour, " +
-				"not neglect — and petting still wakes the pet either way.",
+				"What the clock is allowed to do. A thin small hour is the hour, not " +
+				"neglect — a good day still shows as a good day, and petting wakes " +
+				"the pet whatever you set here.",
 			nightOff: "Nothing — only the vault matters",
-			nightQuiet: "A bored pet sleeps instead",
+			nightQuiet: "A bored or content pet sleeps instead",
 			nightAlways: "Always asleep at night",
 			nightWindow: "Night runs from",
 			nightWindowDesc: "Your local time. The window may cross midnight.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,8 @@ export type CardKind =
 	| "jira"
 	| "weather"
 	| "git"
-	| "leaf";
+	| "leaf"
+	| "pet";
 
 /** A refinement control available on a Jira saved-filter card. */
 export type JiraControl =
@@ -824,6 +825,49 @@ export interface ClockConfig {
 	dateFormat?: string;
 }
 
+/** The animals a "pet" card can keep. Each is one 16×16 pixel sprite recolored
+ * from the card's two colors — no image assets are shipped. */
+export type PetSpecies = "cat" | "dog" | "bird" | "fox" | "frog" | "blob";
+
+/** Per-card configuration for a "pet" card.
+ *
+ * The pet has no hunger, no age and no way to lose it: its mood is derived,
+ * on every render, from how much of the vault you have touched *today* against
+ * `dailyGoal`. A quiet vault makes it bored and then sleepy; a busy one makes
+ * it happy and then excited. Nothing here is a simulation that ticks in the
+ * background — `lastPlayedAt` is the only mutable state, and everything else is
+ * recomputed from vault timestamps, so a week with Obsidian closed, or a
+ * `data.json` synced between devices, cannot put the pet in a wrong state. */
+export interface PetConfig {
+	/** Which animal to draw. Default "cat". */
+	species?: PetSpecies;
+	/** The pet's name, shown under the sprite. Empty means the species name. */
+	name?: string;
+	/** Main body color (hex). The outline, belly and shading are derived from
+	 * it, so two colors define the whole palette. Omitted means the species'
+	 * own default. */
+	bodyColor?: string;
+	/** Accent color (hex) — ears, nose, paws, beak. */
+	accentColor?: string;
+	/** Which vault activity feeds the pet: notes edited (default) or created. */
+	metric?: "modified" | "created";
+	/** How many notes a day count as a good day — the pet is happy at this
+	 * number and excited at twice it. Default 3. */
+	dailyGoal?: number;
+	/** Sprite size. Default "md". */
+	size?: "sm" | "md" | "lg";
+	/** Show the name line (default true). */
+	showName?: boolean;
+	/** Show the mood line (default true). */
+	showMood?: boolean;
+	/** Show the "N notes today · M-day streak" line (default true). */
+	showActivity?: boolean;
+	/** Epoch ms of the last time the pet was petted (clicked). For half an hour
+	 * afterwards the pet is at least happy, whatever the vault is doing. This is
+	 * the card's only mutable state. */
+	lastPlayedAt?: number;
+}
+
 /** A single button in the mobile action bar (shown under the search bar and
  * filters in Mobile mode). Like a launchpad tile, a button can run an Obsidian
  * command, open a vault note/file, or open a URL — chosen by `type`. Hearth's
@@ -949,6 +993,8 @@ export interface DashboardCard {
 	git?: GitConfig;
 	/** kind === "leaf": the registered view type to host. */
 	leafView?: LeafViewConfig;
+	/** kind === "pet": species, colors, name and what feeds its mood. */
+	pet?: PetConfig;
 
 	// ---- Live content ----
 	/** Auto-refresh interval in seconds for live content (embed / web). 0 or

--- a/src/types.ts
+++ b/src/types.ts
@@ -862,6 +862,23 @@ export interface PetConfig {
 	sleepyAfterMin?: number;
 	/** How many minutes a petting keeps the pet happy. Default 30. */
 	pettedForMin?: number;
+
+	/** Whose pointer the pet's eyes follow: nobody, only while the pointer is
+	 * over its own card (default), or anywhere on the dashboard. A sleeping pet
+	 * never looks — its eyes are shut. */
+	eyesFollow?: "off" | "card" | "board";
+
+	/** What the clock does to the pet at night:
+	 * - "off" — nothing, the vault is the only thing that matters;
+	 * - "quiet" (default) — a *bored* pet sleeps instead, so a quiet small hour
+	 *   reads as night rather than as neglect;
+	 * - "always" — the pet sleeps through the window whatever the vault says.
+	 * Petting still wakes it in every mode. */
+	nightSleep?: "off" | "quiet" | "always";
+	/** Hour (0–23, local) the night window opens. Default 23. */
+	nightFrom?: number;
+	/** Hour (0–23, local) the night window closes. Default 7. */
+	nightTo?: number;
 	/** Sprite size. Default "md". */
 	size?: "sm" | "md" | "lg";
 	/** Show the name line (default true). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -857,8 +857,9 @@ export interface PetConfig {
 	excitedAt?: number;
 	/** Notes a day that make the pet content. Default 1 — any activity at all. */
 	contentAt?: number;
-	/** Minutes of a completely quiet vault, on a day with no activity, before
-	 * the pet falls asleep. Until then it is bored. Default 360 (six hours). */
+	/** Minutes with nothing touched anywhere in the vault before the pet falls
+	 * asleep — whatever its mood, however good the day was. Any activity wakes
+	 * it again at the rung the day earned. Default 360 (six hours). */
 	sleepyAfterMin?: number;
 	/** How many minutes a petting keeps the pet happy. Default 30. */
 	pettedForMin?: number;
@@ -870,8 +871,9 @@ export interface PetConfig {
 
 	/** What the clock does to the pet at night:
 	 * - "off" — nothing, the vault is the only thing that matters;
-	 * - "quiet" (default) — a *bored* pet sleeps instead, so a quiet small hour
-	 *   reads as night rather than as neglect;
+	 * - "quiet" (default) — a bored or content pet sleeps instead, so a thin
+	 *   small hour reads as night rather than as neglect (a good day still
+	 *   shows as one);
 	 * - "always" — the pet sleeps through the window whatever the vault says.
 	 * Petting still wakes it in every mode. */
 	nightSleep?: "off" | "quiet" | "always";

--- a/src/types.ts
+++ b/src/types.ts
@@ -851,9 +851,17 @@ export interface PetConfig {
 	accentColor?: string;
 	/** Which vault activity feeds the pet: notes edited (default) or created. */
 	metric?: "modified" | "created";
-	/** How many notes a day count as a good day — the pet is happy at this
-	 * number and excited at twice it. Default 3. */
+	/** Notes a day that make the pet happy — the card's "good day". Default 3. */
 	dailyGoal?: number;
+	/** Notes a day that make the pet excited. Default: twice `dailyGoal`. */
+	excitedAt?: number;
+	/** Notes a day that make the pet content. Default 1 — any activity at all. */
+	contentAt?: number;
+	/** Minutes of a completely quiet vault, on a day with no activity, before
+	 * the pet falls asleep. Until then it is bored. Default 360 (six hours). */
+	sleepyAfterMin?: number;
+	/** How many minutes a petting keeps the pet happy. Default 30. */
+	pettedForMin?: number;
 	/** Sprite size. Default "md". */
 	size?: "sm" | "md" | "lg";
 	/** Show the name line (default true). */

--- a/styles.css
+++ b/styles.css
@@ -7268,3 +7268,197 @@ body.hearth-dv-resizing {
 	font-size: 0.78rem;
 	cursor: pointer;
 }
+
+/* ========================================================================
+ * Pet card
+ *
+ * A 16×16 pixel sprite drawn as an SVG of run-length rects, recolored from
+ * two CSS variables the card sets from its config. Everything that moves is
+ * a CSS animation on the stage — the card itself repaints only on vault
+ * events and a five-minute tick — and every one of them is dropped for a
+ * reader who asked for less motion, or by low power mode (`is-still`).
+ * ===================================================================== */
+
+.hearth-pet {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 2px;
+	height: 100%;
+	min-height: 0;
+	padding: 4px 8px 8px;
+	box-sizing: border-box;
+	text-align: center;
+	--hearth-pet-eye: #23242b;
+	--hearth-pet-shine: #ffffff;
+	--hearth-pet-stage: 92px;
+}
+
+.hearth-pet.is-sm {
+	--hearth-pet-stage: 64px;
+}
+
+.hearth-pet.is-lg {
+	--hearth-pet-stage: 128px;
+}
+
+.hearth-pet-stage {
+	position: relative;
+	flex: 0 1 auto;
+	min-height: 0;
+	width: var(--hearth-pet-stage);
+	max-width: 100%;
+	aspect-ratio: 1;
+	cursor: pointer;
+	/* The sprite is pixel art: keep the pixels square and crisp at any scale. */
+	image-rendering: pixelated;
+	border-radius: 6px;
+}
+
+.hearth-pet-stage:focus-visible {
+	outline: 2px solid var(--interactive-accent);
+	outline-offset: 3px;
+}
+
+.hearth-pet-sprite {
+	width: 100%;
+	height: 100%;
+	display: block;
+	overflow: visible;
+	/* One transform origin for every mood animation: the pet's feet, so it
+	 * squashes and hops off the ground rather than about its middle. */
+	transform-origin: 50% 100%;
+}
+
+.hearth-pet-name {
+	margin-top: 4px;
+	font-weight: 600;
+	font-size: 0.9rem;
+	color: var(--text-normal);
+	line-height: 1.2;
+}
+
+.hearth-pet-mood {
+	font-size: 0.78rem;
+	color: var(--text-muted);
+	line-height: 1.2;
+}
+
+.hearth-pet-activity {
+	font-size: 0.7rem;
+	color: var(--text-faint);
+	line-height: 1.2;
+}
+
+/* ---- Moods ---- */
+
+.hearth-pet-stage.is-excited .hearth-pet-sprite {
+	animation: hearth-pet-hop 0.62s ease-in-out infinite;
+}
+
+.hearth-pet-stage.is-happy .hearth-pet-sprite {
+	animation: hearth-pet-bob 1.5s ease-in-out infinite;
+}
+
+.hearth-pet-stage.is-content .hearth-pet-sprite {
+	animation: hearth-pet-breathe 3.4s ease-in-out infinite;
+}
+
+.hearth-pet-stage.is-bored .hearth-pet-sprite {
+	animation: hearth-pet-sway 5s ease-in-out infinite;
+}
+
+.hearth-pet-stage.is-sleepy .hearth-pet-sprite {
+	animation: hearth-pet-breathe 6s ease-in-out infinite;
+	opacity: 0.85;
+}
+
+@keyframes hearth-pet-hop {
+	0%, 100% { transform: translateY(0) scaleY(1); }
+	25% { transform: translateY(0) scaleY(0.9); }
+	55% { transform: translateY(-12%) scaleY(1.06); }
+	80% { transform: translateY(0) scaleY(0.96); }
+}
+
+@keyframes hearth-pet-bob {
+	0%, 100% { transform: translateY(0); }
+	50% { transform: translateY(-5%); }
+}
+
+@keyframes hearth-pet-breathe {
+	0%, 100% { transform: scaleY(1); }
+	50% { transform: scaleY(1.035); }
+}
+
+@keyframes hearth-pet-sway {
+	0%, 100% { transform: rotate(-1.4deg); }
+	50% { transform: rotate(1.4deg); }
+}
+
+/* ---- Sleeping z's ---- */
+
+.hearth-pet-zzz {
+	position: absolute;
+	top: -2%;
+	right: -4%;
+	pointer-events: none;
+}
+
+.hearth-pet-z::after {
+	content: "z";
+}
+
+.hearth-pet-z {
+	position: absolute;
+	right: 0;
+	font-size: 0.72rem;
+	font-weight: 700;
+	color: var(--text-faint);
+	opacity: 0;
+	animation: hearth-pet-float 3.6s ease-out infinite;
+	animation-delay: calc(var(--i) * 1.2s);
+}
+
+@keyframes hearth-pet-float {
+	0% { transform: translate(0, 0) scale(0.7); opacity: 0; }
+	20% { opacity: 0.9; }
+	100% { transform: translate(10px, -22px) scale(1.15); opacity: 0; }
+}
+
+/* ---- Hearts, on petting ---- */
+
+.hearth-pet-heart {
+	position: absolute;
+	left: 50%;
+	bottom: 28%;
+	font-size: 0.85rem;
+	color: var(--color-red, #e05a6a);
+	pointer-events: none;
+	animation: hearth-pet-heart 0.9s ease-out forwards;
+	animation-delay: calc(var(--i) * 0.09s);
+}
+
+@keyframes hearth-pet-heart {
+	0% { transform: translate(-50%, 0) scale(0.6); opacity: 0; }
+	25% { opacity: 1; }
+	100% { transform: translate(calc(-50% + (var(--i) - 1) * 16px), -34px) scale(1.1); opacity: 0; }
+}
+
+/* Low power mode and a reduced-motion preference both leave a perfectly
+ * readable pet — the mood is in its face, not in the movement. */
+.hearth-pet-stage.is-still .hearth-pet-sprite {
+	animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.hearth-pet-sprite,
+	.hearth-pet-z,
+	.hearth-pet-heart {
+		animation: none !important;
+	}
+
+	.hearth-pet-z {
+		opacity: 0.7;
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -7537,6 +7537,75 @@ body.hearth-dv-resizing {
 	50% { transform: translateY(4%) scaleY(0.98); }
 }
 
+/* ---- Eyes that follow the pointer ----
+ *
+ * The card sets two custom properties from a pointermove; the eyes are their
+ * own group inside every frame, with the face drawn whole underneath, so this
+ * transform is the entire effect — no redraw, and the mood's frame animation
+ * keeps running under it. Inside an SVG a CSS px is one user unit, so the
+ * shift stays under one pixel of the 16×16 grid and crispEdges snaps it,
+ * which is how pixel-art eyes should move. A sleeping pet has none of this:
+ * its eyes are shut, and shut eyes do not wander.
+ */
+.hearth-pet-eyes {
+	transform: translate(var(--hearth-pet-look-x, 0px), var(--hearth-pet-look-y, 0px));
+	transition: transform 0.12s ease-out;
+}
+
+.hearth-pet-stage.is-sleepy .hearth-pet-eyes,
+.hearth-pet-stage.is-still .hearth-pet-eyes {
+	transform: none;
+}
+
+/* ---- Sleeping z's, and the moon of a pet asleep for the night ---- */
+
+.hearth-pet-zzz {
+	position: absolute;
+	top: -2%;
+	right: -4%;
+	pointer-events: none;
+}
+
+.hearth-pet-z::after {
+	content: "z";
+}
+
+.hearth-pet-z {
+	position: absolute;
+	right: 0;
+	font-size: 0.72rem;
+	font-weight: 700;
+	color: var(--text-faint);
+	opacity: 0;
+	animation: hearth-pet-float 3.6s ease-out infinite;
+	animation-delay: calc(var(--i) * 1.2s);
+}
+
+@keyframes hearth-pet-float {
+	0% { transform: translate(0, 0) scale(0.7); opacity: 0; }
+	20% { opacity: 0.9; }
+	100% { transform: translate(10px, -22px) scale(1.15); opacity: 0; }
+}
+
+/* Asleep because of the hour rather than the vault: one moon, hanging still
+ * and breathing with the pet, instead of a stream of z's. */
+.hearth-pet-zzz.is-moon .hearth-pet-z::after {
+	content: "\263D";
+}
+
+.hearth-pet-zzz.is-moon .hearth-pet-z {
+	animation: hearth-pet-moon 6s ease-in-out infinite;
+	animation-delay: 0s;
+	font-size: 0.95rem;
+	font-weight: 400;
+	color: var(--text-muted);
+}
+
+@keyframes hearth-pet-moon {
+	0%, 100% { transform: translateY(0); opacity: 0.5; }
+	50% { transform: translateY(-3px); opacity: 0.9; }
+}
+
 /* ---- Hearts, on petting ---- */
 
 .hearth-pet-heart {
@@ -7581,6 +7650,17 @@ body.hearth-dv-resizing {
 
 	.hearth-pet-frame:not([data-f="0"]) {
 		opacity: 0;
+	}
+
+	/* The pointer tracking is motion too — the eyes hold still. */
+	.hearth-pet-eyes {
+		transform: none !important;
+		transition: none;
+	}
+
+	/* The z's and the moon stop moving but stay legible. */
+	.hearth-pet-z {
+		opacity: 0.7;
 	}
 
 	.hearth-pet-z {

--- a/styles.css
+++ b/styles.css
@@ -7351,79 +7351,190 @@ body.hearth-dv-resizing {
 	line-height: 1.2;
 }
 
-/* ---- Moods ---- */
+/* ---- Moods ----
+ *
+ * Two layers of motion, and they compose:
+ *
+ *  1. FRAMES. The sprite carries every frame of its mood as a stacked <g>,
+ *     and each mood's schedule below fades all but one out. That is drawn
+ *     animation — a blink, a head wagging, a body squashing on the landing,
+ *     a chest rising in its sleep — which is what actually tells the moods
+ *     apart at a glance. Nothing is redrawn to animate: the card paints once
+ *     per vault event and the compositor does the rest.
+ *  2. MOTION. A transform on the whole sprite, anchored at the feet, for what
+ *     a frame swap can't carry: the arc of a hop, a slow sway, a slump.
+ *
+ * The quiet moods are also drained of color and pushed down the card, so a
+ * bored or sleeping pet reads as one across the room, not only by its face.
+ */
+
+.hearth-pet-frame {
+	opacity: 0;
+}
+
+.hearth-pet-frame[data-f="0"] {
+	opacity: 1;
+}
+
+/* An even three-way cycle, shared by the moods that want one. Each frame runs
+ * the same square wave, offset by a third of the cycle with a negative delay. */
+@keyframes hearth-pet-cycle3 {
+	0%, 33.32% { opacity: 1; }
+	33.33%, 100% { opacity: 0; }
+}
+
+.hearth-pet-stage.is-excited .hearth-pet-frame,
+.hearth-pet-stage.is-happy .hearth-pet-frame,
+.hearth-pet-stage.is-sleepy .hearth-pet-frame {
+	animation: hearth-pet-cycle3 var(--hearth-pet-cycle) steps(1, end) infinite;
+}
+
+.hearth-pet-stage.is-excited .hearth-pet-frame[data-f="1"],
+.hearth-pet-stage.is-happy .hearth-pet-frame[data-f="1"],
+.hearth-pet-stage.is-sleepy .hearth-pet-frame[data-f="1"] {
+	animation-delay: calc(var(--hearth-pet-cycle) / -3);
+}
+
+.hearth-pet-stage.is-excited .hearth-pet-frame[data-f="2"],
+.hearth-pet-stage.is-happy .hearth-pet-frame[data-f="2"],
+.hearth-pet-stage.is-sleepy .hearth-pet-frame[data-f="2"] {
+	animation-delay: calc(var(--hearth-pet-cycle) / -1.5);
+}
+
+/* ---- Excited: a fast three-frame hop ---- */
+
+.hearth-pet-stage.is-excited {
+	--hearth-pet-cycle: 0.66s;
+}
 
 .hearth-pet-stage.is-excited .hearth-pet-sprite {
-	animation: hearth-pet-hop 0.62s ease-in-out infinite;
+	animation: hearth-pet-hop 0.66s cubic-bezier(0.3, 0, 0.4, 1) infinite;
+}
+
+@keyframes hearth-pet-hop {
+	0% { transform: translateY(0) rotate(0deg); }
+	18% { transform: translateY(2%) rotate(-3deg); }
+	42% { transform: translateY(-16%) rotate(3deg); }
+	62% { transform: translateY(-19%) rotate(-2deg); }
+	85% { transform: translateY(1%) rotate(1deg); }
+	100% { transform: translateY(0) rotate(0deg); }
+}
+
+/* ---- Happy: a head wag over a bob ---- */
+
+.hearth-pet-stage.is-happy {
+	--hearth-pet-cycle: 1.1s;
 }
 
 .hearth-pet-stage.is-happy .hearth-pet-sprite {
-	animation: hearth-pet-bob 1.5s ease-in-out infinite;
+	animation: hearth-pet-bob 1.1s ease-in-out infinite;
 }
+
+@keyframes hearth-pet-bob {
+	0%, 100% { transform: translateY(0) rotate(-1.5deg); }
+	25% { transform: translateY(-6%) rotate(0deg); }
+	50% { transform: translateY(0) rotate(1.5deg); }
+	75% { transform: translateY(-6%) rotate(0deg); }
+}
+
+/* ---- Content: mostly still, with a blink and a glance ---- */
 
 .hearth-pet-stage.is-content .hearth-pet-sprite {
 	animation: hearth-pet-breathe 3.4s ease-in-out infinite;
 }
 
-.hearth-pet-stage.is-bored .hearth-pet-sprite {
-	animation: hearth-pet-sway 5s ease-in-out infinite;
+/* Hand-scheduled rather than an even cycle: a blink that lasted a third of
+ * the time would be a pet falling asleep on and off. */
+.hearth-pet-stage.is-content .hearth-pet-frame[data-f="0"] {
+	animation: hearth-pet-content-0 5.4s steps(1, end) infinite;
 }
 
-.hearth-pet-stage.is-sleepy .hearth-pet-sprite {
-	animation: hearth-pet-breathe 6s ease-in-out infinite;
-	opacity: 0.85;
+.hearth-pet-stage.is-content .hearth-pet-frame[data-f="1"] {
+	animation: hearth-pet-content-1 5.4s steps(1, end) infinite;
 }
 
-@keyframes hearth-pet-hop {
-	0%, 100% { transform: translateY(0) scaleY(1); }
-	25% { transform: translateY(0) scaleY(0.9); }
-	55% { transform: translateY(-12%) scaleY(1.06); }
-	80% { transform: translateY(0) scaleY(0.96); }
+.hearth-pet-stage.is-content .hearth-pet-frame[data-f="2"] {
+	animation: hearth-pet-content-2 5.4s steps(1, end) infinite;
 }
 
-@keyframes hearth-pet-bob {
-	0%, 100% { transform: translateY(0); }
-	50% { transform: translateY(-5%); }
+@keyframes hearth-pet-content-0 {
+	0%, 57% { opacity: 1; }
+	58%, 100% { opacity: 0; }
+}
+
+@keyframes hearth-pet-content-1 {
+	0%, 57% { opacity: 0; }
+	58%, 62% { opacity: 1; }
+	63%, 100% { opacity: 0; }
+}
+
+@keyframes hearth-pet-content-2 {
+	0%, 62% { opacity: 0; }
+	63%, 100% { opacity: 1; }
 }
 
 @keyframes hearth-pet-breathe {
 	0%, 100% { transform: scaleY(1); }
-	50% { transform: scaleY(1.035); }
+	50% { transform: scaleY(1.04); }
 }
 
-@keyframes hearth-pet-sway {
-	0%, 100% { transform: rotate(-1.4deg); }
-	50% { transform: rotate(1.4deg); }
+/* ---- Bored: slouched, draining color, with a long slow blink ---- */
+
+.hearth-pet-stage.is-bored .hearth-pet-sprite {
+	animation: hearth-pet-slouch 4.6s ease-in-out infinite;
+	filter: saturate(0.72);
 }
 
-/* ---- Sleeping z's ---- */
-
-.hearth-pet-zzz {
-	position: absolute;
-	top: -2%;
-	right: -4%;
-	pointer-events: none;
+.hearth-pet-stage.is-bored .hearth-pet-frame[data-f="0"] {
+	animation: hearth-pet-bored-0 7.2s steps(1, end) infinite;
 }
 
-.hearth-pet-z::after {
-	content: "z";
+.hearth-pet-stage.is-bored .hearth-pet-frame[data-f="1"] {
+	animation: hearth-pet-bored-1 7.2s steps(1, end) infinite;
 }
 
-.hearth-pet-z {
-	position: absolute;
-	right: 0;
-	font-size: 0.72rem;
-	font-weight: 700;
-	color: var(--text-faint);
-	opacity: 0;
-	animation: hearth-pet-float 3.6s ease-out infinite;
-	animation-delay: calc(var(--i) * 1.2s);
+.hearth-pet-stage.is-bored .hearth-pet-frame[data-f="2"] {
+	animation: hearth-pet-bored-2 7.2s steps(1, end) infinite;
 }
 
-@keyframes hearth-pet-float {
-	0% { transform: translate(0, 0) scale(0.7); opacity: 0; }
-	20% { opacity: 0.9; }
-	100% { transform: translate(10px, -22px) scale(1.15); opacity: 0; }
+@keyframes hearth-pet-bored-0 {
+	0%, 44% { opacity: 1; }
+	45%, 100% { opacity: 0; }
+}
+
+/* The heavy blink: a full second of shut eyes, the kind boredom actually
+ * looks like. */
+@keyframes hearth-pet-bored-1 {
+	0%, 44% { opacity: 0; }
+	45%, 58% { opacity: 1; }
+	59%, 100% { opacity: 0; }
+}
+
+@keyframes hearth-pet-bored-2 {
+	0%, 58% { opacity: 0; }
+	59%, 100% { opacity: 1; }
+}
+
+@keyframes hearth-pet-slouch {
+	0%, 100% { transform: rotate(-2.5deg) translateY(2%); }
+	50% { transform: rotate(2.5deg) translateY(3%); }
+}
+
+/* ---- Sleepy: curled down, colorless, breathing slowly ---- */
+
+.hearth-pet-stage.is-sleepy {
+	--hearth-pet-cycle: 5.4s;
+}
+
+.hearth-pet-stage.is-sleepy .hearth-pet-sprite {
+	animation: hearth-pet-sleep 5.4s ease-in-out infinite;
+	filter: saturate(0.4) brightness(0.88);
+	opacity: 0.9;
+}
+
+@keyframes hearth-pet-sleep {
+	0%, 100% { transform: translateY(4%) scaleY(1); }
+	50% { transform: translateY(4%) scaleY(0.98); }
 }
 
 /* ---- Hearts, on petting ---- */
@@ -7447,15 +7558,29 @@ body.hearth-dv-resizing {
 
 /* Low power mode and a reduced-motion preference both leave a perfectly
  * readable pet — the mood is in its face, not in the movement. */
-.hearth-pet-stage.is-still .hearth-pet-sprite {
+.hearth-pet-stage.is-still .hearth-pet-sprite,
+.hearth-pet-stage.is-still .hearth-pet-frame {
 	animation: none;
+	opacity: 1;
 }
 
+/* A reader who asked for less motion keeps the pet, its posture and its
+ * colors — only the movement and the frame cycling stop, on the frame the
+ * mood leads with. */
 @media (prefers-reduced-motion: reduce) {
 	.hearth-pet-sprite,
+	.hearth-pet-frame,
 	.hearth-pet-z,
 	.hearth-pet-heart {
 		animation: none !important;
+	}
+
+	.hearth-pet-frame[data-f="0"] {
+		opacity: 1;
+	}
+
+	.hearth-pet-frame:not([data-f="0"]) {
+		opacity: 0;
 	}
 
 	.hearth-pet-z {

--- a/test/cards-registry.test.ts
+++ b/test/cards-registry.test.ts
@@ -86,6 +86,7 @@ describe("CARD_TEMPLATES (add-card menu)", () => {
 				build: { kind: "git", title: "Git", git: {}, w: 4, h: 4 },
 			},
 			{ id: "leaf", icon: "layout-panel-left", gated: true, build: { kind: "leaf", title: "Plugin view", leafView: {}, w: 5, h: 4 } },
+			{ id: "pet", icon: "cat", gated: false, build: { kind: "pet", title: "Pet", pet: {}, w: 3, h: 4 } },
 		]);
 	});
 
@@ -144,6 +145,7 @@ function maximalCard(): DashboardCard {
 		} as never,
 		weather: { place: { name: "Prague", lat: 50.08, lon: 14.44 } },
 		git: { sections: ["status", "actions"], actions: ["commit", "push"] },
+		pet: { species: "fox", name: "Vulpes" },
 	};
 }
 
@@ -180,6 +182,7 @@ describe("cloneCard deep-clone independence", () => {
 		copy.weather!.place!.name = "Brno";
 		copy.git!.sections!.push("log");
 		copy.git!.actions!.push("pull");
+		copy.pet!.name = "Renard";
 
 		// ...and confirm none of it reached the original.
 		const pristine = maximalCard();
@@ -199,6 +202,7 @@ describe("cloneCard deep-clone independence", () => {
 		expect(orig.jira).toEqual(pristine.jira);
 		expect(orig.weather).toEqual(pristine.weather);
 		expect(orig.git).toEqual(pristine.git);
+		expect(orig.pet).toEqual(pristine.pet);
 	});
 });
 
@@ -235,6 +239,7 @@ describe("liveness classification", () => {
 			weather: "static",
 			git: "static",
 			leaf: "static",
+			pet: "vault",
 		});
 	});
 });

--- a/test/pet.test.ts
+++ b/test/pet.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+	PET_DEFAULT_GOAL,
+	PET_PETTED_MS,
+	PET_SLEEPY_AFTER_MS,
+	PET_SPECIES,
+	PET_SPRITE_SIZE,
+	activityStreak,
+	defaultColors,
+	moodFor,
+	paletteFor,
+	parseHex,
+	shadeHex,
+	spriteFor,
+	spriteRuns,
+	type PetMood,
+} from "../src/cards/pet";
+
+const HOUR = 60 * 60 * 1000;
+
+/** The mood inputs for a vault with `today` notes touched and a freshest note
+ * `sinceLastMs` old, never petted. */
+function pulse(today: number, sinceLastMs: number | null = 0, pettedMsAgo: number | null = null) {
+	return { today, goal: PET_DEFAULT_GOAL, sinceLastMs, pettedMsAgo };
+}
+
+describe("moodFor", () => {
+	it("climbs the ladder with today's activity", () => {
+		expect(moodFor(pulse(0, 10 * HOUR))).toBe("sleepy");
+		expect(moodFor(pulse(0, 1 * HOUR))).toBe("bored");
+		expect(moodFor(pulse(1))).toBe("content");
+		expect(moodFor(pulse(PET_DEFAULT_GOAL))).toBe("happy");
+		expect(moodFor(pulse(PET_DEFAULT_GOAL * 2))).toBe("excited");
+		expect(moodFor(pulse(500))).toBe("excited");
+	});
+
+	it("only ever falls to bored, then asleep — the ladder has no bad rung", () => {
+		// The whole point of the card: whatever the vault (or the clock) does,
+		// the worst state is a sleeping pet, and any activity wakes it.
+		const moods = new Set<PetMood>();
+		for (const today of [0, 1, 2, 3, 6, 99]) {
+			for (const since of [0, HOUR, 24 * HOUR, 365 * 24 * HOUR, null]) {
+				moods.add(moodFor(pulse(today, since)));
+			}
+		}
+		expect([...moods].sort()).toEqual(["bored", "content", "excited", "happy", "sleepy"]);
+	});
+
+	it("dozes off once the freshest note is old, and never before", () => {
+		expect(moodFor(pulse(0, PET_SLEEPY_AFTER_MS - 1))).toBe("bored");
+		expect(moodFor(pulse(0, PET_SLEEPY_AFTER_MS))).toBe("sleepy");
+		// An empty vault has no timestamp to go on.
+		expect(moodFor(pulse(0, null))).toBe("sleepy");
+	});
+
+	it("lets a petting lift the mood but never lower it", () => {
+		expect(moodFor(pulse(0, 100 * HOUR, 0))).toBe("happy");
+		expect(moodFor(pulse(1, 0, PET_PETTED_MS - 1))).toBe("happy");
+		// Worn off.
+		expect(moodFor(pulse(1, 0, PET_PETTED_MS))).toBe("content");
+		// Already excited: petting must not knock it down to happy.
+		expect(moodFor(pulse(PET_DEFAULT_GOAL * 2, 0, 0))).toBe("excited");
+		// A clock that jumped backwards leaves a negative age — not a petting.
+		expect(moodFor(pulse(1, 0, -5000))).toBe("content");
+	});
+
+	it("falls back to the default goal when the card's is nonsense", () => {
+		expect(moodFor({ today: 3, goal: 0, sinceLastMs: 0, pettedMsAgo: null })).toBe("happy");
+		expect(moodFor({ today: 3, goal: -4, sinceLastMs: 0, pettedMsAgo: null })).toBe("happy");
+	});
+});
+
+describe("activityStreak", () => {
+	const day = (key: string, count = 1): [string, number] => [key, count];
+
+	it("counts consecutive days back from today", () => {
+		const counts = new Map([day("2026-06-10"), day("2026-06-09"), day("2026-06-08")]);
+		expect(activityStreak(counts, new Date(2026, 5, 10))).toBe(3);
+	});
+
+	it("does not break the streak on a day that has only just started", () => {
+		// Nothing written yet this morning: yesterday's streak still stands.
+		const counts = new Map([day("2026-06-09"), day("2026-06-08")]);
+		expect(activityStreak(counts, new Date(2026, 5, 10))).toBe(2);
+	});
+
+	it("is zero once a whole day passes unwritten", () => {
+		const counts = new Map([day("2026-06-08")]);
+		expect(activityStreak(counts, new Date(2026, 5, 10))).toBe(0);
+	});
+
+	it("stops at a gap and spans month and year boundaries", () => {
+		const counts = new Map([day("2026-01-01"), day("2025-12-31"), day("2025-12-30"), day("2025-12-28")]);
+		expect(activityStreak(counts, new Date(2026, 0, 1))).toBe(3);
+	});
+
+	it("has no streak in an empty vault", () => {
+		expect(activityStreak(new Map(), new Date(2026, 5, 10))).toBe(0);
+	});
+});
+
+describe("colors", () => {
+	it("parses both hex forms and rejects anything else", () => {
+		expect(parseHex("#fff")).toEqual([255, 255, 255]);
+		expect(parseHex("#1a2b3c")).toEqual([26, 43, 60]);
+		expect(parseHex("1a2b3c")).toEqual([26, 43, 60]);
+		expect(parseHex("rebeccapurple")).toBeNull();
+		expect(parseHex("#12345")).toBeNull();
+		expect(parseHex("")).toBeNull();
+	});
+
+	it("derives darker and lighter shades, and leaves junk alone", () => {
+		expect(shadeHex("#808080", -1)).toBe("#000000");
+		expect(shadeHex("#808080", 1)).toBe("#ffffff");
+		expect(shadeHex("#808080", 0)).toBe("#808080");
+		expect(shadeHex("not a color", -0.5)).toBe("not a color");
+	});
+
+	it("falls back to the species palette when a color is missing or invalid", () => {
+		const fox = defaultColors("fox");
+		expect(paletteFor({ species: "fox" }).body).toBe(fox.body);
+		expect(paletteFor({ species: "fox", bodyColor: "chartreuse" }).body).toBe(fox.body);
+		expect(paletteFor({ species: "fox", bodyColor: "#123456" }).body).toBe("#123456");
+		// The outline is always darker than the body, the belly always lighter.
+		const p = paletteFor({ species: "cat", bodyColor: "#808080" });
+		expect(parseHex(p.outline)![0]).toBeLessThan(0x80);
+		expect(parseHex(p.light)![0]).toBeGreaterThan(0x80);
+	});
+});
+
+describe("sprites", () => {
+	const MOODS: PetMood[] = ["sleepy", "bored", "content", "happy", "excited"];
+
+	it("is a square grid of known palette characters for every species and mood", () => {
+		for (const species of PET_SPECIES) {
+			for (const mood of MOODS) {
+				const rows = spriteFor(species, mood);
+				expect(rows).toHaveLength(PET_SPRITE_SIZE);
+				for (const row of rows) {
+					expect(row).toHaveLength(PET_SPRITE_SIZE);
+					expect(row).toMatch(/^[.oblaew]+$/);
+				}
+			}
+		}
+	});
+
+	it("gives every pet a face — two eyes, drawn differently per mood", () => {
+		for (const species of PET_SPECIES) {
+			const drawn = MOODS.map((mood) => spriteFor(species, mood).join("\n"));
+			for (const sprite of drawn) expect(sprite.match(/e/g)!.length).toBeGreaterThanOrEqual(4);
+			// No two moods look alike, so the card actually reads as a mood.
+			expect(new Set(drawn).size).toBe(MOODS.length);
+		}
+	});
+
+	it("collapses rows into runs that reproduce the sprite exactly", () => {
+		for (const species of PET_SPECIES) {
+			const rows = spriteFor(species, "content");
+			const rebuilt: string[][] = rows.map(() => new Array<string>(PET_SPRITE_SIZE).fill("."));
+			for (const run of spriteRuns(rows)) {
+				expect(run.len).toBeGreaterThan(0);
+				for (let i = 0; i < run.len; i++) rebuilt[run.row][run.col + i] = run.ch;
+			}
+			expect(rebuilt.map((r) => r.join(""))).toEqual(rows);
+		}
+	});
+
+	it("draws far fewer runs than pixels", () => {
+		const runs = spriteRuns(spriteFor("cat", "content"));
+		expect(runs.length).toBeLessThan(PET_SPRITE_SIZE * PET_SPRITE_SIZE * 0.4);
+	});
+});

--- a/test/pet.test.ts
+++ b/test/pet.test.ts
@@ -51,11 +51,32 @@ describe("moodFor", () => {
 		expect([...moods].sort()).toEqual(["bored", "content", "excited", "happy", "sleepy"]);
 	});
 
-	it("dozes off once the freshest note is old, and never before", () => {
+	it("dozes off once the vault goes quiet, and never before", () => {
 		expect(moodFor(pulse(0, PET_SLEEPY_AFTER_MS - 1))).toBe("bored");
 		expect(moodFor(pulse(0, PET_SLEEPY_AFTER_MS))).toBe("sleepy");
 		// An empty vault has no timestamp to go on.
 		expect(moodFor(pulse(0, null))).toBe("sleepy");
+	});
+
+	it("sleeps on an idle vault whatever the day was, and wakes on activity", () => {
+		// Idleness outranks the day: twenty notes this morning and nothing since
+		// is a sleeping pet by evening...
+		expect(moodFor(pulse(PET_DEFAULT_GOAL * 10, PET_SLEEPY_AFTER_MS))).toBe("sleepy");
+		expect(moodFor(pulse(PET_DEFAULT_GOAL, PET_SLEEPY_AFTER_MS + HOUR))).toBe("sleepy");
+		expect(moodFor(pulse(1, PET_SLEEPY_AFTER_MS))).toBe("sleepy");
+		// ...and one touch of the vault brings it back to the rung its day earned.
+		expect(moodFor(pulse(PET_DEFAULT_GOAL * 10, 0))).toBe("excited");
+		expect(moodFor(pulse(PET_DEFAULT_GOAL, 0))).toBe("happy");
+		expect(moodFor(pulse(1, 0))).toBe("content");
+		expect(moodFor(pulse(0, 0))).toBe("bored");
+	});
+
+	it("uses the card's own idle time for every mood", () => {
+		const brief = thresholdsFor({ sleepyAfterMin: 30 });
+		const at = (today: number, sinceLastMs: number) =>
+			moodFor({ today, thresholds: brief, sinceLastMs, pettedMsAgo: null });
+		expect(at(99, 29 * 60 * 1000)).toBe("excited");
+		expect(at(99, 31 * 60 * 1000)).toBe("sleepy");
 	});
 
 	it("lets a petting lift the mood but never lower it", () => {
@@ -121,7 +142,7 @@ describe("night", () => {
 		expect(inNightWindow(at(15), { nightFrom: 99, nightTo: -4 })).toBe(false);
 	});
 
-	it("only reaches a bored pet in quiet mode", () => {
+	it("reaches a bored or content pet in quiet mode, and leaves a good day alone", () => {
 		const night = (mode: "off" | "quiet" | "always", today: number, sinceLastMs = 0) =>
 			moodFor({
 				today,
@@ -130,8 +151,9 @@ describe("night", () => {
 				pettedMsAgo: null,
 				night: { mode, now: true },
 			});
-		// Bored by day, asleep at night — the hour, not neglect.
+		// Bored or merely content by day, asleep at night — the hour, not neglect.
 		expect(night("quiet", 0, HOUR)).toBe("sleepy");
+		expect(night("quiet", 1, HOUR)).toBe("sleepy");
 		// A day that went well is still a day that went well.
 		expect(night("quiet", PET_DEFAULT_GOAL)).toBe("happy");
 		expect(night("quiet", PET_DEFAULT_GOAL * 2)).toBe("excited");

--- a/test/pet.test.ts
+++ b/test/pet.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	PET_DEFAULT_GOAL,
+	PET_DEFAULT_NIGHT,
 	PET_FRAME_COUNT,
 	PET_PETTED_MS,
 	PET_SLEEPY_AFTER_MS,
@@ -8,6 +9,7 @@ import {
 	PET_SPRITE_SIZE,
 	activityStreak,
 	defaultColors,
+	inNightWindow,
 	moodFor,
 	paletteFor,
 	parseHex,
@@ -86,6 +88,72 @@ describe("moodFor", () => {
 			moodFor({ today: 0, thresholds: clingy, sinceLastMs: 0, pettedMsAgo: ms });
 		expect(after(119 * 60 * 1000)).toBe("happy");
 		expect(after(121 * 60 * 1000)).toBe("bored");
+	});
+});
+
+describe("night", () => {
+	const at = (hour: number) => new Date(2026, 5, 10, hour, 30);
+
+	it("wraps midnight on the default window", () => {
+		const [from, to] = PET_DEFAULT_NIGHT;
+		expect(from).toBe(23);
+		expect(to).toBe(7);
+		expect(inNightWindow(at(23), {})).toBe(true);
+		expect(inNightWindow(at(2), {})).toBe(true);
+		expect(inNightWindow(at(6), {})).toBe(true);
+		expect(inNightWindow(at(7), {})).toBe(false);
+		expect(inNightWindow(at(15), {})).toBe(false);
+		expect(inNightWindow(at(22), {})).toBe(false);
+	});
+
+	it("handles a window that does not wrap", () => {
+		const siesta = { nightFrom: 13, nightTo: 15 };
+		expect(inNightWindow(at(13), siesta)).toBe(true);
+		expect(inNightWindow(at(14), siesta)).toBe(true);
+		expect(inNightWindow(at(15), siesta)).toBe(false);
+		expect(inNightWindow(at(3), siesta)).toBe(false);
+	});
+
+	it("treats an empty or nonsense window as no window", () => {
+		expect(inNightWindow(at(9), { nightFrom: 9, nightTo: 9 })).toBe(false);
+		// Out-of-range hours fall back to the defaults rather than never matching.
+		expect(inNightWindow(at(2), { nightFrom: 99, nightTo: -4 })).toBe(true);
+		expect(inNightWindow(at(15), { nightFrom: 99, nightTo: -4 })).toBe(false);
+	});
+
+	it("only reaches a bored pet in quiet mode", () => {
+		const night = (mode: "off" | "quiet" | "always", today: number, sinceLastMs = 0) =>
+			moodFor({
+				today,
+				thresholds: thresholdsFor({}),
+				sinceLastMs,
+				pettedMsAgo: null,
+				night: { mode, now: true },
+			});
+		// Bored by day, asleep at night — the hour, not neglect.
+		expect(night("quiet", 0, HOUR)).toBe("sleepy");
+		// A day that went well is still a day that went well.
+		expect(night("quiet", PET_DEFAULT_GOAL)).toBe("happy");
+		expect(night("quiet", PET_DEFAULT_GOAL * 2)).toBe("excited");
+		// "always" puts it to bed regardless.
+		expect(night("always", PET_DEFAULT_GOAL * 2)).toBe("sleepy");
+		// "off" leaves the clock out of it entirely.
+		expect(night("off", 0, HOUR)).toBe("bored");
+	});
+
+	it("still wakes for a petting, in every night mode", () => {
+		// The pet must never be unwakeable — including at 3am on "always".
+		for (const mode of ["off", "quiet", "always"] as const) {
+			expect(
+				moodFor({
+					today: 0,
+					thresholds: thresholdsFor({}),
+					sinceLastMs: 100 * HOUR,
+					pettedMsAgo: 0,
+					night: { mode, now: true },
+				}),
+			).toBe("happy");
+		}
 	});
 });
 

--- a/test/pet.test.ts
+++ b/test/pet.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	PET_DEFAULT_GOAL,
+	PET_FRAME_COUNT,
 	PET_PETTED_MS,
 	PET_SLEEPY_AFTER_MS,
 	PET_SPECIES,
@@ -12,16 +13,18 @@ import {
 	parseHex,
 	shadeHex,
 	spriteFor,
+	spriteFrames,
 	spriteRuns,
+	thresholdsFor,
 	type PetMood,
 } from "../src/cards/pet";
 
 const HOUR = 60 * 60 * 1000;
 
 /** The mood inputs for a vault with `today` notes touched and a freshest note
- * `sinceLastMs` old, never petted. */
+ * `sinceLastMs` old, on a card left at its default thresholds. */
 function pulse(today: number, sinceLastMs: number | null = 0, pettedMsAgo: number | null = null) {
-	return { today, goal: PET_DEFAULT_GOAL, sinceLastMs, pettedMsAgo };
+	return { today, thresholds: thresholdsFor({}), sinceLastMs, pettedMsAgo };
 }
 
 describe("moodFor", () => {
@@ -64,9 +67,55 @@ describe("moodFor", () => {
 		expect(moodFor(pulse(1, 0, -5000))).toBe("content");
 	});
 
-	it("falls back to the default goal when the card's is nonsense", () => {
-		expect(moodFor({ today: 3, goal: 0, sinceLastMs: 0, pettedMsAgo: null })).toBe("happy");
-		expect(moodFor({ today: 3, goal: -4, sinceLastMs: 0, pettedMsAgo: null })).toBe("happy");
+	it("honours thresholds the card sets", () => {
+		const strict = thresholdsFor({ contentAt: 5, dailyGoal: 10, excitedAt: 20, sleepyAfterMin: 60 });
+		const at = (today: number, sinceLastMs: number | null = 0) =>
+			moodFor({ today, thresholds: strict, sinceLastMs, pettedMsAgo: null });
+		expect(at(4, 30 * 60 * 1000)).toBe("bored");
+		expect(at(5)).toBe("content");
+		expect(at(10)).toBe("happy");
+		expect(at(20)).toBe("excited");
+		// The card's own quiet time, not the default six hours.
+		expect(at(0, 59 * 60 * 1000)).toBe("bored");
+		expect(at(0, 61 * 60 * 1000)).toBe("sleepy");
+	});
+
+	it("keeps a petting for as long as the card says", () => {
+		const clingy = thresholdsFor({ pettedForMin: 120 });
+		const after = (ms: number) =>
+			moodFor({ today: 0, thresholds: clingy, sinceLastMs: 0, pettedMsAgo: ms });
+		expect(after(119 * 60 * 1000)).toBe("happy");
+		expect(after(121 * 60 * 1000)).toBe("bored");
+	});
+});
+
+describe("thresholdsFor", () => {
+	it("fills in the defaults, including excited at twice the good day", () => {
+		expect(thresholdsFor({})).toEqual({
+			content: 1,
+			happy: PET_DEFAULT_GOAL,
+			excited: PET_DEFAULT_GOAL * 2,
+			sleepyAfterMs: PET_SLEEPY_AFTER_MS,
+			pettedMs: PET_PETTED_MS,
+		});
+		expect(thresholdsFor({ dailyGoal: 10 }).excited).toBe(20);
+	});
+
+	it("forces the rungs into a climbing order, however they were set", () => {
+		// Sliders dragged into nonsense (or a hand-edited data.json) must not
+		// leave a mood the pet can never reach.
+		const upside = thresholdsFor({ contentAt: 12, dailyGoal: 5, excitedAt: 2 });
+		expect(upside.content).toBeLessThanOrEqual(upside.happy);
+		expect(upside.excited).toBeGreaterThanOrEqual(upside.happy);
+	});
+
+	it("ignores zero, negative and fractional values", () => {
+		const odd = thresholdsFor({ dailyGoal: 0, contentAt: -3, sleepyAfterMin: 0, pettedForMin: -1 });
+		expect(odd.happy).toBe(PET_DEFAULT_GOAL);
+		expect(odd.content).toBe(1);
+		expect(odd.sleepyAfterMs).toBe(PET_SLEEPY_AFTER_MS);
+		expect(odd.pettedMs).toBe(PET_PETTED_MS);
+		expect(thresholdsFor({ dailyGoal: 4.7 }).happy).toBe(4);
 	});
 });
 
@@ -131,16 +180,55 @@ describe("colors", () => {
 describe("sprites", () => {
 	const MOODS: PetMood[] = ["sleepy", "bored", "content", "happy", "excited"];
 
-	it("is a square grid of known palette characters for every species and mood", () => {
+	it("is a square grid of known palette characters in every frame, species and mood", () => {
 		for (const species of PET_SPECIES) {
 			for (const mood of MOODS) {
-				const rows = spriteFor(species, mood);
-				expect(rows).toHaveLength(PET_SPRITE_SIZE);
-				for (const row of rows) {
-					expect(row).toHaveLength(PET_SPRITE_SIZE);
-					expect(row).toMatch(/^[.oblaew]+$/);
+				const frames = spriteFrames(species, mood);
+				expect(frames).toHaveLength(PET_FRAME_COUNT);
+				expect(frames[0]).toEqual(spriteFor(species, mood));
+				for (const rows of frames) {
+					expect(rows).toHaveLength(PET_SPRITE_SIZE);
+					for (const row of rows) {
+						expect(row).toHaveLength(PET_SPRITE_SIZE);
+						expect(row).toMatch(/^[.oblaew]+$/);
+					}
 				}
 			}
+		}
+	});
+
+	it("animates: every mood's frames actually differ from one another", () => {
+		for (const species of PET_SPECIES) {
+			for (const mood of MOODS) {
+				const frames = spriteFrames(species, mood).map((rows) => rows.join("\n"));
+				expect(new Set(frames).size).toBe(PET_FRAME_COUNT);
+			}
+		}
+	});
+
+	it("keeps the pet standing on the floor in every frame", () => {
+		// The moods move the head, squash the body and slump the whole pet; the
+		// feet must stay put, or the pet slides around its box as it animates.
+		for (const species of PET_SPECIES) {
+			const floor = spriteFor(species, "content")[PET_SPRITE_SIZE - 1];
+			for (const mood of MOODS) {
+				for (const frame of spriteFrames(species, mood)) {
+					expect(frame[PET_SPRITE_SIZE - 1]).toBe(floor);
+				}
+			}
+		}
+	});
+
+	it("draws the low moods slumped, not merely with a different face", () => {
+		// The complaint the posture answers: a bored or sleeping pet has to be
+		// tellable from a content one across the room, so its head sits lower.
+		const headTop = (rows: string[]) => rows.findIndex((row) => /[^.]/.test(row));
+		for (const species of PET_SPECIES) {
+			const upright = headTop(spriteFor(species, "content"));
+			expect(headTop(spriteFor(species, "bored"))).toBeGreaterThan(upright);
+			expect(headTop(spriteFor(species, "sleepy"))).toBeGreaterThan(
+				headTop(spriteFor(species, "bored")),
+			);
 		}
 	});
 


### PR DESCRIPTION
## What does this PR do?

Adds a new card kind: a **Pet** — a 16×16 pixel-art companion (cat, dog, bird, fox, frog or blob) whose mood follows how much of the vault you have touched today.

**The mood ladder is deliberately one-way.** At the daily goal the pet is happy, at twice it excited, at anything above zero content; a quiet day leaves it a little bored and then asleep with drifting z's. That is the whole ladder — no hunger, no age, no illness, no way to lose it. Two weeks away from the vault costs a nap and nothing else. Clicking the pet pets it: a burst of hearts, and half an hour floored at happy.

**Nothing is simulated on a timer.** Every mood is derived on render from file timestamps — `lastPlayedAt` is the card's only mutable state — so a synced `data.json`, a closed laptop, or a device not opened in a month can never leave the pet out of step. The card redraws on vault events (`liveness: "vault"`) plus a five-minute tick that only covers the passage of time (bored → sleepy, a petting wearing off).

**No image assets.** Each sprite is one shared body plus a per-species head held as character grids, painted with a per-mood face and emitted as a run-length-encoded SVG of a few dozen `<rect>`s. The editor takes two colors and derives the rest — outline, shading and belly all come from the body color, so any palette hangs together.

Editor options: animal, name, body/accent color (with a reset to the species' own), size, whether it feeds on notes *edited* or *created*, what counts as a good day (1–20), and which of the name / mood / activity lines to show.

Movement is CSS only, and both low power mode and `prefers-reduced-motion` leave a still, perfectly readable pet — the mood is in its face, not in the motion.

Follows the registry contract in `src/cards/README.md`: new kind in `CardKind` + `PetConfig`, module in `src/cards/pet.ts`, registration and menu order in `src/cards/index.ts`, locale strings in `src/locales/en.ts`.

## Related issue

None — proposed and agreed in conversation before implementing.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (typecheck, lint 0 errors, 532 tests)
- [x] I've tested this in an actual vault

New unit tests in `test/pet.test.ts` cover the mood ladder (including that it can never produce anything below "sleepy", that a petting only ever lifts a mood, and that a backwards clock isn't read as a petting), the streak counter across month/year boundaries, the color derivation, and the sprites — every species/mood grid is 16×16 of legal palette characters, no two moods of a species look alike, and the run-length encoding round-trips exactly.

The registry characterization test is updated with the new template and liveness entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_014kx29FX3sfDevLCSkbNyBy)_