### PR TITLE
Add a search-bar card, with an optional filter row and a seamless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,13 +290,22 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   bar** is the header's search field as a card — the same field, not a lesser
   copy of it, so `#tag`, `key:value` and `>` for commands all work, Omnisearch
   is used when you have routed search to it, body matches and recent files
-  appear as they do above, and the arrow keys walk the results. The **filter
-  row** underneath is optional, and when the field sits low on the board the
-  results open upwards instead of running off the bottom. Turn on **Seamless**
-  and the card stops looking like one: no border, no background, no title row —
-  just the search bar, standing on the board on its own. It still drags,
-  resizes and configures like any other card — while you are arranging, the
-  dashed outline every card gets marks where it is.
+  appear as they do above, and the arrow keys walk the results. When the field
+  sits low on the board the results open upwards instead of running off the
+  bottom.
+
+  **The card is the size control.** The field fills whatever height the card
+  has, so you make the bar chunkier or slimmer by dragging the card's edge in
+  Arrange — no slider, and it starts thicker than the header's. Four things are
+  yours to set: its own **placeholder** (blank keeps the global one), the
+  **filter row** of file-type chips underneath, an optional **button** beside
+  the field — **New note** or **Search online**, the same two the header
+  offers — and **Seamless**.
+
+  **Seamless** is the one to try: the card stops looking like one. No border, no
+  background, no title row — just the search bar, standing on the board on its
+  own. It still drags, resizes and configures like any other card, and while you
+  are arranging, the dashed outline every card gets marks where it is.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,9 +298,11 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   has, so you make the bar chunkier or slimmer by dragging the card's edge in
   Arrange — no slider, and it starts thicker than the header's. Four things are
   yours to set: its own **placeholder** (blank keeps the global one), the
-  **filter row** of file-type chips underneath, an optional **button** beside
-  the field — **New note** or **Search online**, the same two the header
-  offers — and **Seamless**.
+  **filter row** of file-type chips underneath — and, chip by chip, *which* of
+  them this card offers, so a narrow bar can carry the two or three that earn
+  their place rather than every type the vault happens to hold — an optional
+  **button** beside the field (**New note** or **Search online**, the same two
+  the header offers), and **Seamless**.
 
   **Seamless** is the one to try: the card stops looking like one. No border, no
   background, no title row — just the search bar, standing on the board on its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,17 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   and both open pre-filled: a few prompts about what the card should show and
   where its data would come from, plus your Hearth and Obsidian versions. Edit
   anything before you send it.
+- **A search bar you can put anywhere on the board.** **Vault insight → Search
+  bar** is the header's search field as a card — the same field, not a lesser
+  copy of it, so `#tag`, `key:value` and `>` for commands all work, Omnisearch
+  is used when you have routed search to it, body matches and recent files
+  appear as they do above, and the arrow keys walk the results. The **filter
+  row** underneath is optional, and when the field sits low on the board the
+  results open upwards instead of running off the bottom. Turn on **Seamless**
+  and the card stops looking like one: no border, no background, no title row —
+  just the search bar, standing on the board on its own. It still drags,
+  resizes and configures like any other card — while you are arranging, the
+  dashed outline every card gets marks where it is.
 
 ### Fixed
 

