### PR TITLE
chore: cut 2.0.0-beta.2

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "2.0.0-beta.1",
+	"version": "2.0.0-beta.2",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
Cuts `2.0.0-beta.2` from current `main`.

- `manifest-beta.json` → `2.0.0-beta.2` (version-only bump)
- `manifest.json` untouched — stable stays `1.18.0`
- `CHANGELOG.md` untouched — the top `## [2.0.0]` section already describes everything in this snapshot (low power mode, Integrations tab, settings redesign, body-search fixes, Datacore card, Weather card, weather sky background, Git card, Pet card)

The release itself was cut via `workflow_dispatch` on `release.yml` (tag pushes are blocked from this environment), published as a pre-release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gurvz8Qe51SXH1B3m88YJY)_