### PR TITLE
Redesign the add-card picker and stop hiding plugin-backed cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,9 +130,9 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   everything, or only staged — give it a fixed commit message or let the plugin
   prompt for one each time, cap the file and commit lists, and turn on folder
   paths or an extra timed re-read for a repo that also changes outside Obsidian.
-  Discarding asks first unless you say otherwise. The card only appears in the
-  "Add card" picker while the Git plugin is enabled, and Git joins the
-  Integrations catalogue.
+  Discarding asks first unless you say otherwise. The card is offered whether or
+  not the Git plugin is installed — without it, the card says so and points at
+  it — and Git joins the Integrations catalogue.
 - **Datacore card.** Dataview is winding down in favour of
   [Datacore](https://github.com/blacksmithgu/datacore), so Hearth now has a card
   for it, in the same shape as the Dataview card: pick a query type, write a
@@ -143,8 +143,8 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   exactly as inside a `datacorejsx` block, so anything you can draw in a note —
   tables, cards, interactive views — you can put on the dashboard. A query with
   a syntax error says so on the card instead of failing silently, and the card
-  only appears in the "Add card" picker while Datacore is enabled. Datacore also
-  joins the Integrations catalogue.
+  is offered whether or not Datacore is installed — without it, the card says so
+  and points at it. Datacore also joins the Integrations catalogue.
 - **Every integration in one place.** **Settings → Integrations** now opens with
   a complete catalogue of everything Hearth works with — community plugins
   (Omnisearch, TaskNotes, Dataview, Git, Iconic, Iconize, Excalidraw), Obsidian's own
@@ -271,6 +271,21 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   hosted editor is only alive while the card is on screen, and pending
   keystrokes are flushed to the vault before it's torn down. Left off, the card
   keeps the double-click raw editor it has always had (#160).
+- **A real picker for adding cards.** **Arrange → Add card** no longer drops a
+  single column of thirty bare names down the side of the screen. It opens a
+  browser instead: a **search field** that matches names *and* descriptions (so
+  "todo" finds Tasks and "iframe" finds the web card), a rail of **categories** —
+  Notes & files, Planning, Vault insight, Tools, Integrations, Fun — and a grid
+  of tiles where every card says in one line what it actually shows. The
+  category you were last in is where it reopens, arrow keys walk the grid, and
+  on a phone the rail folds into a row of chips above the tiles.
+- **Request a card, from inside the picker.** The last entry in the rail is
+  **Request a card**, for the moment you have looked through the whole catalogue
+  and the card you wanted isn't in it. It offers two routes — a **GitHub issue**,
+  opened on Hearth's feature-request form, or an **email** to the maintainer —
+  and both open pre-filled: a few prompts about what the card should show and
+  where its data would come from, plus your Hearth and Obsidian versions. Edit
+  anything before you send it.
 
 ### Fixed
 
@@ -408,6 +423,15 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Changed
 
+- **Every card is in the picker, always.** Cards backed by a community plugin —
+  Dataview, Datacore, Git — used to be *hidden* from the "Add card" menu until
+  their plugin happened to be installed, so a third of the catalogue was
+  invisible to the people most likely to want to know it existed: you could not
+  find out Hearth had a Git card without already having the Git plugin. They are
+  all listed now, marked **Needs Dataview** (or Datacore, or Git) while the
+  plugin is missing, with a one-click jump to it in Obsidian's plugin browser
+  when you add one. Nothing about the cards themselves changed — each one has
+  always explained what it needs, in place on the board.
 - **Searching note contents costs a lot less on a large vault.** A body search
   walked every note and built a lower-cased copy of it to match against, and the
   walk kept going after you'd typed the next character — so a few keystrokes

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ The search field is keyboard-first, with four transparent modes:
 Add cards from the **Arrange** toolbar; configure each one from the card itself
 (title, content, colors, size, opacity, blur).
 
+**Add card** opens a searchable picker: type to match a card's name or its
+description, or browse by category (Notes & files, Planning, Vault insight,
+Tools, Integrations, Fun). Cards backed by a community plugin are always listed
+— they're marked *Needs Dataview* (or Datacore, or Git) when the plugin isn't
+there, with a one-click jump to install it. And if the card you want doesn't
+exist, **Request a card** at the bottom of the rail opens a pre-filled GitHub
+issue or email.
+
 **Notes & files**
 
 - **Embed** — any note, image, canvas or `.base` file, rendered by Obsidian

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,10 @@ export default tseslint.config(
 		files: ["test/**"],
 		rules: {
 			"@typescript-eslint/no-restricted-imports": "off",
+			// Same reason: tests run in Node, never on a phone, and a couple of
+			// them read repository files (test/cardrequest.test.ts checks the
+			// picker's prefilled issue URL against the real issue-form template).
+			"obsidianmd/no-nodejs-modules": "off",
 		},
 	},
 );

--- a/src/cardpicker.ts
+++ b/src/cardpicker.ts
@@ -118,6 +118,10 @@ class CardPickerModal extends Modal {
 		this.app.saveLocalStorage(SCOPE_KEY, scope);
 		this.renderRail();
 		this.renderResults();
+		// Start a new category at its top: the results column keeps its height
+		// now, so a scrolled-down position would otherwise carry over and land
+		// you in the middle of the next category.
+		if (this.resultsEl) this.resultsEl.scrollTop = 0;
 	}
 
 	// ---- Search ---------------------------------------------------------

--- a/src/cardpicker.ts
+++ b/src/cardpicker.ts
@@ -1,0 +1,401 @@
+import {
+	apiVersion,
+	Modal,
+	Notice,
+	Platform,
+	prepareFuzzySearch,
+	setIcon,
+	type App,
+} from "obsidian";
+import {
+	CARD_CATEGORIES,
+	CARD_TEMPLATES,
+	templateCategory,
+	templateDescription,
+	templateName,
+	unmetRequirement,
+	type CardCategory,
+	type CardTemplateDef,
+} from "./cards";
+import { cardRequestGithubUrl, cardRequestMailtoUrl } from "./cardrequest";
+import { t } from "./i18n";
+
+/**
+ * The "Add card" picker.
+ *
+ * It used to be a flat Obsidian `Menu`: one unlabelled line per template, in
+ * one column, in registry order. That worked at a dozen cards; the catalogue is
+ * now ~30 and the menu had become a wall of names taller than a laptop screen,
+ * with no way to search it, nothing saying what any card actually does, and —
+ * worst — a third of it invisible, because plugin-backed cards were hidden
+ * until their plugin happened to be installed.
+ *
+ * This replaces it with a modal that shows the catalogue as it is: every card,
+ * always, grouped into categories, searchable, each with a one-line
+ * description, and the ones whose plugin is missing marked (and offering a jump
+ * to Obsidian's plugin browser) rather than hidden. The last rail entry is
+ * "Request a card", because the picker is exactly where you notice the card you
+ * wanted doesn't exist yet.
+ */
+
+/** What the rail can be showing: every card, one category, or the request page.
+ * (`CardCategory` values are used verbatim, so the rail is derived from the
+ * registry rather than a second hand-kept list.) */
+type PickerScope = "all" | "request" | CardCategory;
+
+/** localStorage key for the scope the picker reopens on. */
+const SCOPE_KEY = "hearth-card-picker-scope";
+
+export interface CardPickerOptions {
+	/** The running Hearth version, stamped into a card request. */
+	hearthVersion: string;
+	/** Add this template to the dashboard. */
+	onChoose: (template: CardTemplateDef) => void;
+}
+
+/** Open the add-card picker. */
+export function openCardPicker(app: App, opts: CardPickerOptions): void {
+	new CardPickerModal(app, opts).open();
+}
+
+class CardPickerModal extends Modal {
+	private opts: CardPickerOptions;
+	/** Named `pickerScope`, not `scope`: `Modal` already has a `scope` (its
+	 * keymap `Scope`), and shadowing it would break the modal's key handling —
+	 * the #52 naming hazard documented on `HearthTabbedModal`. */
+	private pickerScope: PickerScope = "all";
+	private query = "";
+
+	/** The template tiles currently on screen, in visual order — the list arrow
+	 * keys walk. Rebuilt on every results render. */
+	private tiles: HTMLElement[] = [];
+
+	private searchEl: HTMLInputElement | null = null;
+	private railEl: HTMLElement | null = null;
+	private resultsEl: HTMLElement | null = null;
+
+	constructor(app: App, opts: CardPickerOptions) {
+		super(app);
+		this.opts = opts;
+	}
+
+	onOpen(): void {
+		const saved = this.app.loadLocalStorage(SCOPE_KEY) as string | null;
+		if (typeof saved === "string" && this.isScope(saved)) this.pickerScope = saved;
+
+		this.titleEl.setText(t().cardPicker.title);
+		const { contentEl, modalEl } = this;
+		// The frame is sized on modalEl (a grid of tiles needs more than the
+		// default modal width); the content layout hangs off contentEl.
+		modalEl.addClass("hearth-card-picker-modal");
+		contentEl.empty();
+		contentEl.addClass("hearth-card-picker");
+
+		this.renderSearch(contentEl);
+		const body = contentEl.createDiv("hearth-picker-body");
+		this.railEl = body.createDiv("hearth-picker-rail");
+		this.resultsEl = body.createDiv("hearth-picker-results");
+		this.renderRail();
+		this.renderResults();
+
+		// Phones get the keyboard shoved in their face by an autofocused field,
+		// covering the very grid the picker exists to show; the same reason the
+		// search bar in `search.ts` only focuses on desktop.
+		if (!Platform.isMobile) this.searchEl?.focus();
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+
+	private isScope(value: string): value is PickerScope {
+		return value === "all" || value === "request" || (CARD_CATEGORIES as string[]).includes(value);
+	}
+
+	private setScope(scope: PickerScope): void {
+		if (scope === this.pickerScope) return;
+		this.pickerScope = scope;
+		this.app.saveLocalStorage(SCOPE_KEY, scope);
+		this.renderRail();
+		this.renderResults();
+	}
+
+	// ---- Search ---------------------------------------------------------
+
+	private renderSearch(containerEl: HTMLElement): void {
+		const row = containerEl.createDiv("hearth-picker-search");
+		setIcon(row.createSpan("hearth-picker-search-icon"), "search");
+		const input = row.createEl("input", {
+			cls: "hearth-picker-search-input",
+			attr: {
+				type: "text",
+				placeholder: t().cardPicker.searchPlaceholder,
+				"aria-label": t().cardPicker.searchPlaceholder,
+			},
+		});
+		this.searchEl = input;
+		input.addEventListener("input", () => {
+			this.query = input.value.trim();
+			// Typing searches the whole catalogue: a query that matches nothing in
+			// the category you happen to be standing in reads as "Hearth has no
+			// such card", which is exactly the wrong answer.
+			if (this.query && this.pickerScope !== "all") this.setScope("all");
+			else this.renderResults();
+		});
+		input.addEventListener("keydown", (evt: KeyboardEvent) => {
+			if (!this.tiles.length) return;
+			// Enter takes the top match without a detour through the grid — the
+			// point of typing "pet" is to get the pet card.
+			if (evt.key === "Enter") {
+				evt.preventDefault();
+				this.tiles[0].click();
+			} else if (evt.key === "ArrowDown") {
+				evt.preventDefault();
+				this.tiles[0].focus();
+			}
+		});
+	}
+
+	// ---- Rail -----------------------------------------------------------
+
+	private renderRail(): void {
+		const rail = this.railEl;
+		if (!rail) return;
+		rail.empty();
+		const strings = t().cardPicker;
+
+		this.railButton(rail, "all", strings.allCards, "layout-grid");
+		for (const category of CARD_CATEGORIES) {
+			this.railButton(rail, category, strings.categories[category], CATEGORY_ICONS[category]);
+		}
+		rail.createDiv("hearth-picker-rail-sep");
+		this.railButton(rail, "request", strings.request.railLabel, "message-square-plus");
+	}
+
+	private railButton(rail: HTMLElement, scope: PickerScope, label: string, icon: string): void {
+		const btn = rail.createEl("button", { cls: "hearth-picker-rail-btn" });
+		btn.toggleClass("is-active", this.pickerScope === scope);
+		btn.toggleClass("is-request", scope === "request");
+		btn.setAttribute("aria-pressed", String(this.pickerScope === scope));
+		setIcon(btn.createSpan("hearth-picker-rail-icon"), icon);
+		btn.createSpan({ cls: "hearth-picker-rail-label", text: label });
+		btn.addEventListener("click", () => this.setScope(scope));
+	}
+
+	// ---- Results --------------------------------------------------------
+
+	private renderResults(): void {
+		const results = this.resultsEl;
+		if (!results) return;
+		results.empty();
+		this.tiles = [];
+
+		if (this.pickerScope === "request") {
+			this.renderRequest(results);
+			return;
+		}
+
+		const matches = this.matchingTemplates();
+		if (!matches.length) {
+			this.renderNoMatches(results);
+			return;
+		}
+
+		// Sections are the point of the redesign, so keep them whenever there is
+		// more than one to show; a single-category scope needs no heading, and a
+		// search result reads better as one ranked list.
+		if (this.query || this.pickerScope !== "all") {
+			this.renderGrid(results, matches);
+		} else {
+			for (const category of CARD_CATEGORIES) {
+				const inCategory = matches.filter((tpl) => templateCategory(tpl.id) === category);
+				if (!inCategory.length) continue;
+				results.createDiv({
+					cls: "hearth-picker-section",
+					text: t().cardPicker.categories[category],
+				});
+				this.renderGrid(results, inCategory);
+			}
+		}
+
+		// A quiet way out at the end of the list, for the case the picker can't
+		// answer: you scrolled everything and none of it was the card you wanted.
+		const foot = results.createDiv("hearth-picker-foot");
+		foot.createSpan({ text: t().cardPicker.request.footPrompt });
+		const link = foot.createEl("button", {
+			cls: "hearth-picker-foot-link",
+			text: t().cardPicker.request.footLink,
+		});
+		link.addEventListener("click", () => this.setScope("request"));
+	}
+
+	/** The templates to show, filtered by scope and ranked by the query. */
+	private matchingTemplates(): CardTemplateDef[] {
+		const scoped =
+			this.pickerScope === "all" || this.pickerScope === "request"
+				? CARD_TEMPLATES
+				: CARD_TEMPLATES.filter((tpl) => templateCategory(tpl.id) === this.pickerScope);
+		if (!this.query) return scoped;
+
+		// Name and description both feed the match, so "todo" finds Tasks and
+		// "iframe" finds the web card. Obsidian's own fuzzy matcher, for the same
+		// feel as every other search surface in Hearth.
+		const fuzzy = prepareFuzzySearch(this.query);
+		const ranked: { template: CardTemplateDef; score: number }[] = [];
+		for (const template of scoped) {
+			const name = fuzzy(templateName(template));
+			const desc = fuzzy(templateDescription(template));
+			// A description hit is a weaker signal than a name hit, and scores are
+			// negative (less negative is better), so push description matches down.
+			const score = Math.max(name?.score ?? -Infinity, (desc?.score ?? -Infinity) - 2);
+			if (score > -Infinity) ranked.push({ template, score });
+		}
+		ranked.sort((a, b) => b.score - a.score);
+		return ranked.map((entry) => entry.template);
+	}
+
+	private renderGrid(containerEl: HTMLElement, templates: CardTemplateDef[]): void {
+		const grid = containerEl.createDiv("hearth-picker-grid");
+		for (const template of templates) this.renderTile(grid, template);
+	}
+
+	private renderTile(grid: HTMLElement, template: CardTemplateDef): void {
+		const missing = unmetRequirement(this.app, template);
+		const tile = grid.createEl("button", { cls: "hearth-card-tile" });
+		tile.toggleClass("is-unmet", !!missing);
+		setIcon(tile.createSpan("hearth-card-tile-icon"), template.icon);
+
+		const text = tile.createDiv("hearth-card-tile-text");
+		text.createDiv({ cls: "hearth-card-tile-name", text: templateName(template) });
+		const description = templateDescription(template);
+		if (description) text.createDiv({ cls: "hearth-card-tile-desc", text: description });
+		if (missing) {
+			const badge = text.createDiv("hearth-card-tile-badge");
+			setIcon(badge.createSpan("hearth-card-tile-badge-icon"), "puzzle");
+			badge.createSpan({ text: t().cardPicker.requires(missing.name) });
+		}
+
+		tile.setAttribute("aria-label", templateName(template));
+		tile.addEventListener("keydown", (evt: KeyboardEvent) => this.onTileKey(evt, tile));
+		tile.addEventListener("click", () => {
+			this.close();
+			// The card is added either way — it renders its own "install X" prompt
+			// in place, which is a far better teacher than a missing menu entry —
+			// but say so, with a one-click way to fix it.
+			if (missing) this.noticeMissing(missing.name, missing.pluginId);
+			this.opts.onChoose(template);
+		});
+		this.tiles.push(tile);
+	}
+
+	/** Arrow-key movement across the tiles, in visual order. Left/Right and
+	 * Up/Down both walk the flat list: the grid reflows with the modal's width,
+	 * so there is no fixed column count to step by. */
+	private onTileKey(evt: KeyboardEvent, tile: HTMLElement): void {
+		const step =
+			evt.key === "ArrowDown" || evt.key === "ArrowRight"
+				? 1
+				: evt.key === "ArrowUp" || evt.key === "ArrowLeft"
+					? -1
+					: 0;
+		if (!step) return;
+		evt.preventDefault();
+		const index = this.tiles.indexOf(tile);
+		const next = index + step;
+		if (next < 0) this.searchEl?.focus();
+		else this.tiles[next]?.focus();
+	}
+
+	private noticeMissing(name: string, pluginId?: string): void {
+		const frag = createFragment();
+		frag.appendText(t().cardPicker.missingNotice(name));
+		if (!pluginId) {
+			new Notice(frag, 8000);
+			return;
+		}
+		frag.appendText(" ");
+		const link = frag.createEl("a", {
+			text: t().cardPicker.installLink(name),
+			href: `obsidian://show-plugin?id=${pluginId}`,
+		});
+		link.addEventListener("click", (evt) => {
+			evt.preventDefault();
+			window.open(link.href);
+		});
+		new Notice(frag, 8000);
+	}
+
+	private renderNoMatches(containerEl: HTMLElement): void {
+		const empty = containerEl.createDiv("hearth-picker-empty");
+		setIcon(empty.createSpan("hearth-picker-empty-icon"), "search-x");
+		empty.createDiv({ cls: "hearth-picker-empty-text", text: t().cardPicker.noMatches });
+		const btn = empty.createEl("button", {
+			cls: "mod-cta",
+			text: t().cardPicker.request.railLabel,
+		});
+		btn.addEventListener("click", () => this.setScope("request"));
+	}
+
+	// ---- Request a card -------------------------------------------------
+
+	private renderRequest(containerEl: HTMLElement): void {
+		const strings = t().cardPicker.request;
+		const page = containerEl.createDiv("hearth-picker-request");
+		page.createDiv({ cls: "hearth-picker-section", text: strings.heading });
+		page.createDiv({ cls: "hearth-picker-request-intro", text: strings.intro });
+
+		const context = {
+			hearthVersion: this.opts.hearthVersion,
+			obsidianVersion: apiVersion,
+			platform: Platform.isMobile ? "Mobile" : "Desktop",
+		};
+
+		this.requestOption(page, {
+			icon: "github",
+			title: strings.githubTitle,
+			description: strings.githubDesc,
+			action: strings.githubAction,
+			url: cardRequestGithubUrl(context),
+		});
+		this.requestOption(page, {
+			icon: "mail",
+			title: strings.emailTitle,
+			// The address itself is never printed on screen — it only ever exists
+			// inside the mailto: the button opens.
+			description: strings.emailDesc,
+			action: strings.emailAction,
+			url: cardRequestMailtoUrl(context),
+		});
+
+		page.createDiv({ cls: "hearth-picker-request-note", text: strings.prefilledNote });
+	}
+
+	private requestOption(
+		containerEl: HTMLElement,
+		opts: { icon: string; title: string; description: string; action: string; url: string },
+	): void {
+		const row = containerEl.createDiv("hearth-picker-request-option");
+		setIcon(row.createSpan("hearth-picker-request-icon"), opts.icon);
+		const text = row.createDiv("hearth-picker-request-text");
+		text.createDiv({ cls: "hearth-picker-request-title", text: opts.title });
+		text.createDiv({ cls: "hearth-picker-request-desc", text: opts.description });
+		const btn = row.createEl("button", { cls: "mod-cta", text: opts.action });
+		btn.addEventListener("click", () => {
+			// mailto: and https: both go through the OS handler — the browser (or
+			// Electron) picks the mail client, which is the only portable way to
+			// open a composer from a plugin.
+			window.open(opts.url, "_blank");
+		});
+	}
+}
+
+/** Rail icons, one per category. Kept beside the picker rather than on the
+ * registry: they are a property of this menu, not of the cards. */
+const CATEGORY_ICONS: Record<CardCategory, string> = {
+	notes: "file-text",
+	planning: "calendar-check",
+	vault: "bar-chart-3",
+	tools: "wrench",
+	integrations: "plug",
+	fun: "sparkles",
+};

--- a/src/cardrequest.ts
+++ b/src/cardrequest.ts
@@ -1,0 +1,114 @@
+/**
+ * "Request a card" — the two links at the bottom of the add-card picker.
+ *
+ * The card catalogue is large but finite, and the picker is exactly where
+ * someone notices the card they wanted isn't there. Rather than leave them to
+ * find the repository on their own, the picker offers a pre-filled GitHub
+ * feature request and a pre-filled email, both built here.
+ *
+ * Pure string building, so the URLs (and their prompts staying in step with
+ * `.github/ISSUE_TEMPLATE/feature_request.yml`) are unit-testable — no Obsidian
+ * API is touched.
+ *
+ * The prompt text is deliberately **not** localized: it is the body of a
+ * message addressed to the maintainer, who reads English, and a half-translated
+ * issue is harder to act on than an English one. The picker's own labels around
+ * these links are localized as usual.
+ */
+
+/** Where an emailed card request goes. */
+export const CARD_REQUEST_EMAIL = "ondrej.uhnavy@proton.me";
+
+/** GitHub's issue-form endpoint, and the form the request opens. */
+const GITHUB_NEW_ISSUE_URL = "https://github.com/ondreu/hearth/issues/new";
+const FEATURE_REQUEST_FORM = "feature_request.yml";
+
+/** Everything the templates stamp into a request so the maintainer doesn't have
+ * to ask "which version, on what?" first. */
+export interface CardRequestContext {
+	/** The running Hearth version, from the plugin manifest. */
+	hearthVersion: string;
+	/** Obsidian's `apiVersion`. */
+	obsidianVersion: string;
+	/** "Desktop" / "Mobile" — enough to tell whether a card idea is even
+	 * feasible where it would be used. */
+	platform: string;
+}
+
+/** The issue/email title. Prefixed to match the feature-request form's own
+ * `title:` default, so the two paths produce consistently named requests. */
+export const CARD_REQUEST_TITLE = "[Feature]: New card: ";
+
+/** The "What problem would this solve?" prompt (form field `problem`). */
+const PROBLEM_PROMPT = [
+	"What I want on my dashboard that no current card gives me:",
+	"",
+	"",
+	"How I get at this information today (another plugin, a note, outside Obsidian):",
+	"",
+].join("\n");
+
+/** The "Your idea" prompt (form field `idea`). */
+const IDEA_PROMPT = [
+	"Card name:",
+	"",
+	"What it shows:",
+	"",
+	"Where its data comes from (a plugin, a file, a web service…):",
+	"",
+	"What clicking things on it should do:",
+	"",
+].join("\n");
+
+/** The environment footer both templates end with. */
+function environmentLines(ctx: CardRequestContext): string {
+	return [
+		`Hearth ${ctx.hearthVersion}`,
+		`Obsidian ${ctx.obsidianVersion}`,
+		ctx.platform,
+	].join(" · ");
+}
+
+/**
+ * A pre-filled GitHub feature request.
+ *
+ * GitHub's issue *forms* accept a query parameter per field id, so `problem`
+ * and `idea` land in the right boxes of `feature_request.yml`. Renaming a field
+ * there without renaming it here silently drops that box's prefill — the unit
+ * test pins the ids that must match.
+ */
+export function cardRequestGithubUrl(ctx: CardRequestContext): string {
+	const params = new URLSearchParams({
+		template: FEATURE_REQUEST_FORM,
+		labels: "enhancement",
+		title: CARD_REQUEST_TITLE,
+		problem: PROBLEM_PROMPT,
+		idea: `${IDEA_PROMPT}\n\n${environmentLines(ctx)}`,
+	});
+	return `${GITHUB_NEW_ISSUE_URL}?${params.toString()}`;
+}
+
+/**
+ * A pre-filled email to the maintainer, for people who would rather not have
+ * (or sign in to) a GitHub account.
+ *
+ * `encodeURIComponent` rather than `URLSearchParams`: mail clients want `%20`
+ * in a mailto body, and `URLSearchParams` would write `+`, which several
+ * clients paste through literally.
+ */
+export function cardRequestMailtoUrl(ctx: CardRequestContext): string {
+	const body = [
+		"Hi Ondrej,",
+		"",
+		"I'd like to suggest a new card for Hearth.",
+		"",
+		PROBLEM_PROMPT,
+		"",
+		IDEA_PROMPT,
+		"",
+		"---",
+		environmentLines(ctx),
+	].join("\n");
+	const subject = encodeURIComponent(CARD_REQUEST_TITLE);
+	return `mailto:${CARD_REQUEST_EMAIL}?subject=${subject}&body=${encodeURIComponent(body)}`;
+}

--- a/src/cards/README.md
+++ b/src/cards/README.md
@@ -17,13 +17,28 @@ dispatch, the "Add card" menu, layout-import validation, the live-redraw set,
 2. **Write the module.** Create `./<kind>.ts` exporting a
    `CardDefinition<"<kind>">`: its `render`, optional `renderEditor`, one or more
    `templates`, `liveness`, and `cloneConfig` if it has nested config.
-3. **Register it.** Add the kind to `CARD_DEFINITIONS` in `index.ts` and append
-   its template id(s) to `TEMPLATE_MENU_ORDER`. (A unit test asserts the menu
-   order covers every template exactly once.)
+3. **Register it.** Add the kind to `CARD_DEFINITIONS` in `index.ts` and put its
+   template id(s) into a category in `TEMPLATE_MENU_GROUPS`. (A unit test
+   asserts the groups cover every template exactly once.)
 4. **Add locale strings.** In `../locales/en.ts`: `editors.kinds.<kind>` (type
-   dropdown label), `templates.<templateId>` (add-menu label), and any
-   `cards.<kind>` render-time strings. Every other locale is compile-checked
-   against `en`, so tsc lists what each is missing.
+   dropdown label), `templates.<templateId>` (picker name),
+   `templateDescriptions.<templateId>` (the one-liner under it, also searched),
+   and any `cards.<kind>` render-time strings. Every other locale is
+   compile-checked against `en`, so tsc lists what each is missing. (A unit test
+   asserts every template has both a name and a description.)
+
+## Cards that depend on another plugin
+
+Declare a `requires` on the template — a display name, the community plugin id
+when there is one, and a `satisfied(app)` probe. The card is offered in the
+picker **either way**; `requires` only decides whether it is badged *Needs X*
+and whether adding it shows the "install X" notice. This replaced an
+`available()` predicate that hid the template entirely, which meant a card
+nobody could discover until they already had its dependency.
+
+The corollary is that a card with a `requires` must render something useful
+without it — every one of them shows an `emptyState` naming the plugin — and its
+editor should say the same, as `gitEditor` does.
 
 Steps 1, 3 (the record), and 4 are compiler-enforced.
 

--- a/src/cards/datacore.ts
+++ b/src/cards/datacore.ts
@@ -1,6 +1,7 @@
 import { Component, setIcon, Setting } from "obsidian";
 import { emptyState, wireMarkdownLinks } from "../cardbodies";
 import {
+	DATACORE_PLUGIN_ID,
 	datacoreQueryError,
 	datacoreQueryScript,
 	getDatacoreApi,
@@ -187,8 +188,9 @@ export function datacoreEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 	});
 }
 