--- a/src/cards/definition.ts
+++ b/src/cards/definition.ts
@@ -126,8 +126,11 @@ export interface CardDefinition<K extends CardKind = CardKind> {
 	 * is only primitives. */
 	cloneConfig?(source: DashboardCard, copy: DashboardCard): void;
 	liveness: CardLiveness;
-	/** Extra class on the card root element (links/commands: "is-tile-card"). */
-	cardClass?: string;
+	/** Extra class(es) on the card root element (links/commands: "is-tile-card").
+	 * A function form lets the classes depend on the card's own config — the
+	 * search-bar card drops its frame with "is-seamless" — and may return several
+	 * space-separated classes. Read through `cardClasses()`. */
+	cardClass?: string | ((card: DashboardCard) => string | undefined);
 	/** Post-render header/floating extras, drawn outside arrange mode (embed's
 	 * second-view switcher). */
 	mountExtras?(

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -22,6 +22,7 @@ import { tasksCard } from "./tasks";
 import { calendarCard } from "./calendar";
 import { statsCard } from "./stats";
 import { searchCard } from "./search";
+import { searchbarCard } from "./searchbar";
 import { heatmapCard } from "./heatmap";
 import { calculatorCard } from "./calculator";
 import { dataviewCard } from "./dataview";
@@ -64,6 +65,7 @@ export const CARD_DEFINITIONS: { [K in CardKind]: CardDefinition<K> } = {
 	calendar: calendarCard,
 	stats: statsCard,
 	search: searchCard,
+	searchbar: searchbarCard,
 	heatmap: heatmapCard,
 	calculator: calculatorCard,
 	dataview: dataviewCard,
@@ -116,7 +118,7 @@ export const TEMPLATE_MENU_GROUPS: { category: CardCategory; templates: string[]
 		templates: ["note", "daily", "image", "canvas", "excalidraw", "base", "recent", "favorites", "bookmarks"],
 	},
 	{ category: "planning", templates: ["tasks", "calendar", "clock"] },
-	{ category: "vault", templates: ["search", "stats", "heatmap"] },
+	{ category: "vault", templates: ["search", "searchbar", "stats", "heatmap"] },
 	{ category: "tools", templates: ["links", "commands", "text", "calculator", "web"] },
 	{ category: "integrations", templates: ["dataview", "datacore", "git", "jira", "rss", "weather", "leaf"] },
 	{ category: "fun", templates: ["pet"] },
@@ -185,6 +187,16 @@ export function cardFromTemplate(template: CardTemplateDef): DashboardCard {
 		y: -1,
 		...template.build(),
 	};
+}
+
+/** The extra root classes a card's kind puts on it, resolved against the card
+ * itself (a kind may vary them by config — see `CardDefinition.cardClass`).
+ * Split so a definition can name several; `addClass` rejects a single string
+ * holding spaces. */
+export function cardClasses(card: DashboardCard): string[] {
+	const cls = cardDefinition(card).cardClass;
+	const raw = typeof cls === "function" ? cls(card) : cls;
+	return raw ? raw.split(/\s+/).filter(Boolean) : [];
 }
 
 /** Deep-clone a card with a fresh id, so the copy can be added to a dashboard

--- a/src/cards/searchbar.ts
+++ b/src/cards/searchbar.ts
@@ -1,0 +1,92 @@
+import { Component, Setting } from "obsidian";
+import { t } from "../i18n";
+import { SearchSection } from "../search";
+import { type DashboardCard } from "../types";
+import { type HomeView } from "../view";
+import { type CardDefinition, type CardEditorContext } from "./definition";
+
+
+// ---- Search bar --------------------------------------------------------
+
+/**
+ * A live search field on the board — the same `SearchSection` the header
+ * renders, so it carries every search feature with it (tag/property/`>` command
+ * syntax, Omnisearch routing, body search, recents on focus, keyboard
+ * navigation) rather than reimplementing a second, weaker one.
+ *
+ * Two per-card choices sit on top of it: whether the file-type filter row is
+ * shown, and whether the card keeps its frame. `seamless` drops the frame
+ * entirely (see `cardClass` below), which is how you put a bare search bar
+ * anywhere on the board instead of a card that contains one.
+ */
+export function renderSearchBar(
+	view: HomeView,
+	card: DashboardCard,
+	body: HTMLElement,
+	component: Component,
+): void {
+	const cfg = card.searchBar ?? {};
+	const search = new SearchSection(view);
+	// One positioned wrapper holds the bar, the chip row and the results
+	// overlay, mirroring the header's search column — the overlay is absolutely
+	// positioned against it, so the dropdown lines up with the field's width.
+	const wrap = body.createDiv("hearth-searchbar-card");
+	search.renderBar(wrap);
+	search.renderResultsAndFilters(wrap, wrap, component, { filters: cfg.filters !== false });
+}
+
+
+export function searchBarEditor(ctx: CardEditorContext, containerEl: HTMLElement): void {
+	const cfg = (ctx.card.searchBar ??= {});
+	new Setting(containerEl)
+		.setName(t().editors.searchBar.filters)
+		.setDesc(t().editors.searchBar.filtersDesc)
+		.addToggle((tg) =>
+			tg.setValue(cfg.filters !== false).onChange((v) => {
+				cfg.filters = v ? undefined : false;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			}),
+		);
+	new Setting(containerEl)
+		.setName(t().editors.searchBar.seamless)
+		.setDesc(t().editors.searchBar.seamlessDesc)
+		.addToggle((tg) =>
+			tg.setValue(cfg.seamless === true).onChange((v) => {
+				cfg.seamless = v || undefined;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			}),
+		);
+}
+
+/** A live search field, optionally without any card frame around it. */
+export const searchbarCard: CardDefinition<"searchbar"> = {
+	kind: "searchbar",
+	templates: [
+		{
+			id: "searchbar",
+			name: "Search bar",
+			icon: "text-cursor-input",
+			// Untitled by default: the field explains itself, and a title row above
+			// a bare bar is exactly what the seamless option exists to avoid.
+			build: () => ({ kind: "searchbar", title: "", searchBar: {}, w: 6, h: 2 }),
+		},
+	],
+	render: (view, card, body, component) => renderSearchBar(view, card, body, component),
+	renderEditor: (container, ctx) => searchBarEditor(ctx, container),
+	cloneConfig: (source, copy) => {
+		if (source.searchBar) copy.searchBar = { ...source.searchBar };
+	},
+	// The results overlay has to escape the card box, and a seamless card paints
+	// no surface at all — both are styled off these classes (see styles.css).
+	cardClass: (card) =>
+		card.searchBar?.seamless ? "is-searchbar-card is-seamless" : "is-searchbar-card",
+	// Deliberately not vault-live. The card holds live UI state — the typed
+	// query, the active chip, the open dropdown — and a redraw would throw all
+	// of it away; a background sync landing mid-search would blank the field
+	// under the user's hands. Nothing here goes stale in the meantime either:
+	// results are computed per keystroke, and the chip row (derived from the
+	// file types present in the vault) is rebuilt on the next board render.
+	liveness: { mode: "static" },
+};

--- a/src/cards/searchbar.ts
+++ b/src/cards/searchbar.ts
@@ -1,8 +1,9 @@
 import { Component, Setting } from "obsidian";
+import { FILE_TYPE_GROUPS, fileTypeLabel } from "../filetypes";
 import { createSearchBarButton } from "../header";
 import { t } from "../i18n";
 import { SearchSection } from "../search";
-import { type DashboardCard } from "../types";
+import { type DashboardCard, type SearchBarConfig } from "../types";
 import { type HomeView } from "../view";
 import { type CardDefinition, type CardEditorContext } from "./definition";
 
@@ -41,7 +42,45 @@ export function renderSearchBar(
 	if (cfg.button && cfg.button !== "none") {
 		row.append(createSearchBarButton(view, bar, cfg.button));
 	}
-	search.renderResultsAndFilters(wrap, wrap, component, { filters: cfg.filters === true });
+	search.renderResultsAndFilters(wrap, wrap, component, {
+		filters: cfg.filters === true,
+		hiddenFilters: cfg.hiddenFilters,
+	});
+}
+
+
+/** One toggle per file-type chip, mirroring Settings → Filters but scoped to
+ * this card — so a narrow bar can carry the three chips that earn their place
+ * instead of every type the vault happens to contain. Chips switched off
+ * vault-wide are shown here as off and can't be switched back on: this list
+ * only ever hides more (see SearchSection.detectGroups). */
+function renderFilterTypes(
+	ctx: CardEditorContext,
+	containerEl: HTMLElement,
+	cfg: SearchBarConfig,
+): void {
+	const globallyHidden = new Set(ctx.opts.settings.hiddenFilters);
+	const hidden = new Set(cfg.hiddenFilters ?? []);
+	new Setting(containerEl)
+		.setName(t().editors.searchBar.filterTypes)
+		.setDesc(t().editors.searchBar.filterTypesDesc)
+		.setHeading();
+	for (const group of FILE_TYPE_GROUPS) {
+		const off = globallyHidden.has(group.id);
+		const setting = new Setting(containerEl).setName(fileTypeLabel(group));
+		if (off) setting.setDesc(t().editors.searchBar.filterTypeGlobalOff);
+		setting.addToggle((tg) => {
+			tg.setValue(!off && !hidden.has(group.id));
+			tg.setDisabled(off);
+			tg.onChange((v) => {
+				if (v) hidden.delete(group.id);
+				else hidden.add(group.id);
+				cfg.hiddenFilters = hidden.size ? Array.from(hidden) : undefined;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			});
+		});
+	}
 }
 
 
@@ -68,8 +107,11 @@ export function searchBarEditor(ctx: CardEditorContext, containerEl: HTMLElement
 				cfg.filters = v || undefined;
 				ctx.opts.save();
 				ctx.opts.rerender();
+				// The per-chip toggles below only exist while the row does.
+				ctx.requestRender();
 			}),
 		);
