### PR TITLE
Add a Dashboard settings button to the arrange toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,6 +356,12 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   blur**, with the same reset button to hand the card back to the dashboard
   default. Set it to 0 to drop one card's frame — border and the line under its
   title — while the rest of the board keeps its own.
+- **Dashboard settings, straight from the Arrange toolbar.** A **Dashboard
+  settings** button now sits next to **Add card** while you are arranging, and
+  opens the very same editor as right-clicking the board's switcher button and
+  choosing **Dashboard settings…** — name, header, layout, style and
+  background for the board you are on. The right-click route still works; it is
+  no longer the only one.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ calls**.
   so the pair reads as one continuous tile.
 - **Multiple dashboards** — a `[1] [2] [+]` switcher in the top-left. Name each
   board, give it an emoji, reorder by dragging, and override the global width,
-  columns, row height and background per board.
+  columns, row height and background per board. Open a board's settings either
+  from **Dashboard settings** in the **Arrange** toolbar or by right-clicking
+  its switcher button.
 - **Pinned cards** — pin a card to appear on every dashboard, sharing one
   definition and position.
 - **Fit to page** — lock the board to one screen or let it scroll.

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -16,9 +16,11 @@ import {
 } from "./cardevents";
 import { cardClasses, cardDefinition, cardFromTemplate, cloneCard } from "./cards";
 import { openCardPicker } from "./cardpicker";
+import { openDashboardSettings } from "./dashboards";
 import { CardSettingsModal } from "./editors";
 import {
 	activeCards,
+	activeDashboard,
 	type DashboardCard,
 	effectiveCardBorderWidth,
 	effectiveCardOpacity,
@@ -445,6 +447,19 @@ function renderToolbar(view: HomeView, container: HTMLElement): void {
 					persistAndRender(view);
 				},
 			});
+		});
+
+		// Same editor the dashboard switcher's right-click menu opens, surfaced
+		// here so arrange mode is a self-contained way to configure the board.
+		const dashSettings = bar.createEl("button", { cls: "hearth-tool-btn" });
+		setIcon(dashSettings.createSpan("hearth-tool-icon"), "settings-2");
+		dashSettings.createSpan({
+			cls: "hearth-tool-label",
+			text: t().dashboard.dashboardSettings,
+		});
+		dashSettings.setAttribute("aria-label", t().dashboard.dashboardSettingsAria);
+		dashSettings.addEventListener("click", () => {
+			openDashboardSettings(view, activeDashboard(view.plugin.settings));
 		});
 
 		// Toggle the per-card headers (title input + actions) off so each

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -117,6 +117,13 @@ export function renderDashboardSwitcher(
 	});
 }
 
+/** Open the per-dashboard settings editor for `dash`. Shared by the switcher's
+ * right-click menu and the arrange-mode toolbar button, so both routes land in
+ * exactly the same modal. */
+export function openDashboardSettings(view: HomeView, dash: Dashboard): void {
+	new DashboardSettingsModal(view, dash).open();
+}
+
 /** Context menu for a single dashboard button: settings and delete. */
 function showDashboardMenu(
 	view: HomeView,
@@ -130,7 +137,7 @@ function showDashboardMenu(
 		item
 			.setTitle(t().dashboards.menu.settings)
 			.setIcon("settings-2")
-			.onClick(() => new DashboardSettingsModal(view, dash).open()),
+			.onClick(() => openDashboardSettings(view, dash)),
 	);
 
 	menu.addItem((item) =>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -108,6 +108,8 @@ export const en = {
 	dashboard: {
 		addCard: "Add card",
 		addCardAria: "Add a card to the dashboard",
+		dashboardSettings: "Dashboard settings",
+		dashboardSettingsAria: "Open settings for this dashboard",
 		showTitles: "Show titles",
 		hideTitles: "Hide titles",
 		showCardHeaders: "Show card headers",
@@ -802,7 +804,8 @@ export const en = {
 			cards: "Cards",
 			cardsDesc:
 				"Add and configure cards on the dashboard itself: open the home view, " +
-				"hit Arrange, then use Add card and each card's settings button.",
+				"hit Arrange, then use Add card, Dashboard settings and each card's " +
+				"settings button.",
 		},
 		layout: {
 			heading: "Import / export",

--- a/styles.css
+++ b/styles.css
@@ -4967,6 +4967,10 @@
 	display: flex;
 	justify-content: flex-end;
 	gap: 8px;
+	/* Arrange mode shows four labelled buttons; in a narrow pane they wrap onto
+	 * a second row (still right-aligned) instead of overflowing the board. */
+	flex-wrap: wrap;
+	align-items: center;
 }
 
 .hearth-tool-btn {


### PR DESCRIPTION
## What does this PR do?

Per-dashboard settings were only reachable by right-clicking a board's switcher button, which is easy to miss. Arrange mode now carries a **Dashboard settings** button directly next to **Add card** that opens the very same editor for the active board.

- `src/dashboards.ts` — the `DashboardSettingsModal` is now opened through a shared `openDashboardSettings(view, dash)` export. The switcher's right-click menu calls it too, so the two entry points can't drift apart.
- `src/dashboard.ts` — the arrange toolbar renders the new button (`settings-2` icon, same `hearth-tool-btn` styling as its neighbours) after **Add card**, targeting `activeDashboard(settings)`. Button order while arranging: `Add card | Dashboard settings | Hide titles | Done arranging`.
- `src/locales/en.ts` — new `dashboard.dashboardSettings` / `dashboardSettingsAria` strings; the Settings → Cards hint now mentions the new route.
- `styles.css` — `.hearth-toolbar` gets `flex-wrap: wrap` + `align-items: center`, so the fourth labelled button wraps onto a second (still right-aligned) row in a narrow pane instead of overflowing. Only arrange mode has enough buttons to wrap, and the arrange zone's auto-hide mode is inactive there, so its footprint rule is untouched.
- README and CHANGELOG (2.0.0 → Added) updated.

## Related issue

None — small, self-contained UI affordance.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [x] 📝 Docs
- [x] ✨ Feature / behaviour change

## Checklist

- [x] `npm run build` passes locally (tsc + esbuild clean; 611 tests pass; eslint 0 errors)
- [ ] I've tested this in an actual vault — will be verified in BETA

### Notes on correctness

- No import cycle: `dashboards.ts` imports `HomeView` type-only and never imports `dashboard.ts`, so the new value import is one-directional.
- `activeDashboard()` falls back to the first board and the app always keeps at least one, so the button can't dereference nothing.
- The modal's `commit()` calls `view.render()`, which rebuilds the toolbar; `arrangeMode` lives on the view instance and isn't reset, so you stay in arrange mode while editing and the board updates live behind the modal.

---
_Generated by [Claude Code](https://claude.ai/code/session_011toMNhBYkrfUdD2GRqAwrJ)_