-/** A Datacore query or script, rendered through the Datacore plugin. Gated on
- * that plugin. */
+/** A Datacore query or script, rendered through the Datacore plugin. Offered
+ * whether or not Datacore is installed — the card prompts for it when it
+ * isn't. */
 export const datacoreCard: CardDefinition<"datacore"> = {
 	kind: "datacore",
 	templates: [
@@ -197,7 +199,11 @@ export const datacoreCard: CardDefinition<"datacore"> = {
 			name: "Datacore query",
 			icon: "database-zap",
 			build: () => ({ kind: "datacore", title: "Datacore", datacore: {}, w: 6, h: 4 }),
-			available: (app) => isDatacoreAvailable(app),
+			requires: {
+				name: "Datacore",
+				pluginId: DATACORE_PLUGIN_ID,
+				satisfied: (app) => isDatacoreAvailable(app),
+			},
 		},
 	],
 	render: (view, card, body, component) => renderDatacore(view, card, body, component),

--- a/src/cards/dataview.ts
+++ b/src/cards/dataview.ts
@@ -1,6 +1,6 @@
 import { Component, Setting } from "obsidian";
 import { emptyState, wireMarkdownLinks } from "../cardbodies";
-import { getDataviewApi, isDataviewAvailable } from "../dataview";
+import { DATAVIEW_PLUGIN_ID, getDataviewApi, isDataviewAvailable } from "../dataview";
 import { t } from "../i18n";
 import { type DashboardCard } from "../types";
 import { type HomeView } from "../view";
@@ -242,7 +242,8 @@ export function dataviewEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 	query.settingEl.addClass("hearth-setting-stacked");
 }
 