+	if (cfg.filters === true) renderFilterTypes(ctx, containerEl, cfg);
 	new Setting(containerEl)
 		.setName(t().editors.searchBar.button)
 		.setDesc(t().editors.searchBar.buttonDesc)
@@ -119,7 +161,14 @@ export const searchbarCard: CardDefinition<"searchbar"> = {
 	render: (view, card, body, component) => renderSearchBar(view, card, body, component),
 	renderEditor: (container, ctx) => searchBarEditor(ctx, container),
 	cloneConfig: (source, copy) => {
-		if (source.searchBar) copy.searchBar = { ...source.searchBar };
+		if (source.searchBar) {
+			copy.searchBar = { ...source.searchBar };
+			// The hidden-chip list is an array: copy it, or the clone edits the
+			// original's row too.
+			if (source.searchBar.hiddenFilters) {
+				copy.searchBar.hiddenFilters = [...source.searchBar.hiddenFilters];
+			}
+		}
 	},
 	// The results overlay has to escape the card box, and a seamless card paints
 	// no surface at all — both are styled off these classes (see styles.css).

--- a/src/cards/searchbar.ts
+++ b/src/cards/searchbar.ts
@@ -1,4 +1,5 @@
 import { Component, Setting } from "obsidian";
+import { createSearchBarButton } from "../header";
 import { t } from "../i18n";
 import { SearchSection } from "../search";
 import { type DashboardCard } from "../types";
@@ -12,12 +13,14 @@ import { type CardDefinition, type CardEditorContext } from "./definition";
  * A live search field on the board — the same `SearchSection` the header
  * renders, so it carries every search feature with it (tag/property/`>` command
  * syntax, Omnisearch routing, body search, recents on focus, keyboard
- * navigation) rather than reimplementing a second, weaker one.
+ * navigation) rather than reimplementing a second, weaker one. The action
+ * button beside it is the header's button too, in either of its modes.
  *
