### PR TITLE
chore: cut 2.0.0-beta.3

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "2.0.0-beta.2",
+	"version": "2.0.0-beta.3",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
Cuts the next beta snapshot of `main`.

- `manifest-beta.json` → `2.0.0-beta.3`
- `manifest.json` untouched (stable stays `1.18.0`)

`2.0.0-beta.2` was already published on 2026-08-08, so this snapshot — which picks up the calendar card, the search-bar card, the redesigned add-card picker, the per-card border width, the global/per-board search toggle and the weather/tasks/whatsnew fixes landed since — is `beta.3`.

The `2.0.0` changelog section on `main` already covers everything in this build, so no changelog change was needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XxrhB6oEuk2N2hgZzHoJ5)_