-/** A Dataview query, rendered through the Dataview plugin. Gated on that plugin. */
+/** A Dataview query, rendered through the Dataview plugin. Offered whether or
+ * not Dataview is installed — the card prompts for it when it isn't. */
 export const dataviewCard: CardDefinition<"dataview"> = {
 	kind: "dataview",
 	templates: [
@@ -251,7 +252,11 @@ export const dataviewCard: CardDefinition<"dataview"> = {
 			name: "Dataview query",
 			icon: "database",
 			build: () => ({ kind: "dataview", title: "Dataview", dataview: {}, w: 6, h: 4 }),
-			available: (app) => isDataviewAvailable(app),
+			requires: {
+				name: "Dataview",
+				pluginId: DATAVIEW_PLUGIN_ID,
+				satisfied: (app) => isDataviewAvailable(app),
+			},
 		},
 	],
 	render: (view, card, body, component) => renderDataview(view, card, body, component),

--- a/src/cards/definition.ts
+++ b/src/cards/definition.ts
@@ -16,6 +16,44 @@ import type { CardSettingsOptions } from "../editors";
  * registering it, and adding locale strings; nothing else.
  */
 
+/**
+ * Something a card needs before it can show anything — a community plugin, or
+ * an Obsidian internal the card is built on.
+ *
+ * This used to be a plain `available()` predicate that *hid* the template until
+ * the dependency was there, which made a third of the catalogue invisible: a
+ * user with no Dataview never learned the Dataview card exists, and "why does
+ * my friend have a Git card?" was unanswerable from inside Hearth. Every card
+ * with a requirement already renders its own "install X" prompt when the
+ * dependency is missing, so the picker now offers all of them and marks the
+ * unmet ones instead.
+ */
+export interface CardRequirement {
+	/** Display name of the dependency, e.g. "Dataview". */
+	name: string;
+	/** Community plugin id, when the dependency is one — the picker offers a
+	 * one-click jump to it in Obsidian's plugin browser. */
+	pluginId?: string;
+	/** Whether the dependency is usable right now. */
+	satisfied: (app: App) => boolean;
+}
+
+/**
+ * How the "Add card" picker groups templates. The catalogue passed ~30 entries
+ * some time ago, which is more than a flat list can carry; the picker shows one
+ * section per category, in `CARD_CATEGORIES` order.
+ *
+ * Ids key `t().cardPicker.categories`, so a missing translation is a build
+ * error rather than an empty heading.
+ */
+export type CardCategory =
+	| "notes"
+	| "planning"
+	| "vault"
+	| "tools"
+	| "integrations"
+	| "fun";
+
 /** One entry in the "Add card" picker. A kind may offer several (embed has
  * five: note / image / base / excalidraw / canvas). */
 export interface CardTemplateDef {
@@ -27,9 +65,9 @@ export interface CardTemplateDef {
 	icon: string;
 	/** Builds the card content/size (id and coordinates are assigned later). */
 	build: () => Omit<DashboardCard, "id" | "x" | "y">;
-	/** When set, the template is only offered if this returns true — used to
-	 * hide cards that depend on a community plugin until it is available. */
-	available?: (app: App) => boolean;
+	/** What the card depends on, when it depends on anything. The template is
+	 * offered either way; the picker badges it while unmet. */
+	requires?: CardRequirement;
 }
 
 /**

--- a/src/cards/git.ts
+++ b/src/cards/git.ts
@@ -3,6 +3,7 @@ import { emptyState, moment } from "../cardbodies";
 import { addResetButton, moveItem } from "../editors";
 import {
 	GIT_ACTION_DEFS,
+	GIT_PLUGIN_ID,
 	GIT_ACTION_STYLES,
 	GIT_ACTIONS,
 	GIT_COMMIT_SCOPES,
@@ -732,7 +733,11 @@ export const gitCard: CardDefinition<"git"> = {
 			name: "Git",
 			icon: "git-branch",
 			build: () => ({ kind: "git", title: "Git", git: {}, w: 4, h: 4 }),
-			available: (app) => isGitAvailable(app),
+			requires: {
+				name: "Git",
+				pluginId: GIT_PLUGIN_ID,
+				satisfied: (app) => isGitAvailable(app),
+			},
 		},
 	],
 	render: (view, card, body, component) => renderGit(view, card, body, component),

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -1,5 +1,11 @@
+import type { App } from "obsidian";
 import type { CardKind, DashboardCard } from "../types";
-import type { CardDefinition, CardTemplateDef } from "./definition";
+import type {
+	CardCategory,
+	CardDefinition,
+	CardRequirement,
+	CardTemplateDef,
+} from "./definition";
 import { t } from "../i18n";
 
 import { embedCard } from "./embed";
@@ -28,10 +34,12 @@ import { leafCard } from "./leaf";
 import { petCard } from "./pet";
 
 export type {
+	CardCategory,
 	CardDefinition,
-	CardTemplateDef,
 	CardEditorContext,
 	CardLiveness,
+	CardRequirement,
+	CardTemplateDef,
 } from "./definition";
 
 /**
@@ -93,42 +101,38 @@ export function cardDefinition(card: DashboardCard): CardDefinition {
 }
 
 /**
- * The order the "Add card" picker offers templates in. Kept explicit because it
- * does not match `CardKind` order (e.g. `text` sits late in the menu) and
- * several templates can map to one kind (embed offers five). The unit test in
- * test/cards-registry.test.ts asserts this covers every registered template id
- * exactly once.
+ * How the "Add card" picker groups and orders its templates.
+ *
+ * Kept explicit — and here rather than on each template — because the grouping
+ * is editorial: it is the one place you can see the whole catalogue at once and
+ * judge whether the sections still balance. It does not match `CardKind` order,
+ * and several templates can map to one kind (embed offers five). The unit test
+ * in test/cards-registry.test.ts asserts the groups cover every registered
+ * template id exactly once.
  */
-export const TEMPLATE_MENU_ORDER: string[] = [
-	"note",
-	"image",
-	"base",
-	"excalidraw",
-	"canvas",
-	"daily",
-	"web",
-	"bookmarks",
-	"favorites",
-	"recent",
-	"links",
-	"commands",
-	"clock",
-	"tasks",
-	"calendar",
-	"stats",
-	"search",
-	"heatmap",
-	"text",
-	"calculator",
-	"dataview",
-	"datacore",
-	"rss",
-	"jira",
-	"weather",
-	"git",
-	"leaf",
-	"pet",
+export const TEMPLATE_MENU_GROUPS: { category: CardCategory; templates: string[] }[] = [
+	{
+		category: "notes",
+		templates: ["note", "daily", "image", "canvas", "excalidraw", "base", "recent", "favorites", "bookmarks"],
+	},
+	{ category: "planning", templates: ["tasks", "calendar", "clock"] },
+	{ category: "vault", templates: ["search", "stats", "heatmap"] },
+	{ category: "tools", templates: ["links", "commands", "text", "calculator", "web"] },
+	{ category: "integrations", templates: ["dataview", "datacore", "git", "jira", "rss", "weather", "leaf"] },
+	{ category: "fun", templates: ["pet"] },
 ];
+
+/** The categories, in picker order. */
+export const CARD_CATEGORIES: CardCategory[] = TEMPLATE_MENU_GROUPS.map((g) => g.category);
+
+/** Every template id, flattened in picker order. */
+export const TEMPLATE_MENU_ORDER: string[] = TEMPLATE_MENU_GROUPS.flatMap((g) => g.templates);
+
+/** The category a template belongs to, or null for an id in no group (which
+ * the registry test makes impossible). */
+export function templateCategory(id: string): CardCategory | null {
+	return TEMPLATE_MENU_GROUPS.find((g) => g.templates.includes(id))?.category ?? null;
+}
 
 const TEMPLATES_BY_ID = new Map<string, CardTemplateDef>();
 for (const def of Object.values(CARD_DEFINITIONS)) {
@@ -147,6 +151,29 @@ export const CARD_TEMPLATES: CardTemplateDef[] = TEMPLATE_MENU_ORDER.map((id) =>
 export function templateName(template: CardTemplateDef): string {
 	const names = t().templates as Record<string, string>;
 	return names[template.id] ?? template.name;
+}
+
+/** The template's one-line description for the picker, or "" if a locale has
+ * none (the picker then simply shows the name on its own). */
+export function templateDescription(template: CardTemplateDef): string {
+	const descriptions = t().templateDescriptions as Record<string, string>;
+	return descriptions[template.id] ?? "";
+}
+
+/** The template's unmet dependency, or null when it has none or it is
+ * satisfied. Never throws: every `satisfied` probe reads Obsidian internals,
+ * and this runs while the picker is being built. */
+export function unmetRequirement(
+	app: App,
+	template: CardTemplateDef,
+): CardRequirement | null {
+	const requirement = template.requires;
+	if (!requirement) return null;
+	try {
+		return requirement.satisfied(app) ? null : requirement;
+	} catch {
+		return requirement;
+	}
 }
 
 /** Build a fresh card from a template (id and placeholder coordinates assigned;

--- a/src/cards/leaf.ts
+++ b/src/cards/leaf.ts
@@ -179,7 +179,13 @@ export const leafCard: CardDefinition<"leaf"> = {
 			name: "Plugin view (beta)",
 			icon: "layout-panel-left",
 			build: () => ({ kind: "leaf", title: "Plugin view", leafView: {}, w: 5, h: 4 }),
-			available: (app) => isLeafViewAvailable(app),
+			// Not a plugin dependency: the card needs Obsidian's view registry,
+			// which a future version could move out of reach. No pluginId, so the
+			// picker badges it without offering an install link.
+			requires: {
+				name: "Hostable side-panel views",
+				satisfied: (app) => isLeafViewAvailable(app),
+			},
 		},
 	],
 	render: (view, card, body, component) => renderLeaf(view, card, body, component),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,7 +1,6 @@
 import {
 	Component,
 	debounce,
-	Menu,
 	setIcon,
 	type TAbstractFile,
 } from "obsidian";
@@ -15,13 +14,8 @@ import {
 	type VaultEventHub,
 	watchedCardReactsToKind,
 } from "./cardevents";
-import {
-	CARD_TEMPLATES,
-	cardDefinition,
-	cardFromTemplate,
-	cloneCard,
-	templateName,
-} from "./cards";
+import { cardDefinition, cardFromTemplate, cloneCard } from "./cards";
+import { openCardPicker } from "./cardpicker";
 import { CardSettingsModal } from "./editors";
 import {
 	activeCards,
@@ -420,34 +414,26 @@ function renderToolbar(view: HomeView, container: HTMLElement): void {
 		setIcon(add.createSpan("hearth-tool-icon"), "plus");
 		add.createSpan({ cls: "hearth-tool-label", text: t().dashboard.addCard });
 		add.setAttribute("aria-label", t().dashboard.addCardAria);
-		add.addEventListener("click", (evt) => {
-			const menu = new Menu();
-			for (const template of CARD_TEMPLATES) {
-				// Skip plugin-gated templates (e.g. Dataview) unless available.
-				if (template.available && !template.available(view.app)) continue;
-				menu.addItem((item) =>
-					item
-						.setTitle(templateName(template))
-						.setIcon(template.icon)
-						.onClick(() => {
-							const s = view.plugin.settings;
-							const card = cardFromTemplate(template);
-							// Place the new card into a free slot in the current layout so
-							// it never shifts the cards already on the board (placeFreeform).
-							placeFreeform(
-								card,
-								renderCards(s),
-								effectiveMaxWidth(s),
-								effectiveColumns(s),
-								GRID_GAP,
-								effectiveRowHeight(s) || ROW_HEIGHT,
-							);
-							activeCards(s).push(card);
-							persistAndRender(view);
-						}),
-				);
-			}
-			menu.showAtMouseEvent(evt);
+		add.addEventListener("click", () => {
+			openCardPicker(view.app, {
+				hearthVersion: view.plugin.manifest.version,
+				onChoose: (template) => {
+					const s = view.plugin.settings;
+					const card = cardFromTemplate(template);
+					// Place the new card into a free slot in the current layout so
+					// it never shifts the cards already on the board (placeFreeform).
+					placeFreeform(
+						card,
+						renderCards(s),
+						effectiveMaxWidth(s),
+						effectiveColumns(s),
+						GRID_GAP,
+						effectiveRowHeight(s) || ROW_HEIGHT,
+					);
+					activeCards(s).push(card);
+					persistAndRender(view);
+				},
+			});
 		});
 
 		// Toggle the per-card headers (title input + actions) off so each

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -2252,6 +2252,79 @@ export const en = {
 		pet: "Pet",
 	},
 
+	/** One line per template, shown under its name in the add-card picker and
+	 * searched alongside it. Say what the card *shows* — the name already says
+	 * what it is called. */
+	templateDescriptions: {
+		note: "Any note, rendered live on the board",
+		image: "A picture from the vault, edge to edge",
+		base: "A .base file, rendered by Obsidian's Bases",
+		excalidraw: "An Excalidraw drawing with native pan and zoom",
+		canvas: "A canvas you can pan around in place",
+		daily: "Always today's note, created on first click",
+		web: "A web page in an iframe, refreshed on a timer",
+		bookmarks: "Your Obsidian bookmarks, one click away",
+		favorites: "The notes you starred in Hearth",
+		recent: "The files you opened most recently",
+		links: "A launchpad of links, notes and folders",
+		commands: "Buttons that run Obsidian commands",
+		clock: "The time, the date and a greeting",
+		tasks: "Checkboxes from your vault, as a list or a board",
+		calendar: "A month at a glance, with your notes on it",
+		stats: "Note, word and file counts for the vault",
+		search: "A saved query, kept live",
+		heatmap: "A year of vault activity, day by day",
+		text: "A scratchpad that lives on the dashboard",
+		calculator: "Sums, unit conversion and exchange rates",
+		dataview: "A DQL or DataviewJS query, rendered by Dataview",
+		datacore: "A Datacore query or script",
+		rss: "Headlines from the feeds you follow",
+		jira: "Issues from a Jira filter or JQL search",
+		weather: "The forecast for a place you pick",
+		git: "Repository status, with commit, pull and push",
+		leaf: "Another plugin's side panel, hosted in a card",
+		pet: "A small companion that lives on your board",
+	},
+
+	// ---- Add-card picker -----------------------------------------------
+	cardPicker: {
+		title: "Add a card",
+		searchPlaceholder: "Search cards…",
+		allCards: "All cards",
+		noMatches: "No card matches that.",
+		/** Badge on a card whose plugin (or other dependency) is missing. */
+		requires: (name: string) => `Needs ${name}`,
+		missingNotice: (name: string) =>
+			`${name} isn't available — the card will show a prompt until it is.`,
+		installLink: (name: string) => `Install ${name}`,
+		categories: {
+			notes: "Notes & files",
+			planning: "Planning",
+			vault: "Vault insight",
+			tools: "Tools",
+			integrations: "Integrations",
+			fun: "Fun",
+		},
+		request: {
+			railLabel: "Request a card",
+			heading: "Request a card",
+			intro:
+				"Missing something? Describe the card you wish Hearth had — what it " +
+				"should show and where its data would come from.",
+			footPrompt: "Not what you were looking for?",
+			footLink: "Request a card",
+			githubTitle: "Open a GitHub issue",
+			githubDesc:
+				"Public, searchable, and the best place to discuss the idea. Needs a GitHub account.",
+			githubAction: "Open GitHub",
+			emailTitle: "Send an email",
+			emailDesc: "Straight to the maintainer, if you'd rather not use GitHub. Opens your mail app.",
+			emailAction: "Open email",
+			prefilledNote:
+				"Both open pre-filled with a few prompts and your Hearth and Obsidian versions — edit anything before sending.",
+		},
+	},
+
 	// ---- File-type filter labels ---------------------------------------
 	fileTypes: {
 		folders: "Folders",

--- a/styles.css
+++ b/styles.css
@@ -7852,3 +7852,399 @@ body.hearth-dv-resizing {
 		opacity: 0.7;
 	}
 }
+
+/* ── Add-card picker ───────────────────────────────────────────────────
+   The card catalogue outgrew a dropdown: ~30 templates in one column, with
+   nothing but a name each. This is a browsable modal instead — a category
+   rail down the side, a searchable grid of described tiles, and a last rail
+   entry for requesting a card that doesn't exist yet.
+
+   Height is a flex chain (frame → content → results), not a `vh` cap: the
+   modal frame already knows how tall it may be — the whole screen on a phone
+   — so the results column takes what's left and scrolls inside it. */
+.hearth-card-picker-modal {
+	display: flex;
+	flex-direction: column;
+	width: min(860px, 94vw);
+	max-width: min(860px, 94vw);
+}
+
+.hearth-card-picker.hearth-card-picker {
+	display: flex;
+	flex-direction: column;
+	/* min-height: 0 at every step, or a flex item refuses to shrink below its
+	   content and the scroll never engages. */
+	min-height: 0;
+	flex: 1 1 auto;
+	max-height: min(66vh, 640px);
+}
+
+/* ---- Search field ---- */
+.hearth-picker-search {
+	flex: none;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 0 10px;
+	margin-bottom: 12px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	background: var(--background-modifier-form-field);
+}
+
+.hearth-picker-search:focus-within {
+	border-color: var(--interactive-accent);
+}
+
+.hearth-picker-search-icon {
+	display: inline-flex;
+	color: var(--text-muted);
+	flex: none;
+}
+
+/* The field is the box's whole interior — its own border and background would
+   draw a second frame inside the first. */
+.hearth-picker-search-input {
+	flex: 1 1 auto;
+	min-width: 0;
+	padding: 8px 0;
+	border: none;
+	background: transparent;
+	box-shadow: none;
+	font-size: var(--font-ui-medium);
+	color: var(--text-normal);
+}
+
+.hearth-picker-search-input:focus {
+	box-shadow: none;
+}
+
+/* ---- Rail + results ---- */
+.hearth-picker-body {
+	display: flex;
+	gap: 16px;
+	min-height: 0;
+	flex: 1 1 auto;
+}
+
+.hearth-picker-rail {
+	flex: none;
+	width: 168px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	overflow-y: auto;
+	padding-right: 4px;
+	border-right: 1px solid var(--background-modifier-border);
+}
+
+.hearth-picker-rail-btn {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	padding: 6px 10px;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	box-shadow: none;
+	color: var(--text-muted);
+	font-size: var(--font-ui-small);
+	text-align: left;
+	cursor: pointer;
+}
+
+.hearth-picker-rail-btn:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.hearth-picker-rail-btn.is-active {
+	background: var(--background-modifier-active-hover, var(--background-modifier-hover));
+	color: var(--text-normal);
+	font-weight: 600;
+}
+
+.hearth-picker-rail-icon {
+	display: inline-flex;
+	flex: none;
+}
+
+.hearth-picker-rail-icon .svg-icon {
+	width: 16px;
+	height: 16px;
+}
+
+.hearth-picker-rail-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.hearth-picker-rail-sep {
+	height: 1px;
+	margin: 8px 10px;
+	background: var(--background-modifier-border);
+}
+
+.hearth-picker-rail-btn.is-request {
+	color: var(--text-accent);
+}
+
+.hearth-picker-results {
+	flex: 1 1 auto;
+	min-width: 0;
+	min-height: 0;
+	overflow-y: auto;
+	/* Room for the scrollbar so tiles don't run under it. */
+	padding-right: 6px;
+}
+
+.hearth-picker-section {
+	font-size: var(--font-ui-smaller);
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--text-muted);
+	margin: 4px 0 8px;
+}
+
+.hearth-picker-section:not(:first-child) {
+	margin-top: 20px;
+}
+
+/* auto-fill, not auto-fit: a category with one card (Fun) keeps a card-sized
+   tile instead of stretching it across the whole row. */
+.hearth-picker-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+	gap: 8px;
+}
+
+/* ---- One card tile ---- */
+.hearth-card-tile {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	width: 100%;
+	height: auto;
+	padding: 10px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	background: var(--background-primary);
+	box-shadow: none;
+	text-align: left;
+	cursor: pointer;
+}
+
+.hearth-card-tile:hover {
+	background: var(--background-modifier-hover);
+	border-color: var(--background-modifier-border-hover);
+}
+
+.hearth-card-tile:focus-visible {
+	outline: 2px solid var(--interactive-accent);
+	outline-offset: 1px;
+}
+
+.hearth-card-tile-icon {
+	display: inline-flex;
+	flex: none;
+	margin-top: 1px;
+	color: var(--text-accent);
+}
+
+.hearth-card-tile-text {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.hearth-card-tile-name {
+	font-weight: 600;
+	color: var(--text-normal);
+	line-height: 1.3;
+}
+
+.hearth-card-tile-desc {
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+	line-height: 1.35;
+	white-space: normal;
+}
+
+/* A missing dependency is a footnote, not a barrier: the card can still be
+   added and explains itself in place once it's on the board. */
+.hearth-card-tile-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	margin-top: 4px;
+	font-size: var(--font-ui-smaller);
+	color: var(--text-faint);
+}
+
+.hearth-card-tile-badge-icon {
+	display: inline-flex;
+}
+
+.hearth-card-tile-badge-icon .svg-icon {
+	width: 12px;
+	height: 12px;
+}
+
+.hearth-card-tile.is-unmet .hearth-card-tile-icon {
+	color: var(--text-muted);
+}
+
+/* ---- Empty result & the footer prompt ---- */
+.hearth-picker-empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 10px;
+	padding: 48px 16px;
+	color: var(--text-muted);
+	text-align: center;
+}
+
+.hearth-picker-empty-icon {
+	display: inline-flex;
+	color: var(--text-faint);
+}
+
+.hearth-picker-empty-icon .svg-icon {
+	width: 28px;
+	height: 28px;
+}
+
+.hearth-picker-foot {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	flex-wrap: wrap;
+	margin-top: 24px;
+	padding-top: 14px;
+	border-top: 1px solid var(--background-modifier-border);
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+}
+
+.hearth-picker-foot-link {
+	padding: 0;
+	border: none;
+	background: transparent;
+	box-shadow: none;
+	color: var(--text-accent);
+	font-size: inherit;
+	cursor: pointer;
+	text-decoration: underline;
+}
+
+/* ---- Request a card ---- */
+.hearth-picker-request-intro {
+	margin-bottom: 14px;
+	color: var(--text-muted);
+	line-height: 1.45;
+}
+
+.hearth-picker-request-option {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px;
+	margin-bottom: 8px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+}
+
+.hearth-picker-request-icon {
+	display: inline-flex;
+	flex: none;
+	color: var(--text-accent);
+}
+
+.hearth-picker-request-icon .svg-icon {
+	width: 20px;
+	height: 20px;
+}
+
+.hearth-picker-request-text {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.hearth-picker-request-title {
+	font-weight: 600;
+	color: var(--text-normal);
+}
+
+.hearth-picker-request-desc {
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+	line-height: 1.35;
+	overflow-wrap: anywhere;
+}
+
+.hearth-picker-request-option .mod-cta {
+	flex: none;
+}
+
+.hearth-picker-request-note {
+	margin-top: 12px;
+	font-size: var(--font-ui-smaller);
+	color: var(--text-faint);
+	line-height: 1.4;
+}
+
+/* On a phone the rail becomes a scrolling chip row above the grid: 168px of
+   sidebar would leave the tiles nowhere to live. */
+@media (max-width: 620px) {
+	.hearth-picker-body {
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.hearth-picker-rail {
+		width: 100%;
+		flex-direction: row;
+		gap: 6px;
+		overflow-x: auto;
+		overflow-y: hidden;
+		padding: 0 0 8px;
+		border-right: none;
+		border-bottom: 1px solid var(--background-modifier-border);
+	}
+
+	.hearth-picker-rail-btn {
+		width: auto;
+		flex: none;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 999px;
+		white-space: nowrap;
+	}
+
+	.hearth-picker-rail-sep {
+		display: none;
+	}
+
+	.hearth-picker-grid {
+		grid-template-columns: 1fr;
+	}
+
+	/* Grid, not flex-wrap: a wrapping flex line breaks before it shrinks, which
+	   put the icon, the text and the button on three lines of their own. Here
+	   the icon keeps the text beside it and only the button drops. */
+	.hearth-picker-request-option {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		align-items: start;
+		row-gap: 10px;
+	}
+
+	.hearth-picker-request-option .mod-cta {
+		grid-column: 1 / -1;
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -7938,9 +7938,12 @@ body.hearth-dv-resizing {
 	border-right: 1px solid var(--background-modifier-border);
 }
 
+/* Same reason as .hearth-card-tile: these are buttons, so left alignment has
+   to be asked for. */
 .hearth-picker-rail-btn {
 	display: flex;
 	align-items: center;
+	justify-content: flex-start;
 	gap: 8px;
 	width: 100%;
 	padding: 6px 10px;
@@ -8022,9 +8025,14 @@ body.hearth-dv-resizing {
 }
 
 /* ---- One card tile ---- */
+/* justify-content and text-align are spelled out because Obsidian's own
+   `button` rules centre both: without them a tile whose name and description
+   are narrower than its column had its whole icon-and-text block pushed to the
+   middle, so tiles in the same row started at different offsets. */
 .hearth-card-tile {
 	display: flex;
 	align-items: flex-start;
+	justify-content: flex-start;
 	gap: 10px;
 	width: 100%;
 	height: auto;

--- a/styles.css
+++ b/styles.css
@@ -7876,7 +7876,12 @@ body.hearth-dv-resizing {
 	   content and the scroll never engages. */
 	min-height: 0;
 	flex: 1 1 auto;
-	max-height: min(66vh, 640px);
+	/* A fixed height, not a max: with a max, every category sized the modal to
+	   its own content, so clicking from "Notes & files" (nine tiles) to "Fun"
+	   (one) collapsed the dialog and moved the rail out from under the pointer.
+	   Pinning the height keeps the frame still and lets the results column
+	   scroll inside it. */
+	height: min(66vh, 640px);
 }
 
 /* ---- Search field ---- */

--- a/test/cardrequest.test.ts
+++ b/test/cardrequest.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+	CARD_REQUEST_EMAIL,
+	CARD_REQUEST_TITLE,
+	cardRequestGithubUrl,
+	cardRequestMailtoUrl,
+	type CardRequestContext,
+} from "../src/cardrequest";
+
+/**
+ * The "Request a card" links at the bottom of the add-card picker.
+ *
+ * Both are one-shot: the user clicks, a composer opens, and whatever is (or
+ * isn't) prefilled is what the maintainer receives. There is no error to
+ * observe if a prefill silently stops landing — which is exactly what happens
+ * when a field id in `feature_request.yml` is renamed — so the ids are pinned
+ * against the form file itself here.
+ */
+
+const ctx: CardRequestContext = {
+	hearthVersion: "1.18.0",
+	obsidianVersion: "1.8.7",
+	platform: "Desktop",
+};
+
+describe("cardRequestGithubUrl", () => {
+	it("opens the feature-request form on the Hearth repository", () => {
+		const url = new URL(cardRequestGithubUrl(ctx));
+		expect(url.origin + url.pathname).toBe("https://github.com/ondreu/hearth/issues/new");
+		expect(url.searchParams.get("template")).toBe("feature_request.yml");
+		expect(url.searchParams.get("labels")).toBe("enhancement");
+		expect(url.searchParams.get("title")).toBe(CARD_REQUEST_TITLE);
+	});
+
+	it("prefills field ids the issue form actually declares", () => {
+		const form = readFileSync(".github/ISSUE_TEMPLATE/feature_request.yml", "utf8");
+		const declared = [...form.matchAll(/^\s+id:\s*(\S+)/gm)].map((m) => m[1]);
+		const url = new URL(cardRequestGithubUrl(ctx));
+		const prefilled = [...url.searchParams.keys()].filter(
+			(key) => !["template", "labels", "title"].includes(key),
+		);
+		expect(prefilled.length).toBeGreaterThan(0);
+		for (const key of prefilled) expect(declared).toContain(key);
+	});
+
+	it("stamps the environment into the request", () => {
+		const idea = new URL(cardRequestGithubUrl(ctx)).searchParams.get("idea") ?? "";
+		expect(idea).toContain("Hearth 1.18.0");
+		expect(idea).toContain("Obsidian 1.8.7");
+		expect(idea).toContain("Desktop");
+	});
+});
+
+describe("cardRequestMailtoUrl", () => {
+	it("addresses the maintainer with a subject and a body", () => {
+		const url = cardRequestMailtoUrl(ctx);
+		expect(url.startsWith(`mailto:${CARD_REQUEST_EMAIL}?`)).toBe(true);
+		const params = new URLSearchParams(url.slice(url.indexOf("?") + 1));
+		expect(params.get("subject")).toBe(CARD_REQUEST_TITLE);
+		expect(params.get("body")).toContain("I'd like to suggest a new card for Hearth.");
+		expect(params.get("body")).toContain("Hearth 1.18.0 · Obsidian 1.8.7 · Desktop");
+	});
+
+	// Mail clients differ on whether they decode "+" in a body; several paste it
+	// through as a literal plus, turning every space in the template into one.
+	it("percent-encodes spaces rather than writing +", () => {
+		const url = cardRequestMailtoUrl(ctx);
+		expect(url).toContain("%20");
+		expect(url.slice(url.indexOf("?"))).not.toContain("+");
+	});
+});

--- a/test/cards-registry.test.ts
+++ b/test/cards-registry.test.ts
@@ -2,21 +2,26 @@ import { describe, expect, it } from "vitest";
 // The assertions below are the frozen "before" behavior and must not change
 // across the refactor; only these import paths moved to the registry barrel.
 import {
+	CARD_CATEGORIES,
 	CARD_DEFINITIONS,
 	CARD_TEMPLATES,
 	TEMPLATE_MENU_ORDER,
 	cardDefinition,
 	cloneCard,
+	templateCategory,
+	templateDescription,
+	templateName,
+	unmetRequirement,
 } from "../src/cards";
+import type { App } from "obsidian";
 import type { DashboardCard } from "../src/types";
 
 /**
  * Characterization tests for the card registry refactor (issue #103).
  *
- * They pin two behaviors that the refactor dismantles and must reproduce byte
- * for byte:
- *   1. the "Add card" menu — every template's id, icon and build() output, in
- *      the exact order they are offered today;
+ * They pin two behaviors:
+ *   1. the "Add card" picker — every template's id, icon, category, dependency
+ *      and build() output, in the exact order they are offered;
  *   2. cloneCard() deep-clones every nested config array/object, so mutating a
  *      copy never reaches the original. (The RSS config is the one addition
  *      over the old cloner, which missed it — a clone shared `rss.sources`
@@ -24,41 +29,58 @@ import type { DashboardCard } from "../src/types";
  */
 
 describe("CARD_TEMPLATES (add-card menu)", () => {
-	it("offers the same templates, in the same order, with the same build output", () => {
+	it("offers every template, grouped in picker order, with the same build output", () => {
 		const snapshot = CARD_TEMPLATES.map((tpl) => ({
 			id: tpl.id,
 			icon: tpl.icon,
-			gated: typeof tpl.available === "function",
+			category: templateCategory(tpl.id),
+			requires: tpl.requires?.name ?? null,
 			build: tpl.build(),
 		}));
 		expect(snapshot).toEqual([
-			{ id: "note", icon: "file-text", gated: false, build: { kind: "embed", title: "Note", target: "", w: 6, h: 3 } },
-			{ id: "image", icon: "image", gated: false, build: { kind: "embed", title: "Image", target: "", w: 4, h: 3 } },
-			{ id: "base", icon: "database", gated: false, build: { kind: "embed", title: "Base", target: "", w: 6, h: 4 } },
-			{ id: "excalidraw", icon: "pen-tool", gated: false, build: { kind: "embed", title: "Drawing", target: "", w: 6, h: 4 } },
-			{ id: "canvas", icon: "layout-dashboard", gated: false, build: { kind: "embed", title: "Canvas", target: "", w: 6, h: 4 } },
-			{ id: "daily", icon: "calendar", gated: false, build: { kind: "daily", w: 6, h: 4 } },
-			{ id: "web", icon: "globe", gated: false, build: { kind: "web", title: "Web", url: "", w: 6, h: 4 } },
-			{ id: "bookmarks", icon: "bookmark", gated: false, build: { kind: "bookmarks", title: "Bookmarks", w: 4, h: 3 } },
-			{ id: "favorites", icon: "star", gated: false, build: { kind: "favorites", title: "Favorites", w: 4, h: 3 } },
-			{ id: "recent", icon: "history", gated: false, build: { kind: "recent", title: "Recent", count: 8, w: 4, h: 3 } },
-			{ id: "links", icon: "layout-grid", gated: false, build: { kind: "links", title: "Links", links: [], w: 6, h: 2 } },
-			{ id: "commands", icon: "terminal-square", gated: false, build: { kind: "commands", title: "Commands", commands: [], w: 6, h: 2 } },
-			{ id: "clock", icon: "clock", gated: false, build: { kind: "clock", title: "", w: 4, h: 2 } },
-			{ id: "tasks", icon: "list-todo", gated: false, build: { kind: "tasks", title: "Tasks", tasks: {}, w: 4, h: 4 } },
-			{ id: "calendar", icon: "calendar-days", gated: false, build: { kind: "calendar", title: "Calendar", w: 4, h: 4 } },
-			{ id: "stats", icon: "bar-chart-3", gated: false, build: { kind: "stats", title: "Stats", w: 4, h: 2 } },
-			{ id: "search", icon: "search", gated: false, build: { kind: "search", title: "Query", savedSearch: { query: "" }, w: 4, h: 4 } },
-			{ id: "heatmap", icon: "activity", gated: false, build: { kind: "heatmap", title: "Activity", heatmap: {}, w: 6, h: 3 } },
-			{ id: "text", icon: "pencil", gated: false, build: { kind: "text", title: "Notes", text: "", w: 4, h: 2 } },
-			{ id: "calculator", icon: "calculator", gated: false, build: { kind: "calculator", title: "Calculator", calculator: {}, w: 4, h: 3 } },
-			{ id: "dataview", icon: "database", gated: true, build: { kind: "dataview", title: "Dataview", dataview: {}, w: 6, h: 4 } },
-			{ id: "datacore", icon: "database-zap", gated: true, build: { kind: "datacore", title: "Datacore", datacore: {}, w: 6, h: 4 } },
-			{ id: "rss", icon: "rss", gated: false, build: { kind: "rss", title: "RSS", rss: { sources: [] }, w: 4, h: 5 } },
+			// ---- Notes & files ----
+			{ id: "note", icon: "file-text", category: "notes", requires: null, build: { kind: "embed", title: "Note", target: "", w: 6, h: 3 } },
+			{ id: "daily", icon: "calendar", category: "notes", requires: null, build: { kind: "daily", w: 6, h: 4 } },
+			{ id: "image", icon: "image", category: "notes", requires: null, build: { kind: "embed", title: "Image", target: "", w: 4, h: 3 } },
+			{ id: "canvas", icon: "layout-dashboard", category: "notes", requires: null, build: { kind: "embed", title: "Canvas", target: "", w: 6, h: 4 } },
+			{ id: "excalidraw", icon: "pen-tool", category: "notes", requires: null, build: { kind: "embed", title: "Drawing", target: "", w: 6, h: 4 } },
+			{ id: "base", icon: "database", category: "notes", requires: null, build: { kind: "embed", title: "Base", target: "", w: 6, h: 4 } },
+			{ id: "recent", icon: "history", category: "notes", requires: null, build: { kind: "recent", title: "Recent", count: 8, w: 4, h: 3 } },
+			{ id: "favorites", icon: "star", category: "notes", requires: null, build: { kind: "favorites", title: "Favorites", w: 4, h: 3 } },
+			{ id: "bookmarks", icon: "bookmark", category: "notes", requires: null, build: { kind: "bookmarks", title: "Bookmarks", w: 4, h: 3 } },
+
+			// ---- Planning ----
+			{ id: "tasks", icon: "list-todo", category: "planning", requires: null, build: { kind: "tasks", title: "Tasks", tasks: {}, w: 4, h: 4 } },
+			{ id: "calendar", icon: "calendar-days", category: "planning", requires: null, build: { kind: "calendar", title: "Calendar", w: 4, h: 4 } },
+			{ id: "clock", icon: "clock", category: "planning", requires: null, build: { kind: "clock", title: "", w: 4, h: 2 } },
+
+			// ---- Vault insight ----
+			{ id: "search", icon: "search", category: "vault", requires: null, build: { kind: "search", title: "Query", savedSearch: { query: "" }, w: 4, h: 4 } },
+			{ id: "stats", icon: "bar-chart-3", category: "vault", requires: null, build: { kind: "stats", title: "Stats", w: 4, h: 2 } },
+			{ id: "heatmap", icon: "activity", category: "vault", requires: null, build: { kind: "heatmap", title: "Activity", heatmap: {}, w: 6, h: 3 } },
+
+			// ---- Tools ----
+			{ id: "links", icon: "layout-grid", category: "tools", requires: null, build: { kind: "links", title: "Links", links: [], w: 6, h: 2 } },
+			{ id: "commands", icon: "terminal-square", category: "tools", requires: null, build: { kind: "commands", title: "Commands", commands: [], w: 6, h: 2 } },
+			{ id: "text", icon: "pencil", category: "tools", requires: null, build: { kind: "text", title: "Notes", text: "", w: 4, h: 2 } },
+			{ id: "calculator", icon: "calculator", category: "tools", requires: null, build: { kind: "calculator", title: "Calculator", calculator: {}, w: 4, h: 3 } },
+			{ id: "web", icon: "globe", category: "tools", requires: null, build: { kind: "web", title: "Web", url: "", w: 6, h: 4 } },
+
+			// ---- Integrations ----
+			{ id: "dataview", icon: "database", category: "integrations", requires: "Dataview", build: { kind: "dataview", title: "Dataview", dataview: {}, w: 6, h: 4 } },
+			{ id: "datacore", icon: "database-zap", category: "integrations", requires: "Datacore", build: { kind: "datacore", title: "Datacore", datacore: {}, w: 6, h: 4 } },
+			{
+				id: "git",
+				icon: "git-branch",
+				category: "integrations",
+				requires: "Git",
+				build: { kind: "git", title: "Git", git: {}, w: 4, h: 4 },
+			},
 			{
 				id: "jira",
 				icon: "ticket",
-				gated: false,
+				category: "integrations",
+				requires: null,
 				build: {
 					kind: "jira",
 					title: "Jira",
@@ -73,32 +95,70 @@ describe("CARD_TEMPLATES (add-card menu)", () => {
 					h: 5,
 				},
 			},
+			{ id: "rss", icon: "rss", category: "integrations", requires: null, build: { kind: "rss", title: "RSS", rss: { sources: [] }, w: 4, h: 5 } },
 			{
 				id: "weather",
 				icon: "cloud-sun",
-				gated: false,
+				category: "integrations",
+				requires: null,
 				build: { kind: "weather", title: "Weather", weather: {}, w: 4, h: 3 },
 			},
 			{
-				id: "git",
-				icon: "git-branch",
-				gated: true,
-				build: { kind: "git", title: "Git", git: {}, w: 4, h: 4 },
+				id: "leaf",
+				icon: "layout-panel-left",
+				category: "integrations",
+				requires: "Hostable side-panel views",
+				build: { kind: "leaf", title: "Plugin view", leafView: {}, w: 5, h: 4 },
 			},
-			{ id: "leaf", icon: "layout-panel-left", gated: true, build: { kind: "leaf", title: "Plugin view", leafView: {}, w: 5, h: 4 } },
-			{ id: "pet", icon: "cat", gated: false, build: { kind: "pet", title: "Pet", pet: {}, w: 3, h: 4 } },
+
+			// ---- Fun ----
+			{ id: "pet", icon: "cat", category: "fun", requires: null, build: { kind: "pet", title: "Pet", pet: {}, w: 3, h: 4 } },
 		]);
 	});
 
-	// TEMPLATE_MENU_ORDER is the one enumeration the registry does not
+	// TEMPLATE_MENU_GROUPS is the one enumeration the registry does not
 	// compile-enforce: CARD_TEMPLATES is derived from it, so a preset declared in
-	// a module but missing from the order silently vanishes from the add-card
-	// menu. Pin the round-trip so that omission — or a duplicate id — fails here.
-	it("TEMPLATE_MENU_ORDER covers every registered template id exactly once", () => {
+	// a module but missing from the groups silently vanishes from the picker.
+	// Pin the round-trip so that omission — or a duplicate id — fails here.
+	it("TEMPLATE_MENU_GROUPS covers every registered template id exactly once", () => {
 		const declared = Object.values(CARD_DEFINITIONS)
 			.flatMap((def) => def.templates.map((tpl) => tpl.id))
 			.sort();
 		expect([...TEMPLATE_MENU_ORDER].sort()).toEqual(declared);
+		expect(new Set(TEMPLATE_MENU_ORDER).size).toBe(TEMPLATE_MENU_ORDER.length);
+	});
+
+	// Every card is offered whether or not its dependency is installed (that is
+	// the point of `requires` replacing the old `available` gate), so the picker
+	// must never consult a requirement to decide *whether* to list a template —
+	// only how to badge it.
+	it("offers plugin-backed cards even when the plugin is missing", () => {
+		const app = { plugins: { enabledPlugins: new Set<string>(), plugins: {} } } as unknown as App;
+		for (const id of ["dataview", "datacore", "git"]) {
+			const template = CARD_TEMPLATES.find((tpl) => tpl.id === id);
+			expect(template, id).toBeDefined();
+			expect(unmetRequirement(app, template!)?.name, id).toBeTruthy();
+		}
+	});
+
+	// The picker shows a description under every name and searches on it, so a
+	// template with no matching locale key would read as a blank half-tile.
+	it("has a localized name and description for every template", () => {
+		for (const template of CARD_TEMPLATES) {
+			expect(templateName(template), template.id).toBeTruthy();
+			expect(templateDescription(template), template.id).toBeTruthy();
+		}
+	});
+
+	// Not every category needs to be crowded, but an empty one is a rail entry
+	// that leads to a blank page.
+	it("gives every category at least one template", () => {
+		for (const category of CARD_CATEGORIES) {
+			expect(
+				CARD_TEMPLATES.some((tpl) => templateCategory(tpl.id) === category),
+				category,
+			).toBe(true);
+		}
 	});
 });
 


### PR DESCRIPTION
## What does this PR do?

Two connected changes to how cards get added to a board.

**Every card is always offered.** Dataview, Datacore, Git and the plugin-view card were hidden from the "Add card" menu until their dependency happened to be installed — so a third of the catalogue was invisible to exactly the people who'd want to know it exists. `CardTemplateDef.available()` (the predicate that hid them) becomes `requires`: a display name, the community plugin id, and a `satisfied(app)` probe. It no longer decides *whether* a template is listed — only that it's badged **Needs Dataview** and that adding it shows a notice with a one-click jump to Obsidian's plugin browser. Each of these cards already rendered its own "install X" prompt in place, so nothing about the cards themselves changed.

**The menu becomes a picker.** ~30 bare names in one unsearchable column is past what a `Menu` can carry. `src/cardpicker.ts` replaces it with a modal:

- fuzzy search over names *and* the new one-line descriptions (so "todo" finds Tasks, "iframe" finds the web card), name hits ranked above description hits;
- a category rail — Notes & files, Planning, Vault insight, Tools, Integrations, Fun — derived from the registry's new `TEMPLATE_MENU_GROUPS`, which replaces the flat `TEMPLATE_MENU_ORDER` (still exported, now derived);
- a grid of tiles that each say in one line what the card shows;
- the scope you were last in is where it reopens; Enter takes the top match, arrow keys walk the grid;
- on a phone the rail folds into a scrolling row of chips and the grid to one column.

**Request a card.** The last rail entry, for when you've looked through the whole catalogue and the card you want isn't there. Two routes — a GitHub feature request or an email to the maintainer — both opened pre-filled with prompts about what the card should show and where its data would come from, plus the Hearth and Obsidian versions. The URL builders live in `src/cardrequest.ts` as pure functions. The maintainer's address is never printed on screen; it only exists inside the `mailto:` the button opens.

## Related issue

None — no behaviour outside the add-card flow changes.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [x] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (`npm run lint` and `npm test` too — 576 passing)
- [x] I've tested this in an actual vault

Not vault-tested — no Obsidian in this environment. The picker's layout was checked by rendering its real DOM against `styles.css` in a browser at desktop and phone widths; the logic that is testable without the Obsidian API is unit-tested.

### Tests

- `test/cards-registry.test.ts` — the picker snapshot now pins each template's category and its `requires` name alongside id/icon/`build()`; new cases assert plugin-backed cards are still offered with the plugin absent, that every template has both a localized name and description, and that no category is empty.
- `test/cardrequest.test.ts` (new) — the GitHub URL's prefill keys are checked against the field ids actually declared in `.github/ISSUE_TEMPLATE/feature_request.yml`, so renaming one there fails here instead of silently dropping the prefill; the mailto is checked for `%20` rather than `+` encoding, which several mail clients paste through literally.

### Docs

`README.md` (the picker + always-listed plugin cards), `src/cards/README.md` (registering a template into a category, and the `requires` contract), and the unreleased 2.0.0 `CHANGELOG.md` section — including two existing entries that said the Git and Datacore cards "only appear while the plugin is enabled", which is no longer true.

`eslint.config.mjs` turns `obsidianmd/no-nodejs-modules` off for `test/**` only: the new test reads the issue-form template from disk, and tests never run on a phone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5XxsB3hramTBNZ1knj13p)_