- * Two per-card choices sit on top of it: whether the file-type filter row is
- * shown, and whether the card keeps its frame. `seamless` drops the frame
- * entirely (see `cardClass` below), which is how you put a bare search bar
- * anywhere on the board instead of a card that contains one.
+ * The field's thickness is the card's own height: the bar stretches to fill
+ * whatever room the card has left after the optional chip row, so it is resized
+ * by dragging the card rather than by a setting (see styles.css). `seamless`
+ * drops the frame entirely (see `cardClass` below), which is how you put a bare
+ * search bar anywhere on the board instead of a card that contains one.
  */
 export function renderSearchBar(
 	view: HomeView,
@@ -29,25 +32,57 @@ export function renderSearchBar(
 	const search = new SearchSection(view);
 	// One positioned wrapper holds the bar, the chip row and the results
 	// overlay, mirroring the header's search column — the overlay is absolutely
-	// positioned against it, so the dropdown lines up with the field's width.
+	// positioned against it, so the dropdown spans the card's width.
 	const wrap = body.createDiv("hearth-searchbar-card");
-	search.renderBar(wrap);
-	search.renderResultsAndFilters(wrap, wrap, component, { filters: cfg.filters !== false });
+	// The bar and its button share a row so the button sits beside the field
+	// rather than above the chips, exactly as in the header.
+	const row = wrap.createDiv("hearth-searchbar-row");
+	const bar = search.renderBar(row, { placeholder: cfg.placeholder });
+	if (cfg.button && cfg.button !== "none") {
+		row.append(createSearchBarButton(view, bar, cfg.button));
+	}
+	search.renderResultsAndFilters(wrap, wrap, component, { filters: cfg.filters === true });
 }
 
 
 export function searchBarEditor(ctx: CardEditorContext, containerEl: HTMLElement): void {
 	const cfg = (ctx.card.searchBar ??= {});
 	new Setting(containerEl)
+		.setName(t().editors.searchBar.placeholder)
+		.setDesc(t().editors.searchBar.placeholderDesc)
+		.addText((txt) =>
+			txt
+				.setPlaceholder(ctx.opts.settings.searchPlaceholder || t().search.placeholder)
+				.setValue(cfg.placeholder ?? "")
+				.onChange((v) => {
+					cfg.placeholder = v.trim() ? v : undefined;
+					ctx.opts.save();
+					ctx.opts.rerender();
+				}),
+		);
+	new Setting(containerEl)
 		.setName(t().editors.searchBar.filters)
 		.setDesc(t().editors.searchBar.filtersDesc)
 		.addToggle((tg) =>
-			tg.setValue(cfg.filters !== false).onChange((v) => {
-				cfg.filters = v ? undefined : false;
+			tg.setValue(cfg.filters === true).onChange((v) => {
+				cfg.filters = v || undefined;
 				ctx.opts.save();
 				ctx.opts.rerender();
 			}),
 		);
+	new Setting(containerEl)
+		.setName(t().editors.searchBar.button)
+		.setDesc(t().editors.searchBar.buttonDesc)
+		.addDropdown((d) => {
+			d.addOption("none", t().editors.searchBar.buttonNone);
+			d.addOption("newNote", t().editors.searchBar.buttonNewNote);
+			d.addOption("searchOnline", t().editors.searchBar.buttonSearchOnline);
+			d.setValue(cfg.button ?? "none").onChange((v) => {
+				cfg.button = v === "none" ? undefined : (v as "newNote" | "searchOnline");
+				ctx.opts.save();
+				ctx.opts.rerender();
+			});
+		});
 	new Setting(containerEl)
 		.setName(t().editors.searchBar.seamless)
 		.setDesc(t().editors.searchBar.seamlessDesc)
@@ -58,6 +93,11 @@ export function searchBarEditor(ctx: CardEditorContext, containerEl: HTMLElement
 				ctx.opts.rerender();
 			}),
 		);
+	// There is no thickness control: the bar fills the card, so its height is the
+	// card's. Say so here — it isn't discoverable from a settings pane that has
+	// no slider for it.
+	const note = new Setting(containerEl).setDesc(t().editors.searchBar.sizeNote);
+	note.settingEl.addClass("hearth-setting-note");
 }
 
 /** A live search field, optionally without any card frame around it. */
@@ -68,9 +108,12 @@ export const searchbarCard: CardDefinition<"searchbar"> = {
 			id: "searchbar",
 			name: "Search bar",
 			icon: "text-cursor-input",
-			// Untitled by default: the field explains itself, and a title row above
-			// a bare bar is exactly what the seamless option exists to avoid.
-			build: () => ({ kind: "searchbar", title: "", searchBar: {}, w: 6, h: 2 }),
+			// One row tall: the bar fills the card, so this is what sets its
+			// starting thickness — a little more generous than the header's fixed
+			// 52px, and made thicker or slimmer by resizing the card. Untitled,
+			// because the field explains itself and a title row above a bare bar is
+			// exactly what the seamless option exists to avoid.
+			build: () => ({ kind: "searchbar", title: "", searchBar: {}, w: 6, h: 1 }),
 		},
 	],
 	render: (view, card, body, component) => renderSearchBar(view, card, body, component),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -14,7 +14,7 @@ import {
 	type VaultEventHub,
 	watchedCardReactsToKind,
 } from "./cardevents";
