### PR TITLE
chore: cut 2.0.0-beta.4

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "2.0.0-beta.3",
+	"version": "2.0.0-beta.4",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
Bumps `manifest-beta.json` to `2.0.0-beta.4`, snapshotting current `main` for the BRAT beta channel.

- `manifest.json` untouched — stable stays `1.18.0`.
- Contents since `2.0.0-beta.3`: the Dashboard settings button in the arrange toolbar (#201), already covered by the `[2.0.0]` changelog section.
- Release cut via `release.yml` `workflow_dispatch` (tag pushes are blocked from this environment); published as a pre-release.

---
_Generated by [Claude Code](https://claude.ai/code/session_0137puLnogpoCxqhbMuE5ttX)_