### PR TITLE
fix(whatsnew): reflow and restructure the changelog dialog

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,0 +1,164 @@
+/**
+ * Pure text handling for `CHANGELOG.md`: splitting it into per-release entries
+ * and preparing each body for Markdown rendering. No Obsidian API, no DOM —
+ * see `whatsnew.ts` for the dialog that displays the result.
+ */
+
+/** One release section parsed out of `CHANGELOG.md`. */
+export interface ChangelogEntry {
+	/** The release number, e.g. `2.0.0`. */
+	version: string;
+	/** The release date as written in the heading, if it carries one. */
+	date: string;
+	/** The compare/release URL from the file's link-reference block, if any. */
+	url: string;
+	/** The section body — everything under the heading, reflowed for display. */
+	markdown: string;
+}
+
+/**
+ * A release heading: `## [1.8.0] - 2026-07-11`, `## [1.8.0]` or a bare
+ * `## 1.8.0`. The brackets are optional and a stray quote inside them (e.g. a
+ * malformed `## ["1.9.0]`) is tolerated; the trailing date may be separated by
+ * a hyphen, en dash or em dash.
+ */
+const HEADING_RE = /^##\s+(?:\[["']?([^\]"']+?)["']?\]|([^\s[\]]+))\s*(?:[-–—]\s*(.+))?$/;
+/** A Markdown link-reference definition, e.g. `[1.8.0]: https://…`. These sit
+ * in a block at the foot of the file and turn the version headings into links. */
+const LINK_DEF_RE = /^\[([^\]]+)\]:\s+(\S+)/;
+
+/** Lines that open a block of their own and so must never be joined onto the
+ * line above: headings, list items, quotes, tables, rules and fences. */
+const BLOCK_START_RE = /^\s*(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|>|\||={3,}\s*$|(?:[-*_]\s*){3,}$)/;
+/** Blocks that are exactly one line long, so the line after them starts afresh
+ * rather than being absorbed: headings, table rows and horizontal rules. (A
+ * list item or quote, by contrast, does absorb the lines that follow it.) */
+const SINGLE_LINE_BLOCK_RE = /^\s*(?:#{1,6}\s|\||={3,}\s*$|(?:[-*_]\s*){3,}$)/;
+/** An opening or closing code fence. */
+const FENCE_RE = /^\s*(?:```|~~~)/;
+
+/**
+ * Undo the changelog's hard line wrapping.
+ *
+ * `CHANGELOG.md` is wrapped at ~80 columns for readability in the repo, but
+ * Obsidian renders a single newline as a line break unless the reader has
+ * "Strict line breaks" on. Left alone, the dialog therefore breaks sentences
+ * mid-clause at whatever column the source happened to wrap at. Joining each
+ * paragraph (and each list item) back into one logical line lets the text wrap
+ * to the dialog's width instead.
+ *
+ * Block structure is preserved: blank lines, headings, list markers, quotes,
+ * tables and fenced code all start a new line, as do explicit Markdown hard
+ * breaks (a line ending in two spaces or a backslash). Indented continuation
+ * lines are joined onto their parent with a single space, so a list item's
+ * second paragraph stays inside the item.
+ */
+export function reflowMarkdown(md: string): string {
+	const out: string[] = [];
+	let buffer: string | null = null;
+	let inFence = false;
+
+	const flush = () => {
+		if (buffer !== null) out.push(buffer);
+		buffer = null;
+	};
+
+	for (const raw of md.split("\n")) {
+		if (FENCE_RE.test(raw)) {
+			flush();
+			out.push(raw);
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) {
+			out.push(raw);
+			continue;
+		}
+
+		const line = raw.replace(/\s+$/, "");
+		if (line === "") {
+			flush();
+			out.push("");
+			continue;
+		}
+		// The first line of a block keeps its own indentation — that is what
+		// holds a list item's second paragraph inside the item.
+		if (BLOCK_START_RE.test(line) || buffer === null) {
+			flush();
+			buffer = line;
+		} else {
+			buffer = `${buffer} ${line.trimStart()}`;
+		}
+		// A one-line block ends here, and an explicit hard break (trailing double
+		// space or backslash) is the author asking for a line break — either way,
+		// start afresh.
+		if (SINGLE_LINE_BLOCK_RE.test(line) || /(?: {2}|\\)$/.test(raw)) flush();
+	}
+	flush();
+
+	return out.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+/**
+ * Split the changelog Markdown into per-release entries, newest first (the
+ * file's own order). The preamble above the first `##` heading is dropped, the
+ * heading itself is lifted out of the body — the dialog draws it as its own
+ * header — and the trailing link-reference definitions are resolved into each
+ * entry's {@link ChangelogEntry.url} so nothing has to be re-appended to the
+ * rendered Markdown.
+ */
+export function parseChangelog(md: string): ChangelogEntry[] {
+	const entries: { version: string; date: string; body: string[] }[] = [];
+	const urls = new Map<string, string>();
+	let current: { version: string; date: string; body: string[] } | null = null;
+
+	for (const line of md.split("\n")) {
+		const linkDef = LINK_DEF_RE.exec(line);
+		if (linkDef) {
+			urls.set(linkDef[1], linkDef[2]);
+			continue;
+		}
+		const heading = HEADING_RE.exec(line);
+		if (heading) {
+			current = {
+				version: (heading[1] ?? heading[2]).trim(),
+				date: (heading[3] ?? "").trim(),
+				body: [],
+			};
+			entries.push(current);
+		} else if (current) {
+			current.body.push(line);
+		}
+		// Lines before the first heading are the file preamble — ignored.
+	}
+
+	return entries.map((e) => ({
+		version: e.version,
+		date: e.date,
+		url: urls.get(e.version) ?? "",
+		markdown: reflowMarkdown(e.body.join("\n")),
+	}));
+}
+
+/** The numeric release components of a version, ignoring any pre-release suffix
+ * (`1.9.0-beta.1` → `[1, 9, 0]`), so beta and stable builds compare by release. */
+function versionParts(v: string): number[] {
+	return v
+		.split("-")[0]
+		.split(".")
+		.map((n) => parseInt(n, 10) || 0);
+}
+
+/** Whether release `a` is strictly newer than release `b` (semver-style, by
+ * numeric components; pre-release suffixes are ignored). */
+export function isNewer(a: string, b: string): boolean {
+	const pa = versionParts(a);
+	const pb = versionParts(b);
+	const len = Math.max(pa.length, pb.length);
+	for (let i = 0; i < len; i++) {
+		const x = pa[i] ?? 0;
+		const y = pb[i] ?? 0;
+		if (x !== y) return x > y;
+	}
+	return false;
+}

--- a/src/whatsnew.ts
+++ b/src/whatsnew.ts
@@ -1,60 +1,10 @@
 import { App, Component, MarkdownRenderer, Modal, Setting } from "obsidian";
 import changelogMarkdown from "../CHANGELOG.md";
+import { isNewer, parseChangelog, type ChangelogEntry } from "./changelog";
 import { t } from "./i18n";
 import type HearthPlugin from "./main";
 
-/** One release section parsed out of `CHANGELOG.md`: its version and the raw
- * Markdown of that section (its `##` heading plus body). */
-export interface ChangelogEntry {
-	version: string;
-	markdown: string;
-}
-
-/** A release heading like `## [1.8.0] - 2026-07-11`. The bracketed version is
- * captured, tolerating a stray quote (e.g. a malformed `## ["1.9.0]`). */
-const HEADING_RE = /^##\s+\[["']?([^\]"']+?)["']?\]/;
-/** A Markdown link-reference definition, e.g. `[1.8.0]: https://…`. These sit
- * in a block at the foot of the file and turn the version headings into links. */
-const LINK_DEF_RE = /^\[[^\]]+\]:\s+\S/;
-
-/**
- * Split the changelog Markdown into per-release entries (newest first, matching
- * the file's order) plus the trailing block of link-reference definitions. The
- * preamble above the first `##` heading is dropped; the link definitions are
- * pulled out so they can be re-appended after whichever entries are shown, so
- * each version heading still renders as a link.
- */
-function parseChangelog(md: string): { entries: ChangelogEntry[]; linkDefs: string } {
-	const entries: ChangelogEntry[] = [];
-	const linkDefs: string[] = [];
-	let current: { version: string; body: string[] } | null = null;
-
-	const flush = () => {
-		if (current) {
-			entries.push({ version: current.version, markdown: current.body.join("\n").trim() });
-		}
-	};
-
-	for (const line of md.split("\n")) {
-		if (LINK_DEF_RE.test(line)) {
-			linkDefs.push(line);
-			continue;
-		}
-		const heading = HEADING_RE.exec(line);
-		if (heading) {
-			flush();
-			current = { version: heading[1], body: [line] };
-		} else if (current) {
-			current.body.push(line);
-		}
-		// Lines before the first heading are the file preamble — ignored.
-	}
-	flush();
-
-	return { entries, linkDefs: linkDefs.join("\n") };
-}
-
-const parsed = parseChangelog(changelogMarkdown);
+export type { ChangelogEntry };
 
 /**
  * The changelog, **newest entry first**, parsed straight from `CHANGELOG.md` at
@@ -62,34 +12,7 @@ const parsed = parseChangelog(changelogMarkdown);
  * new" dialog is thus a live mirror of that file: cut a release by editing
  * `CHANGELOG.md` and nothing here needs touching.
  */
-export const CHANGELOG: ChangelogEntry[] = parsed.entries;
-
-/** The link-reference definitions that back the version headings, re-appended
- * to whatever slice of entries the dialog renders. */
-const LINK_DEFS = parsed.linkDefs;
-
-/** The numeric release components of a version, ignoring any pre-release suffix
- * (`1.9.0-beta.1` → `[1, 9, 0]`), so beta and stable builds compare by release. */
-function versionParts(v: string): number[] {
-	return v
-		.split("-")[0]
-		.split(".")
-		.map((n) => parseInt(n, 10) || 0);
-}
-
-/** Whether release `a` is strictly newer than release `b` (semver-style, by
- * numeric components; pre-release suffixes are ignored). */
-function isNewer(a: string, b: string): boolean {
-	const pa = versionParts(a);
-	const pb = versionParts(b);
-	const len = Math.max(pa.length, pb.length);
-	for (let i = 0; i < len; i++) {
-		const x = pa[i] ?? 0;
-		const y = pb[i] ?? 0;
-		if (x !== y) return x > y;
-	}
-	return false;
-}
+export const CHANGELOG: ChangelogEntry[] = parseChangelog(changelogMarkdown);
 
 /**
  * The entries strictly newer than {@link seen}, newest first. An empty or
@@ -101,8 +24,11 @@ export function entriesSince(seen: string): ChangelogEntry[] {
 }
 
 /**
- * The "What's new" dialog: the relevant slice of `CHANGELOG.md` rendered as
- * Markdown (one section per release, newest first). Purely informational.
+ * The "What's new" dialog: the relevant slice of `CHANGELOG.md`, one release
+ * per section, newest first. The version heading is drawn as a header row
+ * rather than left to Markdown, so the version, its date and its compare link
+ * line up the same way for every release; only the section body is rendered as
+ * Markdown. Purely informational.
  */
 export class WhatsNewModal extends Modal {
 	private readonly entries: ChangelogEntry[];
@@ -123,11 +49,11 @@ export class WhatsNewModal extends Modal {
 			text: t().whatsNew.intro,
 		});
 
+		// Only this scrolls, so the intro stays put and the close button below
+		// stays reachable no matter how long the log is.
 		const body = contentEl.createDiv({ cls: "hearth-whatsnew-body" });
-		const sections = this.entries.map((e) => e.markdown).join("\n\n");
-		const md = LINK_DEFS ? `${sections}\n\n${LINK_DEFS}` : sections;
 		this.renderComponent.load();
-		void MarkdownRenderer.render(this.app, md, body, "", this.renderComponent);
+		for (const entry of this.entries) this.renderEntry(body, entry);
 
 		contentEl.createEl("p", {
 			cls: "hearth-whatsnew-footer",
@@ -140,6 +66,31 @@ export class WhatsNewModal extends Modal {
 				.setCta()
 				.onClick(() => this.close()),
 		);
+	}
+
+	/** One release: a version header, then the section body as Markdown. */
+	private renderEntry(parent: HTMLElement, entry: ChangelogEntry): void {
+		const section = parent.createDiv({ cls: "hearth-whatsnew-release" });
+		const header = section.createDiv({ cls: "hearth-whatsnew-release-header" });
+
+		const version = header.createEl("h2", { cls: "hearth-whatsnew-version" });
+		if (entry.url) {
+			version.createEl("a", {
+				text: entry.version,
+				href: entry.url,
+				cls: "hearth-whatsnew-version-link",
+				attr: { rel: "noopener" },
+			});
+		} else {
+			version.setText(entry.version);
+		}
+
+		if (entry.date) {
+			header.createSpan({ cls: "hearth-whatsnew-date", text: entry.date });
+		}
+
+		const bodyEl = section.createDiv({ cls: "hearth-whatsnew-release-body" });
+		void MarkdownRenderer.render(this.app, entry.markdown, bodyEl, "", this.renderComponent);
 	}
 
 	onClose(): void {

--- a/styles.css
+++ b/styles.css
@@ -6553,55 +6553,130 @@ body.hearth-dv-resizing {
 
 /* ── "What's new" release-notes dialog ─────────────────────────────────── */
 .hearth-whatsnew-modal {
-	max-width: 620px;
+	max-width: 680px;
+	width: min(680px, 92vw);
+}
+
+/* Intro and footer stay put; only the release list scrolls, so the close
+ * button is reachable however long the log is. */
+.hearth-whatsnew-modal .modal-content {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	max-height: min(70vh, 720px);
 }
 
 .hearth-whatsnew-modal .hearth-whatsnew-intro {
-	margin: 0 0 12px;
+	flex: none;
+	margin: 0 0 14px;
 	color: var(--text-muted);
 }
 
-/* CHANGELOG.md rendered as Markdown. Each release is an h2 heading; a hairline
- * rule above every heading after the first stacks the log as dated entries
- * rather than one run-on list. */
-.hearth-whatsnew-body h2 {
-	margin: 0 0 8px;
-	font-size: 1.05rem;
+.hearth-whatsnew-body {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	/* Room for the scrollbar so text doesn't run under it. */
+	padding-right: 8px;
 }
 
-.hearth-whatsnew-body h2:not(:first-child) {
-	margin-top: 20px;
-	padding-top: 16px;
+/* One release. A hairline rule above every section after the first stacks the
+ * log as dated entries rather than one run-on list. */
+.hearth-whatsnew-release + .hearth-whatsnew-release {
+	margin-top: 24px;
+	padding-top: 20px;
 	border-top: 1px solid var(--background-modifier-border);
 }
 
+.hearth-whatsnew-release-header {
+	display: flex;
+	align-items: baseline;
+	gap: 10px;
+	margin-bottom: 10px;
+}
+
+.hearth-whatsnew-version {
+	margin: 0;
+	font-size: 1.15rem;
+	font-weight: 650;
+	line-height: 1.2;
+}
+
+.hearth-whatsnew-version-link {
+	color: inherit;
+	text-decoration: none;
+}
+
+.hearth-whatsnew-version-link:hover {
+	color: var(--text-accent);
+	text-decoration: underline;
+}
+
+.hearth-whatsnew-date {
+	font-size: 0.78rem;
+	color: var(--text-faint);
+	white-space: nowrap;
+}
+
 /* The Added / Changed / Fixed section labels within a release. */
-.hearth-whatsnew-body h3 {
-	margin: 14px 0 6px;
-	font-size: 0.8rem;
+.hearth-whatsnew-release-body h3 {
+	margin: 18px 0 8px;
+	font-size: 0.72rem;
+	font-weight: 600;
 	text-transform: uppercase;
-	letter-spacing: 0.05em;
+	letter-spacing: 0.08em;
 	color: var(--text-muted);
 }
 
-.hearth-whatsnew-body p {
-	line-height: 1.45;
+.hearth-whatsnew-release-body h3:first-child {
+	margin-top: 0;
 }
 
-.hearth-whatsnew-body ul {
+.hearth-whatsnew-release-body p {
+	margin: 0 0 8px;
+	line-height: 1.55;
+}
+
+.hearth-whatsnew-release-body ul,
+.hearth-whatsnew-release-body ol {
 	margin: 0;
-	padding-left: 1.2em;
+	padding-left: 1.25em;
 }
 
-.hearth-whatsnew-body li {
-	margin: 5px 0;
-	line-height: 1.45;
+.hearth-whatsnew-release-body li {
+	margin: 0 0 10px;
+	line-height: 1.55;
+}
+
+.hearth-whatsnew-release-body li:last-child {
+	margin-bottom: 0;
+}
+
+/* A bullet's follow-on paragraphs sit tight under its first line. */
+.hearth-whatsnew-release-body li > p {
+	margin: 0 0 6px;
+}
+
+.hearth-whatsnew-release-body li > p:last-child {
+	margin-bottom: 0;
+}
+
+.hearth-whatsnew-release-body code {
+	font-size: 0.85em;
 }
 
 .hearth-whatsnew-footer {
-	margin: 18px 0 0;
+	flex: none;
+	margin: 16px 0 0;
 	font-size: 0.82rem;
 	color: var(--text-muted);
+}
+
+/* The close button row — never squeezed out by a long log. */
+.hearth-whatsnew-modal .modal-content > .setting-item {
+	flex: none;
+	border-top: none;
+	padding-bottom: 0;
 }
 
 /* Jira saved-filter card */

--- a/test/changelog.test.ts
+++ b/test/changelog.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { isNewer, parseChangelog, reflowMarkdown } from "../src/changelog";
+
+describe("reflowMarkdown", () => {
+	it("joins a hard-wrapped paragraph into one line", () => {
+		const md = ["The weather sky, as your background. Settings →", "Appearance → Background."].join(
+			"\n",
+		);
+		expect(reflowMarkdown(md)).toBe(
+			"The weather sky, as your background. Settings → Appearance → Background.",
+		);
+	});
+
+	it("keeps separate paragraphs separate", () => {
+		expect(reflowMarkdown("one\nline\n\nsecond\npara")).toBe("one line\n\nsecond para");
+	});
+
+	it("joins each list item without merging items", () => {
+		const md = ["- first item that", "  wraps here", "- second item", "  wrapping too"].join("\n");
+		expect(reflowMarkdown(md)).toBe("- first item that wraps here\n- second item wrapping too");
+	});
+
+	it("keeps a nested list item on its own line, indentation intact", () => {
+		const md = ["- parent item", "  - child item that", "    wraps"].join("\n");
+		expect(reflowMarkdown(md)).toBe("- parent item\n  - child item that wraps");
+	});
+
+	it("keeps an indented follow-on paragraph inside its list item", () => {
+		const md = ["- first item", "", "  A second paragraph that", "  wraps in the source."].join(
+			"\n",
+		);
+		expect(reflowMarkdown(md)).toBe("- first item\n\n  A second paragraph that wraps in the source.");
+	});
+
+	it("starts a new line at headings, quotes and tables", () => {
+		expect(reflowMarkdown("text\n### Added\nmore\n> quoted\n| a | b |")).toBe(
+			"text\n### Added\nmore\n> quoted\n| a | b |",
+		);
+	});
+
+	it("leaves fenced code blocks untouched", () => {
+		const md = ["```js", "const a = 1;", "const b = 2;", "```", "after the", "fence"].join("\n");
+		expect(reflowMarkdown(md)).toBe(
+			["```js", "const a = 1;", "const b = 2;", "```", "after the fence"].join("\n"),
+		);
+	});
+
+	it("honours an explicit hard break", () => {
+		expect(reflowMarkdown("first line  \nsecond line")).toBe("first line\nsecond line");
+	});
+});
+
+describe("parseChangelog", () => {
+	const md = [
+		"# Changelog",
+		"",
+		"Preamble that is not part of any release.",
+		"",
+		"## [2.0.0] - 2026-07-11",
+		"",
+		"### Added",
+		"",
+		"- A thing that wraps",
+		"  across two lines.",
+		"",
+		"## [1.9.0]",
+		"",
+		"### Fixed",
+		"",
+		"- Another thing.",
+		"",
+		"[1.9.0]: https://example.com/compare/1.8.0...1.9.0",
+	].join("\n");
+
+	it("splits releases newest first and drops the preamble", () => {
+		const entries = parseChangelog(md);
+		expect(entries.map((e) => e.version)).toEqual(["2.0.0", "1.9.0"]);
+		expect(entries[0].markdown).not.toContain("Preamble");
+	});
+
+	it("lifts the heading out of the body and reflows what's left", () => {
+		const [latest] = parseChangelog(md);
+		expect(latest.markdown).toBe("### Added\n\n- A thing that wraps across two lines.");
+	});
+
+	it("captures the release date when the heading carries one", () => {
+		const entries = parseChangelog(md);
+		expect(entries[0].date).toBe("2026-07-11");
+		expect(entries[1].date).toBe("");
+	});
+
+	it("resolves link-reference definitions into entry URLs", () => {
+		const entries = parseChangelog(md);
+		expect(entries[1].url).toBe("https://example.com/compare/1.8.0...1.9.0");
+		// An unreleased version has no link definition yet — no URL, and no
+		// stray brackets left in the version itself.
+		expect(entries[0].url).toBe("");
+		expect(entries[0].version).toBe("2.0.0");
+	});
+
+	it("tolerates a bare heading and a stray quote in the brackets", () => {
+		const entries = parseChangelog('## ["1.9.0]\n\nbody\n\n## 1.8.0 - 2026-01-02\n\nbody');
+		expect(entries.map((e) => e.version)).toEqual(["1.9.0", "1.8.0"]);
+		expect(entries[1].date).toBe("2026-01-02");
+	});
+});
+
+describe("isNewer", () => {
+	it("compares by numeric release components", () => {
+		expect(isNewer("2.0.0", "1.11.0")).toBe(true);
+		expect(isNewer("1.9.0", "1.10.0")).toBe(false);
+		expect(isNewer("1.9.0", "1.9.0")).toBe(false);
+	});
+
+	it("ignores pre-release suffixes", () => {
+		expect(isNewer("2.0.0-beta.1", "2.0.0")).toBe(false);
+		expect(isNewer("2.0.0-beta.1", "1.11.0")).toBe(true);
+	});
+
+	it("treats an unknown or empty seen version as older than everything", () => {
+		expect(isNewer("1.5.0", "")).toBe(true);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the "What's new" dialog rendering release notes with sentences broken mid-clause.

The dialog fed `CHANGELOG.md` straight into `MarkdownRenderer.render`. With Obsidian's default "Strict line breaks" **off**, every single newline becomes a `<br>` — so the file's 80-column hard wrapping was rendered literally, breaking text at whatever column the source happened to wrap at rather than at the dialog's width.

**`src/changelog.ts` (new — pure, tested):**

- `reflowMarkdown()` rejoins hard-wrapped paragraphs and list items into one logical line, so text wraps to the dialog width. Blank lines, headings, list markers (including nested items and indented follow-on paragraphs), quotes, tables, fenced code and explicit hard breaks are all preserved.
- `parseChangelog()` lifts the release heading out of each body and resolves the trailing link-reference block into a per-entry `date` and `url`. This also fixes the literal `[2.0.0]` brackets in the dialog: an unreleased version has no link definition yet, so the reference never resolved and the brackets rendered as text.

**`src/whatsnew.ts`:** each release is drawn as a header row (version, date, compare link when one exists) plus its rendered body, instead of relying on Markdown `h2`s and re-appended link definitions.

**`styles.css`:** `.modal-content` is a flex column and only the release list scrolls, so the intro, footer and close button stay in place however long the log is. Wider modal (680px, capped at 92vw), roomier line height, per-release separators.

Note: releases 1.12.0–2.0.0 carry no link-reference definitions or dates in `CHANGELOG.md`, so those headers show the version alone. Adding them to the file lights up the dates and compare links automatically — no code change needed.

## Related issue

None — formatting fix to an existing dialog.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (lint clean, 563 tests pass, 16 new in `test/changelog.test.ts`)
- [x] I've tested this in an actual vault — layout verified by rendering the dialog's markup and CSS in Chromium, not in Obsidian itself

---
_Generated by [Claude Code](https://claude.ai/code/session_01StYMCG4t5MiWjUYoT3mRRH)_