-import { cardDefinition, cardFromTemplate, cloneCard } from "./cards";
+import { cardClasses, cardDefinition, cardFromTemplate, cloneCard } from "./cards";
 import { openCardPicker } from "./cardpicker";
 import { CardSettingsModal } from "./editors";
 import {
@@ -112,8 +112,8 @@ export function renderDashboard(
 		applyCardPosition(el, card);
 
 		if (card.pinned) el.addClass("is-pinned");
-		const cardClass = cardDefinition(card).cardClass;
-		if (cardClass) el.addClass(cardClass);
+		const kindClasses = cardClasses(card);
+		if (kindClasses.length) el.addClass(...kindClasses);
 		if (card.accent) {
 			el.style.setProperty("--card-accent", card.accent);
 			el.addClass("has-accent");
@@ -126,7 +126,10 @@ export function renderDashboard(
 		// updateFrostLayers / the .hearth-frost note in styles.css). The value is
 		// stashed on the element so the frost rebuild can group cards by blur
 		// without re-reading settings, and blur-off cards never enter a layer.
-		const cardBlur = resolveCardBlur(s, card);
+		// A seamless card paints no surface of its own, so frosting the wallpaper
+		// behind it would leave a blurred rectangle floating on the board with no
+		// card on it. Such a card never joins a frost layer.
+		const cardBlur = kindClasses.includes("is-seamless") ? 0 : resolveCardBlur(s, card);
 		if (cardBlur > 0) {
 			el.addClass("has-blur");
 			el.dataset.blur = String(cardBlur);

--- a/src/header.ts
+++ b/src/header.ts
@@ -83,14 +83,22 @@ export function renderHeader(view: HomeView, container: HTMLElement, component: 
 	const bar = search.renderBar(searchRow);
 
 	if (s.showNewNoteButton && !mobileOnly) {
-		const btn =
-			s.newNoteButtonMode === "searchOnline"
-				? createSearchOnlineButton(bar)
-				: createNewNoteButton(view);
-		searchWrap.append(btn);
+		searchWrap.append(createSearchBarButton(view, bar, s.newNoteButtonMode));
 	}
 
 	search.renderResultsAndFilters(searchCol, searchCol, component);
+}
+
+/** The button that sits beside a search bar, in either of its two modes. Shared
+ * with the search-bar card, which offers the same choice per card — so the two
+ * places can't drift into two subtly different buttons. `bar` is the search bar
+ * the button belongs to; "searchOnline" reads its current query. */
+export function createSearchBarButton(
+	view: HomeView,
+	bar: HTMLElement,
+	mode: "newNote" | "searchOnline",
+): HTMLElement {
+	return mode === "searchOnline" ? createSearchOnlineButton(bar) : createNewNoteButton(view);
 }
 
 /** Read the current query out of the search bar's input element. */

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -869,6 +869,7 @@ export const en = {
 			calendar: "Mini calendar",
 			stats: "Vault statistics",
 			search: "Query",
+			searchbar: "Search bar",
 			heatmap: "Activity heatmap",
 			calculator: "Calculator",
 			dataview: "Dataview query",
@@ -1122,6 +1123,16 @@ export const en = {
 			displayTiles: "Tiles",
 			maxResults: "Max results",
 			maxResultsDesc: "The most matches to show at once.",
+		},
+		searchBar: {
+			filters: "Filter row",
+			filtersDesc:
+				"Show the file-type chips under the field, the same ones the header " +
+				"search bar offers.",
+			seamless: "Seamless",
+			seamlessDesc:
+				"Drop the card frame — no border, background or title row — so this " +
+				"reads as a standalone search bar on the board.",
 		},
 		links: {
 			heading: "Links",
@@ -2239,6 +2250,7 @@ export const en = {
 		calendar: "Mini calendar",
 		stats: "Vault statistics",
 		search: "Query",
+		searchbar: "Search bar",
 		heatmap: "Activity heatmap",
 		text: "Text / jot-down",
 		calculator: "Calculator",
@@ -2273,6 +2285,7 @@ export const en = {
 		calendar: "A month at a glance, with your notes on it",
 		stats: "Note, word and file counts for the vault",
 		search: "A saved query, kept live",
+		searchbar: "A search field on the board, framed or bare",
 		heatmap: "A year of vault activity, day by day",
 		text: "A scratchpad that lives on the dashboard",
 		calculator: "Sums, unit conversion and exchange rates",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1133,6 +1133,11 @@ export const en = {
 			filtersDesc:
 				"Show the file-type chips under the field, the same ones the header " +
 				"search bar offers. They need a taller card to sit in.",
+			filterTypes: "Filter chips",
+			filterTypesDesc:
+				"Which chips this card offers. A chip only appears when the vault " +
+				"actually holds that kind of file.",
+			filterTypeGlobalOff: "Hidden for every search bar in Settings → Filters.",
 			button: "Button",
 			buttonDesc:
 				"An action button beside the field: create a new note, or search the " +

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1125,14 +1125,28 @@ export const en = {
 			maxResultsDesc: "The most matches to show at once.",
 		},
 		searchBar: {
+			placeholder: "Placeholder",
+			placeholderDesc:
+				"Text shown in the empty field. Leave blank to use the one from " +
+				"Settings → Appearance.",
 			filters: "Filter row",
 			filtersDesc:
 				"Show the file-type chips under the field, the same ones the header " +
-				"search bar offers.",
+				"search bar offers. They need a taller card to sit in.",
+			button: "Button",
+			buttonDesc:
+				"An action button beside the field: create a new note, or search the " +
+				"web for whatever is typed in the field.",
+			buttonNone: "None",
+			buttonNewNote: "New note",
+			buttonSearchOnline: "Search online",
 			seamless: "Seamless",
 			seamlessDesc:
 				"Drop the card frame — no border, background or title row — so this " +
 				"reads as a standalone search bar on the board.",
+			sizeNote:
+				"The field is as thick as the card is tall — drag the card's edge in " +
+				"Arrange to make the bar chunkier or slimmer.",
 		},
 		links: {
 			heading: "Links",

--- a/src/search.ts
+++ b/src/search.ts
@@ -122,18 +122,21 @@ export class SearchSection {
 
 	/** Renders the results dropdown (as an overlay inside `overlayParent`, which
 	 * must be positioned) and the filter chip row (under `boundary`). `boundary`
-	 * wraps the whole search section and is the click-outside dismissal area. */
+	 * wraps the whole search section and is the click-outside dismissal area.
+	 * `filters: false` leaves the chip row out entirely (the search-bar card can
+	 * turn it off; the header always shows it). */
 	renderResultsAndFilters(
 		overlayParent: HTMLElement,
 		boundary: HTMLElement,
 		component: Component,
+		opts: { filters?: boolean } = {},
 	): void {
 		this.rootEl = boundary;
 		this.resultsEl = overlayParent.createDiv("hearth-search-results");
 		this.resultsEl.id = this.resultsId;
 		this.resultsEl.setAttribute("role", "listbox");
 		this.resultsEl.hide();
-		this.renderFilters(boundary);
+		if (opts.filters !== false) this.renderFilters(boundary);
 
 		// Close the dropdown when clicking outside the whole search section.
 		// Registered on the per-render component (not the long-lived view) so it's
@@ -426,14 +429,32 @@ export class SearchSection {
 	private showEmpty(text: string = t().search.noMatches): void {
 		this.resultsEl.createDiv("hearth-search-empty").setText(text);
 		this.resultsEl.show();
+		this.placeResults();
 		this.capResultsToViewport();
 		this.inputEl.setAttribute("aria-expanded", "true");
 	}
 
 	private finishResults(): void {
 		this.resultsEl.show();
+		this.placeResults();
 		this.capResultsToViewport();
 		this.inputEl.setAttribute("aria-expanded", "true");
+	}
+
+	/**
+	 * Open the dropdown upwards when there isn't room for it below the field.
+	 * The header bar always has the whole page under it, so this never fires
+	 * there; a search-bar card placed low on the board does hit it — and in
+	 * fit-to-page mode the board clips its overflow, so a downward list would
+	 * simply be cut off. Measured against the window, which is close enough to
+	 * the board's own bottom edge in both modes. Skipped on mobile, where the
+	 * keyboard owns the space below and capResultsToViewport already handles it.
+	 */
+	private placeResults(): void {
+		if (Platform.isMobile) return;
+		const rect = (this.inputEl.closest(".hearth-search-bar") ?? this.inputEl).getBoundingClientRect();
+		const below = window.innerHeight - rect.bottom;
+		this.resultsEl.toggleClass("is-above", below < 200 && rect.top > below);
 	}
 
 	/**

--- a/src/search.ts
+++ b/src/search.ts
@@ -129,14 +129,16 @@ export class SearchSection {
 	/** Renders the results dropdown (as an overlay inside `overlayParent`, which
 	 * must be positioned) and the filter chip row (under `boundary`). `boundary`
 	 * wraps the whole search section and is the click-outside dismissal area.
-	 * `filters: false` leaves the chip row out entirely (the search-bar card can
-	 * turn it off; the header always shows it). */
+	 * `filters: false` leaves the chip row out entirely, and `hiddenFilters`
+	 * drops individual chips from it (the search-bar card offers both; the
+	 * header always shows the full row). */
 	renderResultsAndFilters(
 		overlayParent: HTMLElement,
 		boundary: HTMLElement,
 		component: Component,
-		opts: { filters?: boolean } = {},
+		opts: { filters?: boolean; hiddenFilters?: string[] } = {},
 	): void {
+		this.hiddenFilters = opts.hiddenFilters ?? [];
 		this.rootEl = boundary;
 		this.resultsEl = overlayParent.createDiv("hearth-search-results");
 		this.resultsEl.id = this.resultsId;
@@ -169,6 +171,10 @@ export class SearchSection {
 
 	// ---- Filters --------------------------------------------------------
 
+	/** Chips this instance leaves out on top of the vault-wide ones, set by the
+	 * search-bar card (which can hide them per card). */
+	private hiddenFilters: string[] = [];
+
 	private detectGroups(): FileTypeGroup[] {
 		const present = new Set<string>();
 		let hasFolders = false;
@@ -189,7 +195,9 @@ export class SearchSection {
 			if (!g || g.id === OTHER_GROUP_ID) hasOther = true;
 			if (hasFolders && present.size >= allNonFolderGroups) break;
 		}
-		const hidden = new Set(this.view.plugin.settings.hiddenFilters);
+		// Vault-wide hides come first and always win: a chip switched off in
+		// Settings → Filters stays off everywhere, a card can only hide more.
+		const hidden = new Set([...this.view.plugin.settings.hiddenFilters, ...this.hiddenFilters]);
 		return FILE_TYPE_GROUPS.filter((g) => {
 			if (hidden.has(g.id)) return false;
 			if (g.id === "folders") return hasFolders;

--- a/src/search.ts
+++ b/src/search.ts
@@ -58,8 +58,11 @@ export class SearchSection {
 	private updateDebounced = debounce(() => this.update(), 140, true);
 
 	/** Renders the search bar (icon + input). The caller places the New-note
-	 * button beside the returned bar element. */
-	renderBar(parent: HTMLElement): HTMLElement {
+	 * button beside the returned bar element. `placeholder` overrides the global
+	 * one (the search-bar card sets its own); an empty or blank override falls
+	 * back to it, so clearing the field in the card editor restores the default
+	 * rather than leaving the bar unlabelled. */
+	renderBar(parent: HTMLElement, opts: { placeholder?: string } = {}): HTMLElement {
 		const bar = parent.createDiv("hearth-search-bar");
 		const icon = bar.createDiv("hearth-search-icon");
 		setIcon(icon, "search");
@@ -68,7 +71,10 @@ export class SearchSection {
 			cls: "hearth-search-input",
 			attr: {
 				type: "text",
-				placeholder: this.view.plugin.settings.searchPlaceholder || t().search.placeholder,
+				placeholder:
+					opts.placeholder?.trim() ||
+					this.view.plugin.settings.searchPlaceholder ||
+					t().search.placeholder,
 				spellcheck: "false",
 				role: "combobox",
 				"aria-expanded": "false",

--- a/src/types.ts
+++ b/src/types.ts
@@ -470,6 +470,9 @@ export interface SearchBarConfig {
 	 * the header search bar does. Default false — the chips are the opt-in
 	 * extra here, and they need a taller card to sit in. */
 	filters?: boolean;
+	/** File-type group ids (see FILE_TYPE_GROUPS) this card leaves out of its
+	 * chip row, on top of the ones hidden vault-wide in Settings → Filters. */
+	hiddenFilters?: string[];
 	/** Placeholder shown in the empty field. Blank or omitted falls back to the
 	 * global one (Settings → Appearance → Search placeholder). */
 	placeholder?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -467,8 +467,15 @@ export interface SavedSearchConfig {
 /** Per-card configuration for a "searchbar" (live search field) card. */
 export interface SearchBarConfig {
 	/** Show the auto-detected file-type filter chips under the field, exactly as
-	 * the header search bar does. Default true. */
+	 * the header search bar does. Default false — the chips are the opt-in
+	 * extra here, and they need a taller card to sit in. */
 	filters?: boolean;
+	/** Placeholder shown in the empty field. Blank or omitted falls back to the
+	 * global one (Settings → Appearance → Search placeholder). */
+	placeholder?: string;
+	/** The action button beside the field, or "none" (the default). Same two
+	 * modes as the header's button. */
+	button?: "none" | "newNote" | "searchOnline";
 	/** Drop the card's frame — no border, background, shadow or title row — so
 	 * the field reads as a standalone search bar placed on the board rather than
 	 * as a card. Default false. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type CardKind =
 	| "calendar"
 	| "stats"
 	| "search"
+	| "searchbar"
 	| "heatmap"
 	| "calculator"
 	| "dataview"
@@ -461,6 +462,17 @@ export interface SavedSearchConfig {
 	/** Display layout: "list" (default) renders a vertical list; "tiles"
 	 * renders results as a grid of icon tiles (like the links card). */
 	view?: "list" | "tiles";
+}
+
+/** Per-card configuration for a "searchbar" (live search field) card. */
+export interface SearchBarConfig {
+	/** Show the auto-detected file-type filter chips under the field, exactly as
+	 * the header search bar does. Default true. */
+	filters?: boolean;
+	/** Drop the card's frame — no border, background, shadow or title row — so
+	 * the field reads as a standalone search bar placed on the board rather than
+	 * as a card. Default false. */
+	seamless?: boolean;
 }
 
 /** Per-card configuration for a "heatmap" (activity) card. */
@@ -1001,6 +1013,8 @@ export interface DashboardCard {
 	calendar?: CalendarConfig;
 	/** kind === "search": the saved query and result count. */
 	savedSearch?: SavedSearchConfig;
+	/** kind === "searchbar": filter row and seamless (frameless) display. */
+	searchBar?: SearchBarConfig;
 	/** kind === "heatmap": metric and range. */
 	heatmap?: HeatmapConfig;
 	/** kind === "stats": which stats to show, attachment breakdown and custom

--- a/styles.css
+++ b/styles.css
@@ -431,6 +431,14 @@
 	color: var(--text-muted);
 }
 
+/* Open upwards when there is no room below the field (search.ts measures and
+   sets .is-above). Only the search-bar card hits this — placed low on the
+   board, or in fit-to-page mode where the grid clips its overflow. */
+.hearth-search-results.is-above {
+	top: auto;
+	bottom: calc(100% + 6px);
+}
+
 /* ---- Filters -------------------------------------------------------- */
 
 /* The chips share out the row's leftover space as gap, growing to at most 48px,
@@ -492,6 +500,54 @@
 
 .hearth-filter-icon {
 	display: flex;
+}
+
+/* ---- Search-bar card ------------------------------------------------- */
+
+/* The search-bar card hosts the very same SearchSection the header renders, so
+   the bar, chips and dropdown need no styling of their own — only a positioned
+   column for the overlay to hang off, matching .hearth-search-col. */
+.hearth-searchbar-card {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	width: 100%;
+}
+
+/* The results dropdown is an overlay that has to leave the card box; both the
+   card and its body clip by default (see .hearth-card / .hearth-card-body), so
+   a list of matches would be cut off at the card's edge. Nothing else in this
+   card scrolls, so letting it overflow costs nothing. */
+.hearth-card.is-searchbar-card,
+.hearth-card.is-searchbar-card .hearth-card-body {
+	overflow: visible;
+}
+
+/* Seamless: the card stops being a card. No frame, no surface, no shadow and no
+   padding, so the bar sits directly on the board (or the wallpaper) exactly as
+   the header's does. The card is still a card underneath — it drags, resizes
+   and configures like any other. */
+.hearth-card.is-seamless {
+	border-color: transparent;
+	background: none;
+	box-shadow: none;
+}
+
+.hearth-card.is-seamless:hover {
+	--hearth-card-lift: none;
+}
+
+.hearth-card.is-seamless .hearth-card-body {
+	padding: 0;
+}
+
+/* The title row goes with the frame — but only outside arrange mode, where that
+   same row carries the title input and the card's actions. The card still has
+   an edge to aim at while arranging: the dashed ::after outline every card gets
+   there is drawn on this one too. */
+.hearth-grid:not(.is-arranging) .hearth-card.is-seamless .hearth-card-head {
+	display: none;
 }
 
 /* ---- Recent-card type filter (card editor) -------------------------- */

--- a/styles.css
+++ b/styles.css
@@ -553,6 +553,17 @@
 	height: auto;
 }
 
+/* Let the field be narrowed as far as the user likes. An <input> carries an
+   intrinsic width — roughly 20 characters — and a flex item's automatic minimum
+   size honours it, so without this the bar refuses to shrink past ~200px: the
+   card narrows, the field doesn't, and the button beside it is pushed out
+   through the card's side. Both elements need it — the bar for its own flex
+   line, the input for the bar's. */
+.hearth-searchbar-row .hearth-search-bar,
+.hearth-searchbar-row .hearth-search-input {
+	min-width: 0;
+}
+
 /* The chip row is a fixed-size band under the bar — it must not absorb the
    card's extra height, that is the bar's to take. */
 .hearth-searchbar-card .hearth-filters {

--- a/styles.css
+++ b/styles.css
@@ -506,13 +506,57 @@
 
 /* The search-bar card hosts the very same SearchSection the header renders, so
    the bar, chips and dropdown need no styling of their own — only a positioned
-   column for the overlay to hang off, matching .hearth-search-col. */
+   column for the overlay to hang off, matching .hearth-search-col.
+
+   The column fills the card so the bar can be sized BY the card: there is no
+   thickness setting, you drag the card taller and the field gets chunkier. It
+   centres its contents, so past the bar's maximum the extra height reads as
+   space around a thick bar rather than an ever-taller pill. */
 .hearth-searchbar-card {
 	position: relative;
 	display: flex;
 	flex-direction: column;
+	justify-content: center;
+	/* "safe" keeps a card too short for its contents overflowing downwards only,
+	 * instead of centring the overflow and pushing the bar up out of the card.
+	 * Ignored by engines that don't know it, which leaves plain centring. */
+	justify-content: safe center;
 	gap: 8px;
 	width: 100%;
+	height: 100%;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.hearth-card.is-searchbar-card .hearth-card-body {
+	display: flex;
+}
+
+/* The bar's row takes whatever height is left after the (optional) chip row,
+   between a floor that keeps it tappable at the board's smallest card (56px
+   tall, less the body's padding) and a ceiling that stops an accidentally huge
+   card from becoming an absurd pill. The header's bar is a flat 52px; this
+   starts at 68 at the card's default one-row height. */
+.hearth-searchbar-row {
+	display: flex;
+	align-items: stretch;
+	gap: 12px;
+	flex: 1 1 auto;
+	min-height: 36px;
+	max-height: 120px;
+}
+
+/* Both children stretch to the row's height instead of the fixed 52px they
+   carry in the header. */
+.hearth-searchbar-row .hearth-search-bar,
+.hearth-searchbar-row .hearth-newnote {
+	height: auto;
+}
+
+/* The chip row is a fixed-size band under the bar — it must not absorb the
+   card's extra height, that is the bar's to take. */
+.hearth-searchbar-card .hearth-filters {
+	flex: 0 0 auto;
 }
 
 /* The results dropdown is an overlay that has to leave the card box; both the

--- a/test/cards-registry.test.ts
+++ b/test/cards-registry.test.ts
@@ -56,6 +56,7 @@ describe("CARD_TEMPLATES (add-card menu)", () => {
 
 			// ---- Vault insight ----
 			{ id: "search", icon: "search", category: "vault", requires: null, build: { kind: "search", title: "Query", savedSearch: { query: "" }, w: 4, h: 4 } },
+			{ id: "searchbar", icon: "text-cursor-input", category: "vault", requires: null, build: { kind: "searchbar", title: "", searchBar: {}, w: 6, h: 2 } },
 			{ id: "stats", icon: "bar-chart-3", category: "vault", requires: null, build: { kind: "stats", title: "Stats", w: 4, h: 2 } },
 			{ id: "heatmap", icon: "activity", category: "vault", requires: null, build: { kind: "heatmap", title: "Activity", heatmap: {}, w: 6, h: 3 } },
 
@@ -290,6 +291,7 @@ describe("liveness classification", () => {
 			calendar: "vault",
 			stats: "vault",
 			search: "vault",
+		searchbar: "static",
 			heatmap: "vault",
 			calculator: "static",
 			dataview: "static",

--- a/test/cards-registry.test.ts
+++ b/test/cards-registry.test.ts
@@ -56,7 +56,7 @@ describe("CARD_TEMPLATES (add-card menu)", () => {
 
 			// ---- Vault insight ----
 			{ id: "search", icon: "search", category: "vault", requires: null, build: { kind: "search", title: "Query", savedSearch: { query: "" }, w: 4, h: 4 } },
-			{ id: "searchbar", icon: "text-cursor-input", category: "vault", requires: null, build: { kind: "searchbar", title: "", searchBar: {}, w: 6, h: 2 } },
+			{ id: "searchbar", icon: "text-cursor-input", category: "vault", requires: null, build: { kind: "searchbar", title: "", searchBar: {}, w: 6, h: 1 } },
 			{ id: "stats", icon: "bar-chart-3", category: "vault", requires: null, build: { kind: "stats", title: "Stats", w: 4, h: 2 } },
 			{ id: "heatmap", icon: "activity", category: "vault", requires: null, build: { kind: "heatmap", title: "Activity", heatmap: {}, w: 6, h: 3 } },
 


### PR DESCRIPTION
## What does this PR do?

Adds a `searchbar` card kind — the header's search field, available as a card so it can go anywhere on the board (Add card → **Vault insight → Search bar**). This is the second of the two routes #195 suggests: the header's own bar is left exactly as it is, and a card replicates it with customization on top.

It hosts the same `SearchSection` the header renders rather than a second implementation, so tag / `key:value` / `>`-command syntax, Omnisearch routing, body search, recents-on-focus, keyboard navigation and the mobile-keyboard handling all come with it.

**The card is the size control.** The field fills whatever height the card has, so the bar is made chunkier or slimmer by dragging the card's edge in Arrange — no slider, and it starts at 68px against the header's fixed 52.

Per-card options:

- **Placeholder** — blank falls back to the global one from Settings → Appearance.
- **Filter row** — the file-type chips under the field, off by default, plus a toggle per chip so a narrow bar can carry the two or three that earn their place instead of every type the vault holds. The card's list only ever hides more: it is unioned with the vault-wide one, and a chip switched off in Settings → Filters shows as off and disabled here.
- **Button** — None / New note / Search online. It is the header's own button; the factory moved to an exported `createSearchBarButton()` that both call sites use, so the two can't drift.
- **Seamless** — drops the card frame entirely: no border, background, shadow, body padding or title row, so the bar stands on the board by itself. It is still a card underneath — it drags, resizes and configures like any other, and the dashed outline every card gets in arrange mode marks where it sits.

Three things needed changes outside the new module:

- `CardDefinition.cardClass` now also accepts `(card) => string | undefined`, read through a new `cardClasses()` helper — seamless makes the root class depend on the card's own config. The existing string form is unchanged.
- A seamless card is kept out of the frost layers in `dashboard.ts`: it paints no surface, so blurring the wallpaper behind it would leave a frosted rectangle floating on the board.
- The results dropdown now flips **above** the field when there is no room below it. The header never hits this, but a card placed low on the board does — and in fit-to-page mode the grid clips its overflow, so the list would simply be cut off.

Liveness is deliberately `static`, not `vault`: the card holds live UI state (typed query, active chip, open dropdown) and a vault-event redraw would blank the field mid-search, e.g. when a background sync lands. Nothing goes stale meanwhile — results are computed per keystroke and the chip row is rebuilt on the next board render.

Also updates the two registry-snapshot assertions in `test/cards-registry.test.ts` and adds a CHANGELOG entry under 2.0.0.

### Known rough edge

With the button on, the bar's row can't be narrowed below the button's own width (~150px for "Search online"), so a card dragged near the board's 120px minimum pushes it out sideways. Hiding the button's label at narrow widths would fix it; left out for now.

## Related issue

Closes #195.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (`typecheck`, `lint` — 0 errors, the same 35 pre-existing warnings — and `test`, 576 passing, all pass too)
- [x] I've tested this in an actual vault — not done: this was written in a remote container with no Obsidian to load the plugin into. Worth a look in a real vault, particularly the seamless card against a wallpaper, the default thickness, and the dropdown's upward flip.