### PR TITLE
fix(arrange): keep a fit-to-page arrangement where it was put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ preceding beta series.
 History begins at 1.5.0. For releases before 1.5.0, see the
 [GitHub Releases](https://github.com/ondreu/Hearth/releases) page.
 
+## [2.1.0]
+
+### Fixed
+
+- **Arranging a fit-to-page board keeps the arrangement.** On a board whose
+  cards are taller than the pane — which is what happens as soon as you zoom
+  Obsidian in, so it depended on your screen and zoom level rather than on
+  anything you did — cards no longer jump when you finish arranging. The board
+  squeezes the layout vertically to fit one screen, but a drag or resize was
+  stored as the *squeezed* pixels, so the squeeze was applied a second time on
+  the next draw: the card landed above where you dropped it, shorter than you
+  made it, gaps between neighbours narrowed, and every further arrange session
+  walked the whole board a little further up. The stored geometry is now
+  converted back out of the fit, so a card stays exactly where you put it.
+- **Snapping works at every zoom level.** On the same fitted boards, the
+  magnetic alignment guides were computed from the cards' unsqueezed positions
+  while you were dragging against their visible edges, so edges tens of pixels
+  away never came close enough to snap — matching a neighbour's height or edge
+  was simply impossible until you zoomed back out. Guides now come from where
+  the cards actually are on screen. A dragged card also no longer jolts to a
+  different position the instant it starts moving.
+
 ## [2.0.0]
 
 ### Added

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -38,12 +38,11 @@ import {
 } from "./types";
 import {
 	applyCardPosition,
-	applyCardPositionFitted,
 	applyEdgeMerging,
+	applyFitLayout,
 	enableDragResize,
 	ensureFreeform,
 	ensureLayout,
-	fitVerticalScale,
 	type GridLayout,
 	GRID_GAP,
 	layoutHeight,
@@ -199,13 +198,9 @@ export function renderDashboard(
 			if (!grid.isConnected) return;
 			// One shared scale keeps relative spacing intact, so cards never
 			// overlap when the window is made short (clamping each card on its own
-			// piled them at the top).
-			const vScale = fitVerticalScale(cards, grid.clientHeight);
-			const boardWidth = grid.clientWidth;
-			for (const card of cards) {
-				const el = gridLayout.elements.get(card);
-				if (el) applyCardPositionFitted(el, card, vScale, boardWidth);
-			}
+			// piled them at the top). Ending a drag re-runs the very same helper, so
+			// an arranged card is never left in a different space from its neighbours.
+			applyFitLayout(grid, gridLayout);
 			applyEdgeMerging(grid);
 		};
 		// Apply the fit synchronously on the next frame, before the browser

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -252,6 +252,79 @@ export function fitVerticalScale(cards: DashboardCard[], boardHeight: number): n
 	return boardHeight / contentHeight;
 }
 
+/** The vertical scale currently applied to this board's cards on screen: the
+ * fit-to-page squeeze when the board is fitted, 1 otherwise. Anything that has
+ * to convert between a card's stored geometry and the pixels it actually
+ * occupies must go through this — see cardGeometryFromScreen. */
+export function boardFitScale(gridEl: HTMLElement, cards: DashboardCard[]): number {
+	if (!gridEl.closest(".hearth-fit")) return 1;
+	return fitVerticalScale(cards, gridEl.clientHeight);
+}
+
+/** Re-apply the fit-to-page layout: derive the one shared vertical scale from
+ * the cards' stored geometry and position every card with it. Render-only — see
+ * applyCardPositionFitted for why this never writes back. Returns the scale it
+ * used. Both the initial/observer-driven refit and the end of a drag go through
+ * here, so a committed arrangement is drawn in exactly the same coordinate space
+ * as the rest of the board. */
+export function applyFitLayout(gridEl: HTMLElement, layout: GridLayout): number {
+	const vScale = fitVerticalScale(layout.cards, gridEl.clientHeight);
+	const boardWidth = gridEl.clientWidth;
+	for (const card of layout.cards) {
+		const el = layout.elements.get(card);
+		if (el) applyCardPositionFitted(el, card, vScale, boardWidth);
+	}
+	return vScale;
+}
+
+/** A card's live on-screen footprint, in the grid's own pixel space. */
+export interface ScreenRect {
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+}
+
+/** Read a card element's footprint as laid out right now. offset* is relative to
+ * the positioned grid, so this is the board-space geometry the pointer sees —
+ * including any fit-to-page vertical squeeze already applied to it. */
+export function screenRect(el: HTMLElement): ScreenRect {
+	return {
+		left: el.offsetLeft,
+		top: el.offsetTop,
+		width: el.offsetWidth,
+		height: el.offsetHeight,
+	};
+}
+
+/** Convert an on-screen footprint back into a card's stored geometry.
+ *
+ * The horizontal axis is a plain board-width fraction. The vertical axis is
+ * where this earns its keep: on a fit-to-page board the cards are painted at
+ * `fy * vScale` / `fh * vScale` (applyCardPositionFitted), so the pixels a drag
+ * ends on are NOT the pixels to store. Dividing the screen geometry back out by
+ * the same scale is what keeps a drop where the user dropped it — storing the
+ * scaled values instead made every committed move/resize re-squeeze on the next
+ * render, jumping the card upward (and shrinking it) by the fit factor, then
+ * compounding on the next arrange because the true geometry had been
+ * overwritten. */
+export function cardGeometryFromScreen(
+	rect: ScreenRect,
+	boardWidth: number,
+	vScale: number,
+): { fx: number; fw: number; fy: number; fh: number } {
+	const w = boardWidth > 0 ? boardWidth : 1;
+	// A zero/negative scale would blow the geometry up to infinity; fitVerticalScale
+	// never returns one, but the model must not depend on that.
+	const scale = vScale > 0 ? vScale : 1;
+	return {
+		fx: clamp(rect.left / w, 0, 1),
+		fw: clamp(rect.width / w, Math.min(MIN_W_PX / w, 1), 1),
+		fy: Math.max(0, rect.top / scale),
+		fh: Math.max(MIN_H_PX, rect.height / scale),
+	};
+}
+
 /** Total pixel height the board needs to show every card. */
 export function layoutHeight(cards: DashboardCard[]): number {
 	let bottom = 0;
@@ -286,6 +359,9 @@ interface DragContext {
 	boardWidth: number;
 	/** Board height (fit-to-page clips to this); Infinity when scrolling. */
 	boardHeight: number;
+	/** The fit-to-page vertical squeeze in force when the drag started, so the
+	 * committed geometry can be converted back out of screen space. */
+	vScale: number;
 	mode: "move" | "resize";
 	/** For resize: which edges follow the pointer. */
 	dir: ResizeDir | null;
@@ -296,7 +372,14 @@ interface DragContext {
 
 /** Collect the vertical (x) and horizontal (y) guide positions a dragged card
  * can snap to: the board's own edges/centre plus every other card's edges,
- * centres and a one-gap offset for tidy adjacency. */
+ * centres and a one-gap offset for tidy adjacency.
+ *
+ * The guides are read off the siblings as they are actually laid out, not from
+ * their stored geometry. On a fit-to-page board the two disagree by the fit
+ * scale, and a guide line that sits tens of pixels away from the edge the user
+ * can see is a guide that never comes within SNAP_THRESHOLD of it — which is
+ * why snapping simply stopped working once the layout overflowed the pane
+ * (typically after zooming Obsidian in, which shortens the board). */
 function collectTargets(
 	layout: GridLayout,
 	active: DashboardCard,
@@ -306,10 +389,9 @@ function collectTargets(
 	const ys = new Set<number>([0]);
 	for (const card of layout.cards) {
 		if (card === active) continue;
-		const left = (card.fx ?? 0) * boardWidth;
-		const width = (card.fw ?? 0) * boardWidth;
-		const top = card.fy ?? 0;
-		const height = card.fh ?? 0;
+		const el = layout.elements.get(card);
+		if (!el) continue;
+		const { left, top, width, height } = screenRect(el);
 		xs.add(left);
 		xs.add(left + width / 2);
 		xs.add(left + width);
@@ -370,6 +452,15 @@ export function enableDragResize(
 	let guideX: HTMLElement | null = null;
 	let guideY: HTMLElement | null = null;
 
+	/** Redraw the board from the stored geometry, in whichever coordinate space
+	 * the board is currently using: fitted boards re-derive the shared vertical
+	 * scale (which a commit may have changed) and reposition every card with it,
+	 * scrolling boards just place the dragged card. */
+	const reposition = () => {
+		if (gridEl.closest(".hearth-fit")) applyFitLayout(gridEl, layout);
+		else applyCardPosition(cardEl, card);
+	};
+
 	// The dragged card's own position is written synchronously on every
 	// pointermove so it tracks the pointer with no lag. The *derived* visual
 	// work — growing the board (a forced layout read over every card), the
@@ -420,21 +511,28 @@ export function enableDragResize(
 		e.preventDefault();
 		e.stopPropagation();
 		const boardWidth = gridEl.clientWidth;
+		const fit = !!gridEl.closest(".hearth-fit");
 		// Fit-to-page clamps cards to the visible board; scroll mode lets the board
 		// grow downward without limit, so a card can be dragged/resized as far down
 		// as the pointer goes (the board height follows via updateBoardHeight).
-		const boardHeight = gridEl.closest(".hearth-fit") ? gridEl.clientHeight : Infinity;
+		const boardHeight = fit ? gridEl.clientHeight : Infinity;
 		const { xTargets, yTargets } = collectTargets(layout, card, boardWidth);
+		// Seed the drag from where the card actually is on screen rather than from
+		// its stored geometry: the pointer deltas below are screen pixels, and on a
+		// fitted board the stored values are the pre-squeeze ones, so mixing the two
+		// snapped the card to its unscaled position the moment it started moving.
+		const rect = screenRect(cardEl);
 		ctx = {
 			pointerId: e.pointerId,
 			startClientX: e.clientX,
 			startClientY: e.clientY,
-			startLeft: (card.fx ?? 0) * boardWidth,
-			startTop: card.fy ?? 0,
-			startWidth: (card.fw ?? 0) * boardWidth,
-			startHeight: card.fh ?? MIN_H_PX,
+			startLeft: rect.left,
+			startTop: rect.top,
+			startWidth: rect.width,
+			startHeight: Math.max(MIN_H_PX, rect.height),
 			boardWidth,
 			boardHeight,
+			vScale: boardFitScale(gridEl, layout.cards),
 			mode,
 			dir,
 			xTargets,
@@ -541,19 +639,25 @@ export function enableDragResize(
 		// Drop any queued mid-drag reflow; this handler recomputes everything
 		// synchronously below from the final committed geometry.
 		cancelReflow();
-		const w = ctx.boardWidth || 1;
-		// Persist the live pixel geometry back into the fractional/pixel model.
-		card.fx = clamp(cardEl.offsetLeft / w, 0, 1);
-		card.fw = clamp(cardEl.offsetWidth / w, MIN_W_PX / w, 1);
-		card.fy = Math.max(0, cardEl.offsetTop);
-		card.fh = Math.max(MIN_H_PX, cardEl.offsetHeight);
+		// Persist the live pixel geometry back into the fractional/pixel model,
+		// undoing any fit-to-page squeeze the card was drawn with.
+		const geo = cardGeometryFromScreen(screenRect(cardEl), ctx.boardWidth, ctx.vScale);
+		card.fx = geo.fx;
+		card.fw = geo.fw;
+		card.fy = geo.fy;
+		card.fh = geo.fh;
 		cardEl.removeClass("is-moving");
 		cardEl.removeClass("is-resizing");
 		showGuide("x", null);
 		showGuide("y", null);
 		ctx = null;
-		// Normalise back to the responsive percentage form.
-		applyCardPosition(cardEl, card);
+		// Normalise back to the stored form. On a fitted board that means re-running
+		// the fit across every card, not just this one: growing or moving a card can
+		// change the layout's total height and so the scale the whole board is drawn
+		// at. Repositioning only the dragged card — with the unscaled helper, as this
+		// used to — left it in a different coordinate space from its neighbours until
+		// the next full render, which is when it appeared to teleport.
+		reposition();
 		updateBoardHeight(gridEl);
 		// After a committed move/resize, recompute merges from the final
 		// stored positions (responsive reflow may have shifted neighbours).

--- a/test/gridfit.test.ts
+++ b/test/gridfit.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+	applyCardPositionFitted,
+	boardFitScale,
+	cardGeometryFromScreen,
+	fitVerticalScale,
+	layoutHeight,
+	MIN_H_PX,
+	MIN_W_PX,
+} from "../src/grid";
+import type { DashboardCard } from "../src/types";
+
+/**
+ * A fit-to-page board paints its cards through a shared vertical scale, so the
+ * pixels a drag or resize ends on are not the pixels to store. These tests pin
+ * the conversion back out of that scaled space, and the property that actually
+ * broke: committing an arrangement must leave the layout where the user put it,
+ * however many times they arrange it.
+ *
+ * The geometry helpers only touch `el.style`, so a bare stub stands in for the
+ * card element — no DOM needed.
+ */
+
+interface StubEl {
+	style: Record<string, string>;
+}
+
+function stub(): StubEl {
+	return { style: {} };
+}
+
+function asEl(el: StubEl): HTMLElement {
+	return el as unknown as HTMLElement;
+}
+
+/** The footprint a stub was positioned at, as the drag engine would measure it
+ * off the live element (offset* is integral, so round like the browser does). */
+function rectOf(el: StubEl) {
+	const px = (v: string) => Math.round(parseFloat(v));
+	return {
+		left: px(el.style.left),
+		top: px(el.style.top),
+		width: px(el.style.width),
+		height: px(el.style.height),
+	};
+}
+
+function card(overrides: Partial<DashboardCard> = {}): DashboardCard {
+	return {
+		id: "c1",
+		kind: "text",
+		title: "",
+		x: 0,
+		y: 0,
+		w: 2,
+		h: 2,
+		fx: 0,
+		fy: 0,
+		fw: 0.5,
+		fh: 200,
+		...overrides,
+	};
+}
+
+const BOARD_W = 1000;
+
+describe("cardGeometryFromScreen", () => {
+	it("stores the screen geometry as-is on an unscaled board", () => {
+		const geo = cardGeometryFromScreen(
+			{ left: 250, top: 120, width: 500, height: 300 },
+			BOARD_W,
+			1,
+		);
+		expect(geo).toEqual({ fx: 0.25, fw: 0.5, fy: 120, fh: 300 });
+	});
+
+	it("divides the vertical axis back out of the fit scale", () => {
+		// A card dropped at screen y=150 on a board squeezed to 75% really lives at
+		// y=200 in stored space; storing 150 is what walked the board upward.
+		const geo = cardGeometryFromScreen(
+			{ left: 0, top: 150, width: 500, height: 300 },
+			BOARD_W,
+			0.75,
+		);
+		expect(geo.fy).toBeCloseTo(200, 6);
+		expect(geo.fh).toBeCloseTo(400, 6);
+		// The horizontal axis is a plain board fraction — the scale is vertical only.
+		expect(geo.fx).toBe(0);
+		expect(geo.fw).toBe(0.5);
+	});
+
+	it("keeps the stored geometry inside the model's bounds", () => {
+		const geo = cardGeometryFromScreen(
+			{ left: -40, top: -40, width: 4, height: 4 },
+			BOARD_W,
+			1,
+		);
+		expect(geo.fx).toBe(0);
+		expect(geo.fy).toBe(0);
+		expect(geo.fh).toBe(MIN_H_PX);
+		expect(geo.fw).toBeCloseTo(MIN_W_PX / BOARD_W, 6);
+	});
+
+	it("treats a non-positive scale as unscaled rather than exploding", () => {
+		for (const bad of [0, -0.5]) {
+			const geo = cardGeometryFromScreen({ left: 0, top: 100, width: 500, height: 200 }, BOARD_W, bad);
+			expect(geo.fy).toBe(100);
+			expect(geo.fh).toBe(200);
+		}
+	});
+
+	it("never asks for a width fraction above 1 on a board narrower than the minimum", () => {
+		const geo = cardGeometryFromScreen({ left: 0, top: 0, width: 60, height: 100 }, 60, 1);
+		expect(geo.fw).toBeLessThanOrEqual(1);
+		expect(geo.fw).toBeGreaterThan(0);
+	});
+});
+
+describe("fitted board round trip", () => {
+	it("recovers the stored geometry from where the card was painted", () => {
+		const cards = [card({ fy: 0, fh: 300 }), card({ id: "c2", fy: 316, fh: 300 })];
+		const boardHeight = 460;
+		const vScale = fitVerticalScale(cards, boardHeight);
+		expect(vScale).toBeLessThan(1);
+
+		for (const c of cards) {
+			const el = stub();
+			applyCardPositionFitted(asEl(el), c, vScale, BOARD_W);
+			const geo = cardGeometryFromScreen(rectOf(el), BOARD_W, vScale);
+			// Painting rounds to whole pixels, so allow the scale's worth of that.
+			const tol = 1 / vScale + 0.001;
+			expect(geo.fy).toBeCloseTo(c.fy as number, 0);
+			expect(Math.abs(geo.fy - (c.fy as number))).toBeLessThanOrEqual(tol);
+			expect(Math.abs(geo.fh - (c.fh as number))).toBeLessThanOrEqual(2 * tol);
+			expect(geo.fx).toBeCloseTo(c.fx as number, 2);
+			expect(geo.fw).toBeCloseTo(c.fw as number, 2);
+		}
+	});
+
+	it("does not walk the layout upward over repeated arrange-and-commit cycles", () => {
+		// Each cycle: paint the fitted board, then commit every card back from the
+		// pixels it was painted at (as ending a drag does). The stored layout has to
+		// hold still — committing the *scaled* pixels shrank it by the fit factor
+		// every single time, so the cards crept up the board and off their
+		// neighbours' edges.
+		const cards = [
+			card({ id: "a", fx: 0, fw: 0.5, fy: 0, fh: 400 }),
+			card({ id: "b", fx: 0.5, fw: 0.5, fy: 0, fh: 200 }),
+			card({ id: "c", fx: 0.5, fw: 0.5, fy: 216, fh: 184 }),
+		];
+		const boardHeight = 300;
+		const before = layoutHeight(cards);
+		expect(fitVerticalScale(cards, boardHeight)).toBeLessThan(1);
+
+		for (let i = 0; i < 10; i++) {
+			const vScale = fitVerticalScale(cards, boardHeight);
+			for (const c of cards) {
+				const el = stub();
+				applyCardPositionFitted(asEl(el), c, vScale, BOARD_W);
+				const geo = cardGeometryFromScreen(rectOf(el), BOARD_W, vScale);
+				c.fx = geo.fx;
+				c.fw = geo.fw;
+				c.fy = geo.fy;
+				c.fh = geo.fh;
+			}
+		}
+
+		// Whole-pixel painting means a little jitter, but no systematic drift.
+		expect(layoutHeight(cards)).toBeCloseTo(before, 0);
+		// The stacked pair on the right still meets card `b`'s bottom edge.
+		expect(cards[2].fy as number).toBeCloseTo(
+			(cards[1].fy as number) + (cards[1].fh as number) + 16,
+			0,
+		);
+	});
+});
+
+describe("boardFitScale", () => {
+	const cards = [card({ fy: 0, fh: 600 })];
+
+	function grid(fitted: boolean, clientHeight: number): HTMLElement {
+		return {
+			clientHeight,
+			closest: (sel: string) => (fitted && sel === ".hearth-fit" ? ({} as HTMLElement) : null),
+		} as unknown as HTMLElement;
+	}
+
+	it("is 1 on a scrolling board, however tall the cards are", () => {
+		expect(boardFitScale(grid(false, 100), cards)).toBe(1);
+	});
+
+	it("matches the fit squeeze on a fitted board", () => {
+		expect(boardFitScale(grid(true, 300), cards)).toBeCloseTo(0.5, 6);
+		// Cards that already fit are never enlarged.
+		expect(boardFitScale(grid(true, 900), cards)).toBe(1);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

#207 and #206 are the same bug, and it isn't the laptop, Windows 11 or the screen size: it's fit-to-page mode (the default) once the layout is taller than the pane — which is exactly what zooming Obsidian in causes, hence the zoom correlation and the "doesn't happen on my Windows 10 desktop" difference.

`applyCardPositionFitted` paints cards at `fy * vScale` / `fh * vScale` to squeeze the board into one screen. The drag engine in `src/grid.ts` treated the stored geometry and the painted pixels as the same coordinate space, in three places:

1. **The cards move after you finish arranging (#207, and #206's "card teleportation" video).** `end()` read `cardEl.offsetTop`/`offsetHeight` — the *squeezed* pixels — and stored them as `fy`/`fh`. The next draw squeezed them a second time, so the card sat above where it was dropped and shorter than it was made, and the gap between stacked neighbours narrowed. Because the true geometry had been overwritten, every further arrange session walked the whole board a little further up.
2. **Snapping doesn't work at some zoom levels (#206's first video).** The snap guides were built from the siblings' *unsqueezed* positions while the user dragged against their visible edges — tens of pixels away, so no guide ever came within `SNAP_THRESHOLD` and matching a neighbour's height or edge was impossible until you zoomed back out.
3. **A jolt on the first `pointermove`**, because the drag seeded `startTop`/`startHeight` from the stored values while `dx`/`dy` were screen pixels.

The fix moves the drag engine entirely into screen space and converts back on commit:

- new pure `cardGeometryFromScreen()` divides the vertical axis back out by the fit scale (`boardFitScale()` resolves it, 1 on a scrolling board), so a drop stays where it was dropped;
- `collectTargets()` and the drag seed read the cards' live footprints (`screenRect()`) instead of their stored geometry;
- committing re-runs the shared `applyFitLayout()` rather than positioning the dragged card with the unscaled helper — a commit can change the layout's total height and therefore the scale the *whole* board is drawn at, so repositioning one card alone left it in a different space from its neighbours. The observer-driven refit in `dashboard.ts` now calls that same helper, so the two paths cannot drift apart.

Nothing here changes the render-only nature of fitting: the stored geometry is still only ever written by an explicit user move/resize.

Note on behaviour that is *not* a bug: on a fitted board that already overflows, growing a card still rescales the board slightly on release. That is what "everything must fit one screen" means; it is now proportional and stable instead of compounding.

`test/gridfit.test.ts` adds 9 tests over the pure helpers (the geometry functions only touch `el.style`, so a stub element covers them in the existing node test env). The one that matters is the drift test: ten arrange-and-commit cycles must leave the layout height and the inter-card gap unmoved. Against the old commit path the same loop collapses a 400px layout to 300px and a 16px gap to 12px on the first pass.

## Related issue

Closes #207. Closes #206.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault

On that last box — I can't check it. This was written and verified in a headless environment: typecheck, `npm run lint` (0 errors), the full suite (620 passed, 1 skipped), `npm run build` and `npm run verify:manifests` all pass, and the drift/round-trip properties are pinned by tests, but nobody has dragged a card in Obsidian with this build. Worth a manual pass on a zoomed-in window before merging, ideally by @Zih-Ying or @darknebulosity on the machines that showed it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0113meVPTYxzPVJ3YgU9UcPm)_