### PR TITLE
fix(weather): give the coordinates row room, and stop it losing the first value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "hearth",
-	"version": "1.17.0",
+	"version": "1.18.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "hearth",
-			"version": "1.17.0",
+			"version": "1.18.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^20.11.0",
@@ -14,7 +14,7 @@
 				"eslint": "^9.39.5",
 				"eslint-plugin-obsidianmd": "^0.4.1",
 				"moment": "2.29.4",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"tslib": "^2.6.2",
 				"typescript": "^5.4.0",
 				"typescript-eslint": "^8.63.0",

--- a/src/placepicker.ts
+++ b/src/placepicker.ts
@@ -213,10 +213,24 @@ function searchRows(containerEl: HTMLElement, opts: PlacePickerOptions): void {
 	}
 }
 
+/** The name a place gets when nobody has typed one: its own coordinates. */
+function coordName(place: WeatherPlace): string {
+	return `${place.lat.toFixed(2)}, ${place.lon.toFixed(2)}`;
+}
+
 /** Latitude/longitude entry, for a place the geocoder doesn't know — or for
  * anyone who would rather not send a place name anywhere at all. */
 function coordinateRows(containerEl: HTMLElement, opts: PlacePickerOptions): void {
 	const strings = t().editors.weather;
+
+	// Typing does not re-render the picker, so `opts.current` is only accurate
+	// until the first keystroke. Keep the place being edited here instead:
+	// otherwise typing a latitude and then a longitude would build the second
+	// one on the pre-edit place and throw the first away.
+	let draft: WeatherPlace | undefined = opts.current ? { ...opts.current } : undefined;
+	// Whether the name is one we derived from the coordinates. Such a name
+	// follows them as they change; one that was searched for or typed stands.
+	let namedByCoords = !draft?.name.trim() || draft.name === coordName(draft);
 
 	/** Write one coordinate, creating the place if this is the first one typed. */
 	const setCoord = (which: "lat" | "lon", raw: string): void => {
@@ -224,29 +238,36 @@ function coordinateRows(containerEl: HTMLElement, opts: PlacePickerOptions): voi
 		if (raw.trim() === "" || Number.isNaN(value)) return;
 		const limit = which === "lat" ? 90 : 180;
 		if (Math.abs(value) > limit) return;
-		const place: WeatherPlace = opts.current
-			? { ...opts.current }
-			: { name: "", lat: 0, lon: 0 };
+		const place: WeatherPlace = draft ? { ...draft } : { name: "", lat: 0, lon: 0 };
 		place[which] = value;
-		if (!place.name.trim()) place.name = `${place.lat.toFixed(2)}, ${place.lon.toFixed(2)}`;
-		opts.onPick(place);
+		if (namedByCoords) place.name = coordName(place);
+		draft = place;
+		opts.onPick({ ...place });
 	};
 
+	// Two inputs plus a label do not fit on one settings row — Obsidian gives
+	// the control strip the room it asks for and squeezes the name and
+	// description into a sliver. Stack the inputs under the label instead.
 	const coords = new Setting(containerEl)
 		.setName(strings.coordinates)
-		.setDesc(strings.coordinatesDesc);
-	coords.addText((txt) =>
+		.setDesc(strings.coordinatesDesc)
+		.setClass("hearth-weather-coords");
+	coords.addText((txt) => {
 		txt
 			.setPlaceholder(strings.latPlaceholder)
 			.setValue(opts.current ? String(opts.current.lat) : "")
-			.onChange((v) => setCoord("lat", v)),
-	);
-	coords.addText((txt) =>
+			.onChange((v) => setCoord("lat", v));
+		txt.inputEl.addClass("hearth-weather-coord-input");
+		txt.inputEl.inputMode = "decimal";
+	});
+	coords.addText((txt) => {
 		txt
 			.setPlaceholder(strings.lonPlaceholder)
 			.setValue(opts.current ? String(opts.current.lon) : "")
-			.onChange((v) => setCoord("lon", v)),
-	);
+			.onChange((v) => setCoord("lon", v));
+		txt.inputEl.addClass("hearth-weather-coord-input");
+		txt.inputEl.inputMode = "decimal";
+	});
 
 	new Setting(containerEl)
 		.setName(strings.placeName)
@@ -257,8 +278,10 @@ function coordinateRows(containerEl: HTMLElement, opts: PlacePickerOptions): voi
 				.setValue(opts.current?.name ?? "")
 				.setDisabled(!opts.current)
 				.onChange((v) => {
-					if (!opts.current) return;
-					opts.onPick({ ...opts.current, name: v });
+					if (!draft) return;
+					namedByCoords = !v.trim();
+					draft = { ...draft, name: namedByCoords ? coordName(draft) : v };
+					opts.onPick({ ...draft });
 				}),
 		);
 }

--- a/styles.css
+++ b/styles.css
@@ -3617,6 +3617,24 @@
 	font-size: 0.9rem;
 }
 
+/* Manual coordinates: two inputs beside a label leave the name/description a
+   sliver of the dialog ("Coord…" over a one-word-per-line paragraph). Stack
+   the pair under the label and let them share the full width. */
+.hearth-weather-coords {
+	display: block;
+}
+
+.hearth-weather-coords .setting-item-control {
+	margin-top: 8px;
+	justify-content: flex-start;
+	flex-wrap: wrap;
+}
+
+.hearth-weather-coord-input {
+	flex: 1 1 8em;
+	min-width: 0;
+}
+
 /* Mini calendar card */
 .hearth-calendar {
 	display: flex;


### PR DESCRIPTION
## What does this PR do?

Two fixes to the manual coordinates entry in the place picker (`src/placepicker.ts`), used by the weather card editor and the background settings.

**Layout.** The Coordinates setting puts two text inputs in Obsidian's right-hand control strip, which takes the width it asks for and crushes the name/description column into a sliver — the setting rendered as "Coord…" above a paragraph one word per line. It now carries a `hearth-weather-coords` class that stacks the two inputs under the label and lets them share the full width, the same treatment `.hearth-rss-github` already uses for its three-control row. The inputs also get `inputMode="decimal"` so mobile shows a numeric keypad.

**Lost coordinate.** Both inputs derived the new place from `opts.current`, but typing does not re-render the picker, so that value is only accurate until the first keystroke. Entering a latitude and then a longitude rebuilt the place from the pre-edit state and discarded the latitude — on a fresh card it silently reset to 0. The place being edited is now tracked locally. Related: the auto-generated `"50.09, 14.42"` name was written once and then frozen, so it could end up disagreeing with the coordinates; it now follows them, while a name that came from search or was typed by hand is left alone (clearing the name field returns to the coordinate-derived one).

No tests added — this is DOM-rendering editor code with no existing test file. The existing suite passes (568 tests).

## Related issue

None — small fix.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault — not possible from this environment; the layout change is CSS-only and mirrors an existing pattern, but a look in a real vault would be worth it before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtM49VyUyc9Z516EHFWvUQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtM49VyUyc9Z516EHFWvUQ)_