### PR TITLE
Add a Slideshow card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ## [2.1.0]
 
+### Added
+
+- **A slideshow card.** **Notes & files → Slideshow** is the image embed with
+  more than one picture: it shows them in turn, on a timer you set. Choose the
+  pictures one by one — each can carry its own caption, and the list can be
+  reordered by hand — or point the card at a folder and let every image in it
+  (optionally including subfolders) play, so a card fills itself as you drop
+  photos in.
+
+  **The order is yours**: your own list order, by name, by date created or
+  modified (either direction), or shuffled — a shuffled card reshuffles between
+  passes, so it shows everything once per round without settling into the same
+  running order forever.
+
+  **And so is the way pictures change**: a plain cut, a crossfade, a slide or a
+  zoom, over as long as you like, with an optional slow zoom into each picture
+  while it is held. Pictures either fill the card or fit whole inside it, the
+  caption can be shown over them, and hovering brings up previous / pause / next
+  with the position. It rotates two `<img>` layers no matter how many pictures
+  there are, so a folder of hundreds costs the same as a pair — and it respects
+  low power mode and a reduced-motion preference, holding still rather than
+  animating.
+
 ### Fixed
 
 - **Arranging a fit-to-page board keeps the arrangement.** On a board whose

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ issue or email.
 - **Embed** — any note, image, canvas or `.base` file, rendered by Obsidian
   itself. Per-card zoom, optional in-place editing (raw or Live Preview), and a
   second view you can flip to with a switcher.
+- **Slideshow** — pictures from your vault, rotated on a timer. Pick them one by
+  one (each with its own caption) or point the card at a folder, with or without
+  its subfolders. Order by name, creation or modification date, your own list
+  order, or shuffled; choose the seconds per picture, the transition (cut,
+  crossfade, slide or zoom) and its length, an optional slow zoom while a picture
+  is held, and whether pictures fill the card or fit inside it. Hover for
+  previous / pause / next.
 - **Daily note** — always today's note, with one-click creation when missing.
 - **Excalidraw & canvas** — edge-to-edge templates with native pan/zoom.
 - **Plugin view** *(beta)* — host another plugin's side-panel view (calendar,

--- a/src/cardbodies.ts
+++ b/src/cardbodies.ts
@@ -12,7 +12,8 @@ import { type HomeView } from "./view";
  * Shared rendering helpers used by more than one card module (issue #103,
  * Phase B). Each kind's own render logic now lives in its `src/cards/<kind>.ts`
  * module; what remains here is only the cross-cutting machinery those modules
- * build on: the `emptyState` placeholder, the Markdown-embed core (used by the
+ * build on: the `emptyState` placeholder, the floating `cardOverlayButton`
+ * (daily, embed, slideshow), the Markdown-embed core (used by the
  * embed, daily, dataview and text cards), the daily-note path resolvers (daily,
  * embed, calendar, stats, heatmap), the vault-activity helpers (calendar,
  * heatmap), the free-form tile drag/resize grid (links, commands), the embed
@@ -70,6 +71,31 @@ export function emptyState(body: HTMLElement, icon: string, text: string): void 
 	const empty = body.createDiv("hearth-card-empty");
 	setIcon(empty.createDiv("hearth-card-empty-icon"), icon);
 	empty.createDiv({ cls: "hearth-card-empty-text", text });
+}
+
+
+/**
+ * A small action button floated over the card — the "open this file" affordance
+ * the daily, embed and slideshow cards each offer. It is attached to the card
+ * *element* rather than the body, so it takes no part in the body's scroll or
+ * flow, and falls back to the body when the card element can't be found (the
+ * card settings preview has no `.hearth-card` ancestor).
+ */
+export function cardOverlayButton(
+	body: HTMLElement,
+	icon: string,
+	label: string,
+	onClick: (evt: MouseEvent) => void,
+): HTMLButtonElement {
+	const cardEl = body.closest(".hearth-card");
+	const overlay = (cardEl ?? body).createDiv("hearth-card-actions-overlay");
+	const button = overlay.createEl("button", {
+		cls: "hearth-open-btn",
+		attr: { "aria-label": label },
+	});
+	setIcon(button, icon);
+	button.addEventListener("click", onClick);
+	return button;
 }
 
 

--- a/src/cards/README.md
+++ b/src/cards/README.md
@@ -50,9 +50,10 @@ Each kind's **render** and **editor** implementations now live in its own module
 keep only the helpers used by more than one kind:
 
 - `../cardbodies.ts` — the render helpers shared across kinds: the `emptyState`
-  placeholder, the Markdown-embed core, the daily-note path resolvers, the
-  vault-activity helpers, the free-form tile grid, the embed view-state cluster
-  and `feedHost`.
+  placeholder, the floating `cardOverlayButton` (the "open this file" affordance
+  on the daily, embed and slideshow cards), the Markdown-embed core, the
+  daily-note path resolvers, the vault-activity helpers, the free-form tile grid,
+  the embed view-state cluster and `feedHost`.
 - `../editors.ts` — the settings-modal framework (`CardSettingsModal`,
   `CardSettingsOptions`) and the generic editor helpers `addResetButton` and
   `moveItem`.
@@ -66,3 +67,12 @@ keep only the helpers used by more than one kind:
 The rule of thumb: logic used by a single kind belongs in that kind's module;
 logic shared across kinds stays in the relevant shared file, and the module
 imports it.
+
+One exception, for tests: a kind's *pure* logic sometimes lives one level up, in
+`src/<kind>.ts` (`taskscope.ts` for the tasks card, `slideshow.ts` for the
+slideshow card). A card module that imports `../editors.ts` sits in an import
+cycle — editors imports the registry barrel, which imports every card module —
+and a unit test that imports the card module directly walks into it, getting a
+half-built registry. Keeping the data-only functions in their own module, with no
+Obsidian imports at all, keeps them directly testable; the card module imports
+them like any other helper.

--- a/src/cards/daily.ts
+++ b/src/cards/daily.ts
@@ -1,5 +1,6 @@
 import { Component, Notice, setIcon, Setting, TFile } from "obsidian";
 import {
+	cardOverlayButton,
 	dailyNotesOptions,
 	emptyState,
 	livePreviewSetting,
@@ -58,14 +59,7 @@ export function renderDaily(
 	// as a floating overlay on the card element (not the body) so it doesn't
 	// affect the body's scroll/flow.
 	if (card.showOpenButton !== false) {
-		const cardEl = body.closest(".hearth-card");
-		const overlay = (cardEl ?? body).createDiv("hearth-card-actions-overlay");
-		const open = overlay.createEl("button", {
-			cls: "hearth-open-btn",
-			attr: { "aria-label": t().cards.daily.openToday },
-		});
-		setIcon(open, "square-pen");
-		open.addEventListener("click", () => {
+		cardOverlayButton(body, "square-pen", t().cards.daily.openToday, () => {
 			void openFile(view, file, "card");
 		});
 	}

--- a/src/cards/embed.ts
+++ b/src/cards/embed.ts
@@ -1,9 +1,10 @@
-import { Component, MarkdownRenderer, setIcon, Setting, TFile } from "obsidian";
+import { Component, MarkdownRenderer, Setting, TFile } from "obsidian";
 import { isBaseTarget, isEmbeddableBaseViewName, listBaseViews } from "../bases";
 import {
 	activeEmbedIndex,
 	activeEmbedView,
 	activeEmbedViewParams,
+	cardOverlayButton,
 	embedViews,
 	emptyState,
 	livePreviewSetting,
@@ -212,14 +213,7 @@ export function mountEmbedViewSwitcher(
  * part in the body's scroll or flow. Where the file lands follows the global
  * open-behaviour setting (#106). */
 function renderEmbedOpenButton(view: HomeView, file: TFile, body: HTMLElement): void {
-	const cardEl = body.closest(".hearth-card");
-	const overlay = (cardEl ?? body).createDiv("hearth-card-actions-overlay");
-	const open = overlay.createEl("button", {
-		cls: "hearth-open-btn",
-		attr: { "aria-label": t().cards.embed.openFile },
-	});
-	setIcon(open, "square-arrow-out-up-right");
-	open.addEventListener("click", (evt) => {
+	cardOverlayButton(body, "square-arrow-out-up-right", t().cards.embed.openFile, (evt) => {
 		void openFile(view, file, "card", evt);
 	});
 }

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -9,6 +9,7 @@ import type {
 import { t } from "../i18n";
 
 import { embedCard } from "./embed";
+import { slideshowCard } from "./slideshow";
 import { dailyCard } from "./daily";
 import { webCard } from "./web";
 import { bookmarksCard } from "./bookmarks";
@@ -53,6 +54,7 @@ export type {
  */
 export const CARD_DEFINITIONS: { [K in CardKind]: CardDefinition<K> } = {
 	embed: embedCard,
+	slideshow: slideshowCard,
 	daily: dailyCard,
 	web: webCard,
 	bookmarks: bookmarksCard,
@@ -117,7 +119,7 @@ export function cardDefinition(card: DashboardCard): CardDefinition {
 export const TEMPLATE_MENU_GROUPS: { category: CardCategory; templates: string[] }[] = [
 	{
 		category: "notes",
-		templates: ["note", "daily", "image", "canvas", "excalidraw", "base", "recent", "favorites", "bookmarks"],
+		templates: ["note", "daily", "image", "slideshow", "canvas", "excalidraw", "base", "recent", "favorites", "bookmarks"],
 	},
 	{ category: "planning", templates: ["tasks", "schedule", "calendar", "clock"] },
 	{ category: "vault", templates: ["search", "searchbar", "stats", "heatmap"] },

--- a/src/cards/slideshow.ts
+++ b/src/cards/slideshow.ts
@@ -37,7 +37,7 @@ import { type HomeView } from "../view";
 import { type CardDefinition, type CardEditorContext } from "./definition";
 
 /**
- * The slideshow card: a picture embed that rotates (issue #211).
+ * The slideshow card: a picture embed that rotates.
  *
  * It is the image embed's sibling — same `<img>`, same edge-to-edge framing —
  * with a list of pictures instead of one, and a timer. Pictures come either from

--- a/src/cards/slideshow.ts
+++ b/src/cards/slideshow.ts
@@ -1,0 +1,751 @@
+import { type App, Component, setIcon, Setting, TFile, TFolder } from "obsidian";
+import { cardOverlayButton, emptyState } from "../cardbodies";
+import { moveItem } from "../editors";
+import { isImageFile } from "../filetypes";
+import { t } from "../i18n";
+import { openFile } from "../opener";
+import { FilePickerModal, FolderPickerModal } from "../pickers";
+import {
+	SLIDESHOW_DEFAULT_INTERVAL_SEC,
+	SLIDESHOW_FITS,
+	SLIDESHOW_MAX_INTERVAL_SEC,
+	SLIDESHOW_MAX_TRANSITION_MS,
+	SLIDESHOW_ORDERS,
+	SLIDESHOW_TRANSITIONS,
+	SLIDESHOW_DEFAULT_TRANSITION_MS,
+	normalizeFolderPath,
+	orderPictures,
+	pictureLabel,
+	shufflePictures,
+	slideshowIntervalMs,
+	slideshowOrder,
+	slideshowReactsTo,
+	slideshowSource,
+	slideshowTransitionMs,
+	type SlideshowPicture,
+} from "../slideshow";
+import {
+	lowPowerActive,
+	type DashboardCard,
+	type SlideshowConfig,
+	type SlideshowFit,
+	type SlideshowOrder,
+	type SlideshowSlide,
+	type SlideshowTransition,
+} from "../types";
+import { type HomeView } from "../view";
+import { type CardDefinition, type CardEditorContext } from "./definition";
+
+/**
+ * The slideshow card: a picture embed that rotates (issue #211).
+ *
+ * It is the image embed's sibling — same `<img>`, same edge-to-edge framing —
+ * with a list of pictures instead of one, and a timer. Pictures come either from
+ * a hand-picked list (each entry can carry its own caption) or from a folder,
+ * optionally including subfolders; both can be ordered by name, creation or
+ * modification date, or shuffled.
+ *
+ * Two things are worth knowing about the implementation:
+ *
+ * - **Two layers, not N.** However many pictures a card has, only two `<img>`
+ *   elements exist: the one on screen and the one coming in. A card pointed at a
+ *   folder of 500 photos therefore decodes two of them, not 500, and every
+ *   transition is a plain CSS animation between that pair (see the
+ *   `.hearth-slide` rules in styles.css).
+ * - **The pure parts live next door.** Ordering, the folder-scope test, the
+ *   interval clamps and the redraw predicate are data-only functions in
+ *   `src/slideshow.ts`, unit-tested there; this module is the vault reads, the
+ *   DOM and the editor.
+ */
+
+// ---- Vault reads --------------------------------------------------------
+
+/** Turn a vault image file into a picture, carrying over a list entry's caption. */
+function pictureFor(file: TFile, caption?: string): SlideshowPicture {
+	return {
+		path: file.path,
+		name: file.basename,
+		created: file.stat?.ctime ?? 0,
+		modified: file.stat?.mtime ?? 0,
+		caption,
+	};
+}
+
+/** The hand-picked list, resolved against the vault. Entries whose file is gone
+ * (or was never an image) are dropped rather than drawn as a broken picture. */
+function listPictures(app: App, cfg: SlideshowConfig): SlideshowPicture[] {
+	const pictures: SlideshowPicture[] = [];
+	for (const slide of cfg.slides ?? []) {
+		const path = slide.path?.trim();
+		if (!path) continue;
+		const file = app.vault.getAbstractFileByPath(path);
+		if (file && isImageFile(file)) pictures.push(pictureFor(file, slide.caption));
+	}
+	return pictures;
+}
+
+/** Every image in the card's folder (and, when asked, its subfolders). */
+function folderPictures(app: App, cfg: SlideshowConfig): SlideshowPicture[] {
+	const scope = normalizeFolderPath(cfg.folder);
+	const root = scope === "" ? app.vault.getRoot() : app.vault.getAbstractFileByPath(scope);
+	if (!(root instanceof TFolder)) return [];
+	const pictures: SlideshowPicture[] = [];
+	const walk = (folder: TFolder) => {
+		for (const child of folder.children) {
+			if (child instanceof TFolder) {
+				if (cfg.includeSubfolders === true) walk(child);
+			} else if (isImageFile(child)) {
+				pictures.push(pictureFor(child));
+			}
+		}
+	};
+	walk(root);
+	return pictures;
+}
+
+/** Every picture the card shows, in display order. */
+export function collectSlideshowPictures(app: App, cfg: SlideshowConfig): SlideshowPicture[] {
+	const pictures =
+		slideshowSource(cfg) === "folder" ? folderPictures(app, cfg) : listPictures(app, cfg);
+	return orderPictures(pictures, slideshowOrder(cfg));
+}
+
+
+// ---- Render -------------------------------------------------------------
+
+/**
+ * Transient per-card rotation state, keyed by the card object (the same trick
+ * `activeEmbedView` uses). It survives body redraws — dropping a photo into a
+ * watched folder, or leaving arrange mode — so the slideshow picks up where it
+ * was instead of jumping back to the first picture, and resets when Obsidian
+ * reloads.
+ */
+interface SlideshowState {
+	/** Path of the picture that was on screen. */
+	path?: string;
+	/** Whether the viewer paused the rotation with the pause button. */
+	paused?: boolean;
+}
+
+const slideshowState = new WeakMap<DashboardCard, SlideshowState>();
+
+/** The animation-state classes a layer carries during a transition. Cleared
+ * before each swap so the next animation starts from scratch. */
+const LAYER_STATE_CLASSES = ["is-in-next", "is-in-prev", "is-out-next", "is-out-prev"];
+
+
+export function renderSlideshow(
+	view: HomeView,
+	card: DashboardCard,
+	body: HTMLElement,
+	component: Component,
+): void {
+	const cfg = card.slideshow ?? {};
+	const pictures = collectSlideshowPictures(view.app, cfg);
+	if (pictures.length === 0) {
+		emptyState(
+			body,
+			"images",
+			slideshowSource(cfg) === "folder"
+				? t().cards.empty.slideshowFolderEmpty
+				: t().cards.empty.slideshowEmpty,
+		);
+		return;
+	}
+
+	const state = slideshowState.get(card) ?? {};
+	slideshowState.set(card, state);
+
+	const holdMs = slideshowIntervalMs(cfg);
+	const order = slideshowOrder(cfg);
+	const count = pictures.length;
+
+	body.addClass("hearth-slideshow-host");
+	const stage = body.createDiv("hearth-slideshow");
+	stage.addClass(`is-trans-${cfg.transition ?? "fade"}`);
+	stage.addClass(cfg.fit === "contain" ? "is-fit-contain" : "is-fit-cover");
+	if (cfg.kenBurns) stage.addClass("is-kenburns");
+	stage.style.setProperty("--hearth-slide-ms", `${slideshowTransitionMs(cfg)}ms`);
+	// The slow zoom runs for exactly as long as the picture is held, so it never
+	// finishes early and sits still, nor gets cut off halfway.
+	stage.style.setProperty(
+		"--hearth-slide-hold",
+		`${holdMs || SLIDESHOW_DEFAULT_INTERVAL_SEC * 1000}ms`,
+	);
+
+	// Two layers for any number of pictures: the one on screen and the one coming
+	// in. Swapping which is "active" is the whole transition.
+	const layers = [0, 1].map(() => stage.createDiv("hearth-slide"));
+	const images = layers.map((layer) => {
+		const img = layer.createEl("img", { cls: "hearth-slide-img" });
+		// A picture is decoration here, not something to drag out of the card —
+		// the native image drag would otherwise fight the card's own in arrange mode.
+		img.draggable = false;
+		img.decoding = "async";
+		return img;
+	});
+
+	// Resume where the rotation was, when that picture is still in the set.
+	const resumeAt = pictures.findIndex((picture) => picture.path === state.path);
+	let index = resumeAt >= 0 ? resumeAt : 0;
+	let active = 0;
+	let hovering = false;
+
+	const resourcePath = (path: string): string | null => {
+		const file = view.app.vault.getAbstractFileByPath(path);
+		return file && isImageFile(file) ? view.app.vault.getResourcePath(file) : null;
+	};
+
+	const paint = (layer: number, picture: SlideshowPicture) => {
+		const img = images[layer];
+		img.src = resourcePath(picture.path) ?? "";
+		img.alt = pictureLabel(picture);
+	};
+
+	const caption = cfg.showCaption ? stage.createDiv("hearth-slide-caption") : null;
+	// A single picture has nothing to step through, so it gets no chrome — such a
+	// card is just an image embed, and dead buttons would suggest otherwise.
+	const controls =
+		cfg.controls === false || count < 2 ? null : stage.createDiv("hearth-slideshow-controls");
+	let pauseButton: HTMLButtonElement | null = null;
+	let counter: HTMLElement | null = null;
+
+	const updateChrome = () => {
+		const picture = pictures[index];
+		if (caption) caption.setText(pictureLabel(picture));
+		if (counter) counter.setText(`${index + 1}/${count}`);
+		if (pauseButton) {
+			const paused = state.paused === true;
+			setIcon(pauseButton, paused ? "play" : "pause");
+			const label = paused ? t().cards.slideshow.play : t().cards.slideshow.pause;
+			pauseButton.setAttribute("aria-label", label);
+			pauseButton.setAttribute("title", label);
+			pauseButton.toggleClass("is-paused", paused);
+		}
+	};
+
+	// ---- Rotation ----
+
+	let timer: number | null = null;
+	const stop = () => {
+		if (timer === null) return;
+		window.clearTimeout(timer);
+		timer = null;
+	};
+	// Low power mode switches off every timed refresh, this one included: the card
+	// keeps the picture it is on (and its controls still step through by hand).
+	const rotates = count > 1 && holdMs > 0 && !lowPowerActive(view.plugin.settings);
+	const schedule = () => {
+		stop();
+		if (!rotates || state.paused === true || hovering) return;
+		timer = window.setTimeout(() => {
+			advance(1);
+			schedule();
+		}, holdMs);
+	};
+	component.register(stop);
+
+	const swap = (target: number, direction: "next" | "prev") => {
+		if (target === index) return;
+		const incoming = 1 - active;
+		paint(incoming, pictures[target]);
+		// Clearing the state classes on both layers and reading a layout value in
+		// between makes the browser drop the finished animations, so the very same
+		// transition plays again on the next swap instead of staying at its end
+		// state.
+		layers[incoming].removeClasses(LAYER_STATE_CLASSES);
+		layers[active].removeClasses(LAYER_STATE_CLASSES);
+		void stage.offsetWidth;
+		layers[incoming].addClass("is-active", direction === "prev" ? "is-in-prev" : "is-in-next");
+		layers[active].removeClass("is-active");
+		layers[active].addClass(direction === "prev" ? "is-out-prev" : "is-out-next");
+		active = incoming;
+		index = target;
+		state.path = pictures[index].path;
+		updateChrome();
+	};
+
+	const advance = (step: 1 | -1) => {
+		if (count < 2) return;
+		let target = index + step;
+		if (target >= count) {
+			// A shuffled card reshuffles between passes, so a long slideshow doesn't
+			// repeat the same running order forever — while still showing every
+			// picture once per pass.
+			if (order === "random") reshuffle();
+			target = 0;
+		} else if (target < 0) {
+			target = count - 1;
+		}
+		swap(target, step > 0 ? "next" : "prev");
+	};
+
+	/** Reshuffle for the next pass, keeping the picture currently on screen out
+	 * of first place so nothing repeats across the seam. */
+	const reshuffle = () => {
+		const showing = pictures[index].path;
+		shufflePictures(pictures);
+		if (pictures[0].path === showing) {
+			const other = 1 + Math.floor(Math.random() * (count - 1));
+			[pictures[0], pictures[other]] = [pictures[other], pictures[0]];
+		}
+	};
+
+	/** A manual step: move, then restart the clock so the new picture gets a full
+	 * turn rather than whatever was left of the previous one's. */
+	const step = (by: 1 | -1) => {
+		advance(by);
+		schedule();
+	};
+
+	if (controls) mountControls();
+
+	// First paint: no transition, and the caption/counter filled in for it.
+	paint(active, pictures[index]);
+	layers[active].addClass("is-active");
+	state.path = pictures[index].path;
+	updateChrome();
+	schedule();
+
+	if (cfg.pauseOnHover === true) {
+		stage.addEventListener("pointerenter", () => {
+			hovering = true;
+			stop();
+		});
+		stage.addEventListener("pointerleave", () => {
+			hovering = false;
+			schedule();
+		});
+	}
+
+	// An optional overlay button that opens the picture on screen in its own tab,
+	// the same affordance (and default-off) as the embed card's (#144).
+	if (card.showOpenButton === true) {
+		cardOverlayButton(body, "square-arrow-out-up-right", t().cards.slideshow.openImage, (evt) => {
+			const file = view.app.vault.getAbstractFileByPath(pictures[index].path);
+			if (file instanceof TFile) void openFile(view, file, "card", evt);
+		});
+	}
+
+	function mountControls(): void {
+		if (!controls) return;
+		const button = (icon: string, label: string, onClick: () => void): HTMLButtonElement => {
+			const el = controls.createEl("button", {
+				cls: "hearth-slideshow-btn",
+				attr: { "aria-label": label, title: label },
+			});
+			setIcon(el, icon);
+			// Don't let a click on the controls start a card drag or reach the card.
+			el.addEventListener("pointerdown", (e) => e.stopPropagation());
+			el.addEventListener("click", (e) => {
+				e.stopPropagation();
+				onClick();
+			});
+			return el;
+		};
+
+		button("chevron-left", t().cards.slideshow.previous, () => step(-1));
+		// Pausing a card that isn't rotating would be a button that does nothing.
+		if (rotates) {
+			pauseButton = button("pause", t().cards.slideshow.pause, () => {
+				state.paused = state.paused === true ? undefined : true;
+				schedule();
+				updateChrome();
+			});
+		}
+		button("chevron-right", t().cards.slideshow.next, () => step(1));
+		counter = controls.createDiv({ cls: "hearth-slideshow-count" });
+		counter.setAttribute("aria-hidden", "true");
+	}
+}
+
+
+// ---- Editor -------------------------------------------------------------
+
+export function slideshowEditor(ctx: CardEditorContext, containerEl: HTMLElement): void {
+	const card = ctx.card;
+	const cfg = (card.slideshow ??= {});
+	const strings = t().editors.slideshow;
+
+	new Setting(containerEl)
+		.setName(strings.source)
+		.setDesc(strings.sourceDesc)
+		.addDropdown((d) => {
+			d.addOption("list", strings.sourceList);
+			d.addOption("folder", strings.sourceFolder);
+			d.setValue(slideshowSource(cfg)).onChange((v) => {
+				cfg.source = v === "folder" ? "folder" : undefined;
+				ctx.opts.save();
+				// The two sources are configured with completely different controls.
+				ctx.requestRender();
+			});
+		});
+
+	if (slideshowSource(cfg) === "folder") folderSection(ctx, containerEl, cfg);
+	else listSection(ctx, containerEl, cfg);
+
+	new Setting(containerEl).setName(strings.playbackHeading).setHeading();
+
+	new Setting(containerEl)
+		.setName(strings.order)
+		.setDesc(strings.orderDesc)
+		.addDropdown((d) => {
+			// "Manual" is the list's own order, which a folder doesn't have one of.
+			const orders =
+				slideshowSource(cfg) === "folder"
+					? SLIDESHOW_ORDERS.filter((o) => o !== "manual")
+					: SLIDESHOW_ORDERS;
+			for (const o of orders) d.addOption(o, strings.orders[o]);
+			d.setValue(slideshowOrder(cfg)).onChange((v) => {
+				cfg.order = v as SlideshowOrder;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			});
+		});
+
+	const interval = new Setting(containerEl)
+		.setName(strings.interval)
+		.setDesc(strings.intervalDesc);
+	interval.addText((txt) => {
+		txt
+			.setValue(String(cfg.intervalSec ?? SLIDESHOW_DEFAULT_INTERVAL_SEC))
+			.onChange((v) => {
+				// Saved per keystroke but not redrawn per keystroke: the new interval
+				// takes effect when the dialog closes (which redraws the board).
+				const n = parseInt(v, 10);
+				cfg.intervalSec =
+					Number.isNaN(n) || n < 0 ? undefined : Math.min(n, SLIDESHOW_MAX_INTERVAL_SEC);
+				ctx.opts.save();
+			});
+		txt.inputEl.type = "number";
+		txt.inputEl.addClass("hearth-count-input");
+		txt.inputEl.setAttribute("aria-label", strings.intervalAria);
+	});
+	interval.addExtraButton((b) =>
+		b
+			.setIcon("rotate-ccw")
+			.setTooltip(t().settings.resetField)
+			.onClick(() => {
+				cfg.intervalSec = undefined;
+				ctx.opts.save();
+				ctx.requestRender();
+				ctx.opts.rerender();
+			}),
+	);
+
+	new Setting(containerEl)
+		.setName(strings.transition)
+		.setDesc(strings.transitionDesc)
+		.addDropdown((d) => {
+			for (const tr of SLIDESHOW_TRANSITIONS) d.addOption(tr, strings.transitions[tr]);
+			d.setValue(cfg.transition ?? "fade").onChange((v) => {
+				cfg.transition = v as SlideshowTransition;
+				ctx.opts.save();
+				// The duration slider below is pointless for a cut.
+				ctx.requestRender();
+				ctx.opts.rerender();
+			});
+		});
+
+	if ((cfg.transition ?? "fade") !== "none") {
+		const speed = new Setting(containerEl)
+			.setName(strings.transitionSpeed)
+			.setDesc(strings.transitionSpeedDesc);
+		speed.addSlider((s) =>
+			s
+				.setLimits(100, SLIDESHOW_MAX_TRANSITION_MS, 100)
+				.setValue(slideshowTransitionMs(cfg))
+				.setDynamicTooltip()
+				.onChange((v) => {
+					// No redraw per step — dragging a slider would rebuild the board (and
+					// restart every slideshow on it) on every notch. It applies when the
+					// dialog closes, as the embed card's zoom slider does.
+					cfg.transitionMs = v === SLIDESHOW_DEFAULT_TRANSITION_MS ? undefined : v;
+					ctx.opts.save();
+				}),
+		);
+		speed.addExtraButton((b) =>
+			b
+				.setIcon("rotate-ccw")
+				.setTooltip(t().settings.resetSlider)
+				.onClick(() => {
+					cfg.transitionMs = undefined;
+					ctx.opts.save();
+					ctx.requestRender();
+					ctx.opts.rerender();
+				}),
+		);
+	}
+
+	new Setting(containerEl)
+		.setName(strings.kenBurns)
+		.setDesc(strings.kenBurnsDesc)
+		.addToggle((tg) =>
+			tg.setValue(cfg.kenBurns === true).onChange((v) => {
+				cfg.kenBurns = v || undefined;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			}),
+		);
+
+	new Setting(containerEl).setName(strings.displayHeading).setHeading();
+
+	new Setting(containerEl)
+		.setName(strings.fit)
+		.setDesc(strings.fitDesc)
+		.addDropdown((d) => {
+			for (const fit of SLIDESHOW_FITS) d.addOption(fit, strings.fits[fit]);
+			d.setValue(cfg.fit ?? "cover").onChange((v) => {
+				cfg.fit = v as SlideshowFit;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			});
+		});
+
+	toggle(ctx, containerEl, strings.controls, strings.controlsDesc, cfg.controls !== false, (v) => {
+		cfg.controls = v ? undefined : false;
+	});
+	toggle(ctx, containerEl, strings.caption, strings.captionDesc, cfg.showCaption === true, (v) => {
+		cfg.showCaption = v || undefined;
+	});
+	toggle(
+		ctx,
+		containerEl,
+		strings.pauseOnHover,
+		strings.pauseOnHoverDesc,
+		cfg.pauseOnHover === true,
+		(v) => {
+			cfg.pauseOnHover = v || undefined;
+		},
+	);
+	toggle(
+		ctx,
+		containerEl,
+		strings.openButton,
+		strings.openButtonDesc,
+		card.showOpenButton === true,
+		(v) => {
+			card.showOpenButton = v || undefined;
+		},
+	);
+}
+
+
+/** A save-and-redraw toggle row — every display option below is one. */
+function toggle(
+	ctx: CardEditorContext,
+	containerEl: HTMLElement,
+	name: string,
+	desc: string,
+	value: boolean,
+	onChange: (value: boolean) => void,
+): void {
+	new Setting(containerEl)
+		.setName(name)
+		.setDesc(desc)
+		.addToggle((tg) =>
+			tg.setValue(value).onChange((v) => {
+				onChange(v);
+				ctx.opts.save();
+				ctx.opts.rerender();
+			}),
+		);
+}
+
+
+/** The hand-picked list: one row per picture, plus the two ways to add. */
+function listSection(
+	ctx: CardEditorContext,
+	containerEl: HTMLElement,
+	cfg: SlideshowConfig,
+): void {
+	const strings = t().editors.slideshow;
+	const slides = (cfg.slides ??= []);
+
+	new Setting(containerEl).setName(strings.picturesHeading).setHeading();
+	if (slides.length === 0) {
+		new Setting(containerEl).setDesc(strings.picturesEmpty);
+	}
+
+	slides.forEach((slide, index) => {
+		const row = new Setting(containerEl).setClass("hearth-link-setting");
+		row.addText((txt) =>
+			txt
+				.setPlaceholder(strings.picturePlaceholder)
+				.setValue(slide.path)
+				.onChange((v) => {
+					slide.path = v;
+					ctx.opts.save();
+				}),
+		);
+		row.addExtraButton((b) =>
+			b
+				.setIcon("image")
+				.setTooltip(strings.pickPicture)
+				.onClick(() => {
+					openImagePicker(ctx, (file) => {
+						slide.path = file.path;
+						ctx.opts.save();
+						ctx.requestRender();
+					});
+				}),
+		);
+		row.addText((txt) =>
+			txt
+				.setPlaceholder(strings.captionPlaceholder)
+				.setValue(slide.caption ?? "")
+				.onChange((v) => {
+					slide.caption = v.trim() || undefined;
+					ctx.opts.save();
+				}),
+		);
+		row.addExtraButton((b) =>
+			b
+				.setIcon("chevron-up")
+				.setTooltip(strings.moveUp)
+				.setDisabled(index === 0)
+				.onClick(() => moveItem(ctx, slides, index, index - 1)),
+		);
+		row.addExtraButton((b) =>
+			b
+				.setIcon("chevron-down")
+				.setTooltip(strings.moveDown)
+				.setDisabled(index === slides.length - 1)
+				.onClick(() => moveItem(ctx, slides, index, index + 1)),
+		);
+		row.addExtraButton((b) =>
+			b
+				.setIcon("trash-2")
+				.setTooltip(strings.removePicture)
+				.onClick(() => {
+					slides.splice(index, 1);
+					ctx.opts.save();
+					ctx.requestRender();
+				}),
+		);
+	});
+
+	const add = new Setting(containerEl);
+	add.addButton((b) =>
+		b.setButtonText(strings.addPicture).onClick(() => {
+			openImagePicker(ctx, (file) => {
+				slides.push(newSlide(file.path));
+				ctx.opts.save();
+				ctx.requestRender();
+			});
+		}),
+	);
+	// The bulk add is the bridge between the two sources: take a folder's images
+	// as a starting point, then reorder, caption or prune them by hand — which a
+	// folder-source card can't do.
+	add.addButton((b) =>
+		b.setButtonText(strings.addFolderPictures).onClick(() => {
+			new FolderPickerModal(ctx.app, (folder) => {
+				const existing = new Set(slides.map((slide) => slide.path));
+				for (const picture of collectSlideshowPictures(ctx.app, {
+					source: "folder",
+					folder: folder.path,
+					order: "name",
+				})) {
+					if (!existing.has(picture.path)) slides.push(newSlide(picture.path));
+				}
+				ctx.opts.save();
+				ctx.requestRender();
+			}).open();
+		}),
+	);
+}
+
+
+/** A picture picker limited to the vault's images — a slideshow of PDFs isn't
+ * a thing, and the full file list buries the photos. */
+function openImagePicker(ctx: CardEditorContext, onChoose: (file: TFile) => void): void {
+	new FilePickerModal(ctx.app, onChoose, t().pickers.image, (file) => isImageFile(file)).open();
+}
+
+
+function newSlide(path: string): SlideshowSlide {
+	return {
+		id: `slide-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e4)}`,
+		path,
+	};
+}
+
+
+/** The folder source: which folder, and whether subfolders count. */
+function folderSection(
+	ctx: CardEditorContext,
+	containerEl: HTMLElement,
+	cfg: SlideshowConfig,
+): void {
+	const strings = t().editors.slideshow;
+	const setting = new Setting(containerEl).setName(strings.folder).setDesc(strings.folderDesc);
+	setting.addText((txt) =>
+		txt
+			.setPlaceholder(strings.folderPlaceholder)
+			.setValue(cfg.folder ?? "")
+			.onChange((v) => {
+				cfg.folder = v.trim() || undefined;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			}),
+	);
+	setting.addExtraButton((b) =>
+		b
+			.setIcon("folder-open")
+			.setTooltip(strings.pickFolder)
+			.onClick(() => {
+				new FolderPickerModal(ctx.app, (folder) => {
+					// The vault root is stored as "" rather than "/" (see normalizeFolderPath).
+					cfg.folder = folder.isRoot() ? undefined : folder.path;
+					ctx.opts.save();
+					ctx.requestRender();
+					ctx.opts.rerender();
+				}).open();
+			}),
+	);
+
+	toggle(
+		ctx,
+		containerEl,
+		strings.includeSubfolders,
+		strings.includeSubfoldersDesc,
+		cfg.includeSubfolders === true,
+		(v) => {
+			cfg.includeSubfolders = v || undefined;
+		},
+	);
+
+	// How many pictures the folder currently yields — the one number that tells
+	// you whether the folder (and the subfolder toggle) is the one you meant.
+	const found = collectSlideshowPictures(ctx.app, cfg).length;
+	new Setting(containerEl).setDesc(strings.folderCount(found));
+}
+
+
+/** Pictures from the vault, rotated on a timer. */
+export const slideshowCard: CardDefinition<"slideshow"> = {
+	kind: "slideshow",
+	templates: [
+		{
+			id: "slideshow",
+			name: "Slideshow",
+			icon: "images",
+			build: () => ({ kind: "slideshow", title: "Slideshow", slideshow: { slides: [] }, w: 4, h: 3 }),
+		},
+	],
+	render: (view, card, body, component) => renderSlideshow(view, card, body, component),
+	renderEditor: (container, ctx) => slideshowEditor(ctx, container),
+	cloneConfig: (source, copy) => {
+		if (!source.slideshow) return;
+		copy.slideshow = {
+			...source.slideshow,
+			slides: source.slideshow.slides?.map((slide) => ({ ...slide })),
+		};
+	},
+	// A folder card has to notice the photo just dropped into it, and a list card
+	// the picture that was deleted or renamed — but neither cares about an edit to
+	// an unrelated note, which is why this has its own predicate rather than
+	// redrawing (and restarting the rotation) on every vault event.
+	liveness: { mode: "vault", shouldRedraw: (card, ev) => slideshowReactsTo(card, ev) },
+};

--- a/src/filetypes.ts
+++ b/src/filetypes.ts
@@ -16,6 +16,7 @@ export interface FileTypeGroup {
 
 export const FOLDERS_GROUP_ID = "folders";
 export const EXCALIDRAW_GROUP_ID = "excalidraw";
+export const IMAGES_GROUP_ID = "images";
 export const OTHER_GROUP_ID = "other";
 
 /** Community plugin id for Excalidraw (used to detect drawing support). */
@@ -51,6 +52,18 @@ const EXT_TO_GROUP: Map<string, FileTypeGroup> = (() => {
 
 const EXCALIDRAW_GROUP = FILE_TYPE_GROUPS.find((g) => g.id === EXCALIDRAW_GROUP_ID)!;
 const OTHER_GROUP = FILE_TYPE_GROUPS.find((g) => g.id === OTHER_GROUP_ID)!;
+
+/** The picture formats Hearth renders as an `<img>` — the "images" group's own
+ * extensions, so the one list drives the search filter, the widget-tile icons
+ * (#119) and the slideshow card rather than each keeping a copy. */
+export const IMAGE_EXTENSIONS: ReadonlySet<string> = new Set(
+	FILE_TYPE_GROUPS.find((g) => g.id === IMAGES_GROUP_ID)!.extensions,
+);
+
+/** Whether this file is a picture Hearth can show (see IMAGE_EXTENSIONS). */
+export function isImageFile(file: TAbstractFile): file is TFile {
+	return file instanceof TFile && IMAGE_EXTENSIONS.has(file.extension.toLowerCase());
+}
 
 /**
  * Excalidraw drawings are stored either as `*.excalidraw` files or, more

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -28,6 +28,10 @@ import {
 	type RssConfig,
 	type RssSource,
 	type SavedSearchConfig,
+	type SlideshowConfig,
+	type SlideshowOrder,
+	type SlideshowSlide,
+	type SlideshowTransition,
 	type TaskFieldDef,
 	type TaskFieldKey,
 	type TaskValueMap,
@@ -39,6 +43,12 @@ import {
 } from "./types";
 import { CARD_KINDS } from "./cards";
 import { isEmbeddableBaseViewName } from "./bases";
+import {
+	SLIDESHOW_MAX_INTERVAL_SEC,
+	SLIDESHOW_MAX_TRANSITION_MS,
+	SLIDESHOW_ORDERS,
+	SLIDESHOW_TRANSITIONS,
+} from "./slideshow";
 import { DATACORE_LANGUAGES, type DatacoreLanguage } from "./datacore";
 import {
 	GIT_ACTION_STYLES,
@@ -362,6 +372,9 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 	}
 	if (r.rss && typeof r.rss === "object") {
 		card.rss = sanitizeRss(r.rss as Record<string, unknown>);
+	}
+	if (r.slideshow && typeof r.slideshow === "object") {
+		card.slideshow = sanitizeSlideshow(r.slideshow as Record<string, unknown>);
 	}
 	if (r.jira !== undefined) {
 		card.jira = sanitizeJira(r.jira);
@@ -738,6 +751,54 @@ function sanitizeRss(r: Record<string, unknown>): RssConfig {
 	if (typeof r.showExcerpt === "boolean") cfg.showExcerpt = r.showExcerpt;
 	if (typeof r.showDate === "boolean") cfg.showDate = r.showDate;
 	if (typeof r.mergeAll === "boolean") cfg.mergeAll = r.mergeAll;
+	return cfg;
+}
+
+function sanitizeSlide(raw: unknown): SlideshowSlide | null {
+	if (!raw || typeof raw !== "object") return null;
+	const r = raw as Record<string, unknown>;
+	const path = str(r.path);
+	if (path === undefined) return null;
+	const slide: SlideshowSlide = {
+		id: str(r.id) ?? `slide-${Math.random().toString(36).slice(2)}`,
+		path,
+	};
+	const caption = str(r.caption);
+	if (caption !== undefined) slide.caption = caption;
+	return slide;
+}
+
+/** Allowlist and clamp an imported slideshow card configuration. The numeric
+ * fields are clamped to the same bounds the card itself enforces, so an imported
+ * layout can't schedule a runaway timer or a minute-long transition. */
+function sanitizeSlideshow(r: Record<string, unknown>): SlideshowConfig {
+	const cfg: SlideshowConfig = {};
+	if (r.source === "folder") cfg.source = "folder";
+	if (Array.isArray(r.slides)) {
+		cfg.slides = r.slides
+			.map(sanitizeSlide)
+			.filter((s): s is SlideshowSlide => s !== null);
+	}
+	const folder = str(r.folder);
+	if (folder !== undefined) cfg.folder = folder;
+	if (typeof r.includeSubfolders === "boolean") cfg.includeSubfolders = r.includeSubfolders;
+	if (SLIDESHOW_ORDERS.includes(r.order as SlideshowOrder)) {
+		cfg.order = r.order as SlideshowOrder;
+	}
+	if (typeof r.intervalSec === "number" && Number.isFinite(r.intervalSec)) {
+		cfg.intervalSec = clampNum(r.intervalSec, 0, SLIDESHOW_MAX_INTERVAL_SEC, 0);
+	}
+	if (SLIDESHOW_TRANSITIONS.includes(r.transition as SlideshowTransition)) {
+		cfg.transition = r.transition as SlideshowTransition;
+	}
+	if (typeof r.transitionMs === "number" && Number.isFinite(r.transitionMs)) {
+		cfg.transitionMs = clampNum(r.transitionMs, 0, SLIDESHOW_MAX_TRANSITION_MS, 0);
+	}
+	if (typeof r.kenBurns === "boolean") cfg.kenBurns = r.kenBurns;
+	if (r.fit === "contain" || r.fit === "cover") cfg.fit = r.fit;
+	if (typeof r.controls === "boolean") cfg.controls = r.controls;
+	if (typeof r.showCaption === "boolean") cfg.showCaption = r.showCaption;
+	if (typeof r.pauseOnHover === "boolean") cfg.pauseOnHover = r.pauseOnHover;
 	return cfg;
 }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -102,6 +102,8 @@ export const en = {
 		fileToEmbed: "Pick a file to embed…",
 		command: "Pick a command…",
 		noteToFavorite: "Pick a note to favorite…",
+		folder: "Pick a folder…",
+		image: "Pick an image…",
 	},
 
 	// ---- Dashboard toolbar & card controls -----------------------------
@@ -395,6 +397,7 @@ export const en = {
 				"web, RSS, calendar-subscription and Jira cards stop refreshing on a timer (manual refresh still works)",
 			effectLiveRefresh: "the dashboard stops rebuilding itself on vault changes",
 			effectClock: "clock cards drop seconds and the sweeping second hand",
+			effectSlideshow: "slideshow cards hold one picture instead of rotating",
 			/** Shown in the sections whose settings the mode currently overrides. */
 			overridden:
 				"Low power mode is on, so these are overridden right now. They are " +
@@ -867,6 +870,7 @@ export const en = {
 		done: "Done",
 		kinds: {
 			embed: "Embed (note / image / base)",
+			slideshow: "Slideshow",
 			daily: "Daily note (today)",
 			web: "Web page (iframe)",
 			bookmarks: "Bookmarks",
@@ -933,6 +937,80 @@ export const en = {
 			openButton: "Open button",
 			openButtonDesc:
 				"Show a button that opens the embedded file in its own tab. Off by default.",
+		},
+		slideshow: {
+			source: "Pictures from",
+			sourceDesc:
+				"A list you pick picture by picture, or every image in a folder.",
+			sourceList: "A list of pictures",
+			sourceFolder: "A folder",
+			picturesHeading: "Pictures",
+			picturesEmpty: "No pictures yet — add one below.",
+			picturePlaceholder: "Image path",
+			captionPlaceholder: "Caption (optional)",
+			pickPicture: "Pick an image",
+			addPicture: "Add picture",
+			addFolderPictures: "Add a folder's pictures",
+			removePicture: "Remove picture",
+			moveUp: "Move up",
+			moveDown: "Move down",
+			folder: "Folder",
+			folderDesc: "Every image in this folder is shown. Leave empty for the vault root.",
+			folderPlaceholder: "Attachments/Photos",
+			pickFolder: "Pick a folder",
+			includeSubfolders: "Include subfolders",
+			includeSubfoldersDesc: "Also show images inside this folder's subfolders.",
+			folderCount: (count: number) =>
+				count === 1 ? "1 image found here right now." : `${count} images found here right now.`,
+			playbackHeading: "Playback",
+			order: "Order",
+			orderDesc: "The order the pictures are shown in.",
+			orders: {
+				manual: "List order",
+				name: "Name (A → Z)",
+				nameDesc: "Name (Z → A)",
+				created: "Date created (oldest first)",
+				createdDesc: "Date created (newest first)",
+				modified: "Date modified (oldest first)",
+				modifiedDesc: "Date modified (newest first)",
+				random: "Random",
+			},
+			interval: "Seconds per picture",
+			intervalDesc:
+				"How long each picture is shown. 0 holds the first picture and turns the " +
+				"rotation off; low power mode pauses it too.",
+			intervalAria: "Seconds each picture is shown",
+			transition: "Transition",
+			transitionDesc: "How one picture gives way to the next.",
+			transitions: {
+				none: "Cut (no animation)",
+				fade: "Crossfade",
+				slide: "Slide",
+				zoom: "Zoom",
+			},
+			transitionSpeed: "Transition length",
+			transitionSpeedDesc: "How long the transition takes, in milliseconds.",
+			kenBurns: "Slow zoom",
+			kenBurnsDesc:
+				"Drift slowly into each picture while it is shown (the “Ken Burns” effect).",
+			displayHeading: "Display",
+			fit: "Fit",
+			fitDesc: "How each picture fills the card.",
+			fits: {
+				cover: "Fill the card (crop)",
+				contain: "Fit the whole picture",
+			},
+			controls: "Controls",
+			controlsDesc:
+				"Show previous / pause / next buttons and the position, on hover. On by default.",
+			caption: "Caption",
+			captionDesc:
+				"Show each picture's caption over it, falling back to its file name.",
+			pauseOnHover: "Pause on hover",
+			pauseOnHoverDesc: "Hold the current picture while the pointer is over the card.",
+			openButton: "Open button",
+			openButtonDesc:
+				"Show a button that opens the picture on screen in its own tab. Off by default.",
 		},
 		daily: {
 			editable: "Editable",
@@ -1880,6 +1958,8 @@ export const en = {
 			searchNoQuery: "Set a query in card settings",
 			searchNoMatches: "No matches",
 			embedPickFile: "Pick a file to embed in settings",
+			slideshowEmpty: "Add pictures in card settings",
+			slideshowFolderEmpty: "No images in this folder",
 			embedEnableBases: "Enable the core Bases plugin to embed .base files",
 			embedEnableCanvas: "Enable the core Canvas plugin to embed canvases",
 			embedInstallExcalidraw: "Install the Excalidraw plugin to embed drawings",
@@ -1946,6 +2026,13 @@ export const en = {
 			/** Switcher button label when a view has no file chosen yet. */
 			viewFallback: (n: number) => `View ${n}`,
 			switchTo: (label: string) => `Switch to ${label}`,
+		},
+		slideshow: {
+			previous: "Previous picture",
+			next: "Next picture",
+			pause: "Pause the slideshow",
+			play: "Resume the slideshow",
+			openImage: "Open this picture",
 		},
 		text: {
 			placeholder: "Jot something down…",
@@ -2334,6 +2421,7 @@ export const en = {
 	templates: {
 		note: "Embedded note",
 		image: "Embedded image",
+		slideshow: "Slideshow",
 		base: "Embedded base",
 		excalidraw: "Excalidraw drawing",
 		canvas: "Embedded canvas",
@@ -2370,6 +2458,7 @@ export const en = {
 	templateDescriptions: {
 		note: "Any note, rendered live on the board",
 		image: "A picture from the vault, edge to edge",
+		slideshow: "Pictures from a list or a folder, rotated on a timer",
 		base: "A .base file, rendered by Obsidian's Bases",
 		excalidraw: "An Excalidraw drawing with native pan and zoom",
 		canvas: "A canvas you can pan around in place",

--- a/src/pickers.ts
+++ b/src/pickers.ts
@@ -1,4 +1,4 @@
-import { App, Command, FuzzySuggestModal, TFile } from "obsidian";
+import { App, Command, FuzzySuggestModal, TFile, TFolder } from "obsidian";
 import { t } from "./i18n";
 
 /**
@@ -32,6 +32,44 @@ export class FilePickerModal extends FuzzySuggestModal<TFile> {
 
 	onChooseItem(file: TFile): void {
 		this.onChoose(file);
+	}
+}
+
+/**
+ * A fuzzy folder picker, used where a card is scoped to a folder rather than to
+ * one file (the slideshow card's folder source). The vault root is offered as
+ * "/" so "every image in the vault" is reachable without typing a path.
+ */
+export class FolderPickerModal extends FuzzySuggestModal<TFolder> {
+	private onChoose: (folder: TFolder) => void;
+
+	constructor(app: App, onChoose: (folder: TFolder) => void, placeholder?: string) {
+		super(app);
+		this.onChoose = onChoose;
+		this.setPlaceholder(placeholder ?? t().pickers.folder);
+	}
+
+	getItems(): TFolder[] {
+		const root = this.app.vault.getRoot();
+		const folders: TFolder[] = [root];
+		const walk = (folder: TFolder) => {
+			for (const child of folder.children) {
+				if (child instanceof TFolder) {
+					folders.push(child);
+					walk(child);
+				}
+			}
+		};
+		walk(root);
+		return folders;
+	}
+
+	getItemText(folder: TFolder): string {
+		return folder.path;
+	}
+
+	onChooseItem(folder: TFolder): void {
+		this.onChoose(folder);
 	}
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -771,6 +771,7 @@ export class HomeSettingTab extends PluginSettingTab {
 			strings.effectRefresh,
 			strings.effectLiveRefresh,
 			strings.effectClock,
+			strings.effectSlideshow,
 		]) {
 			list.createEl("li", { text: line });
 		}

--- a/src/slideshow.ts
+++ b/src/slideshow.ts
@@ -9,7 +9,7 @@ import type {
 } from "./types";
 
 /**
- * The slideshow card's pure half (issue #211): which pictures a card shows, in
+ * The slideshow card's pure half: which pictures a card shows, in
  * what order, how fast, and which vault events are worth a redraw. Data in, data
  * out — no vault, no DOM, no Obsidian imports at all — so all of it is
  * unit-tested in test/slideshow.test.ts.

--- a/src/slideshow.ts
+++ b/src/slideshow.ts
@@ -1,0 +1,207 @@
+import type { VaultEvent } from "./cardevents";
+import type {
+	DashboardCard,
+	SlideshowConfig,
+	SlideshowFit,
+	SlideshowOrder,
+	SlideshowSource,
+	SlideshowTransition,
+} from "./types";
+
+/**
+ * The slideshow card's pure half (issue #211): which pictures a card shows, in
+ * what order, how fast, and which vault events are worth a redraw. Data in, data
+ * out — no vault, no DOM, no Obsidian imports at all — so all of it is
+ * unit-tested in test/slideshow.test.ts.
+ *
+ * It lives here rather than in `src/cards/slideshow.ts` for the same reason
+ * `taskscope.ts` does: the card module imports the settings-modal helpers, which
+ * import the card registry, which imports the card module — a cycle that a test
+ * importing the card module directly walks straight into. Everything that
+ * touches the vault or draws anything stays in the card module.
+ */
+
+/** Seconds a picture is held when the card doesn't say. */
+export const SLIDESHOW_DEFAULT_INTERVAL_SEC = 8;
+/** Longest hold a card can be configured with (an hour) — a guard against a
+ * hand-edited data.json, not a limit anyone reaches through the editor. */
+export const SLIDESHOW_MAX_INTERVAL_SEC = 3600;
+/** Transition length when the card doesn't say, in milliseconds. */
+export const SLIDESHOW_DEFAULT_TRANSITION_MS = 700;
+/** Longest transition a card can be configured with. */
+export const SLIDESHOW_MAX_TRANSITION_MS = 3000;
+
+/** The orders offered in the editor, in dropdown order. */
+export const SLIDESHOW_ORDERS: SlideshowOrder[] = [
+	"manual",
+	"name",
+	"nameDesc",
+	"created",
+	"createdDesc",
+	"modified",
+	"modifiedDesc",
+	"random",
+];
+
+/** The transitions offered in the editor, in dropdown order. */
+export const SLIDESHOW_TRANSITIONS: SlideshowTransition[] = ["none", "fade", "slide", "zoom"];
+
+/** The fit modes offered in the editor, in dropdown order. */
+export const SLIDESHOW_FITS: SlideshowFit[] = ["cover", "contain"];
+
+/**
+ * One picture, reduced to what ordering and drawing need. Deliberately plain
+ * data — no `TFile` — so the ordering below is testable without a vault.
+ */
+export interface SlideshowPicture {
+	/** Vault path of the image. */
+	path: string;
+	/** Basename: the sort key of the by-name orders. */
+	name: string;
+	/** Vault ctime in ms, or 0 when unknown. */
+	created: number;
+	/** Vault mtime in ms, or 0 when unknown. */
+	modified: number;
+	/** Caption from the card's list, when the entry carries one. */
+	caption?: string;
+}
+
+/** Where a card takes its pictures from, defaulting to the hand-picked list. */
+export function slideshowSource(cfg: SlideshowConfig): SlideshowSource {
+	return cfg.source === "folder" ? "folder" : "list";
+}
+
+/**
+ * The order a card actually shows its pictures in. "manual" means "the order the
+ * list is in", which a folder has none of — a folder source resolves it to
+ * by-name instead, so such a card never falls back to the vault's own arbitrary
+ * child order.
+ */
+export function slideshowOrder(cfg: SlideshowConfig): SlideshowOrder {
+	const order = cfg.order ?? "manual";
+	if (order === "manual" && slideshowSource(cfg) === "folder") return "name";
+	return order;
+}
+
+/** How long one picture is held, in milliseconds. 0 means "don't rotate" —
+ * either the card asked for it (interval 0) or the stored value is unusable. */
+export function slideshowIntervalMs(cfg: SlideshowConfig): number {
+	const seconds = cfg.intervalSec ?? SLIDESHOW_DEFAULT_INTERVAL_SEC;
+	if (!Number.isFinite(seconds) || seconds <= 0) return 0;
+	return Math.min(seconds, SLIDESHOW_MAX_INTERVAL_SEC) * 1000;
+}
+
+/** How long one picture takes to give way to the next, in milliseconds. */
+export function slideshowTransitionMs(cfg: SlideshowConfig): number {
+	const ms = cfg.transitionMs ?? SLIDESHOW_DEFAULT_TRANSITION_MS;
+	if (!Number.isFinite(ms) || ms < 0) return SLIDESHOW_DEFAULT_TRANSITION_MS;
+	return Math.min(ms, SLIDESHOW_MAX_TRANSITION_MS);
+}
+
+/** A folder path in the form the scope test wants: no leading or trailing
+ * slash, with the vault root as the empty string. */
+export function normalizeFolderPath(folder: string | undefined): string {
+	return (folder ?? "").trim().replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+/**
+ * Whether `path` is inside the card's folder scope. Without `includeSubfolders`
+ * only direct children count, so a folder of albums doesn't silently pull in
+ * every album. An empty (or "/") scope is the vault root.
+ */
+export function inSlideshowFolder(
+	folder: string | undefined,
+	path: string,
+	includeSubfolders = false,
+): boolean {
+	const scope = normalizeFolderPath(folder);
+	const prefix = scope === "" ? "" : `${scope}/`;
+	if (!path.startsWith(prefix)) return false;
+	const rest = path.slice(prefix.length);
+	if (rest === "") return false;
+	return includeSubfolders || !rest.includes("/");
+}
+
+/** Whether `path` is the scope folder itself or one of its ancestors — the
+ * shapes a rename can take that move the whole scope somewhere else. */
+function holdsFolderScope(folder: string | undefined, path: string): boolean {
+	const scope = normalizeFolderPath(folder);
+	if (scope === "") return false;
+	return scope === path || scope.startsWith(`${path}/`);
+}
+
+/** Whether a listed path is, or lives under, an event's path. Covers a folder
+ * rename, which arrives as one event for the folder rather than one per file. */
+function pathTouches(listed: string, path: string): boolean {
+	return listed === path || listed.startsWith(`${path}/`);
+}
+
+/**
+ * Whether a vault event can change what a slideshow card shows.
+ *
+ * Only existence events can: a file edit or a metadata reparse never adds or
+ * removes a picture, and redrawing on either would restart the rotation from the
+ * first slide every time an unrelated note was saved. Beyond that the test is
+ * deliberately generous — a needless redraw costs one image decode, while a
+ * missed one leaves a folder card blind to the photo just dropped into it.
+ */
+export function slideshowReactsTo(card: DashboardCard, ev: VaultEvent): boolean {
+	if (ev.kind === "modify" || ev.kind === "meta") return false;
+	const cfg = card.slideshow ?? {};
+	const paths = ev.oldPath ? [ev.file.path, ev.oldPath] : [ev.file.path];
+	if (slideshowSource(cfg) === "folder") {
+		return paths.some(
+			(path) =>
+				inSlideshowFolder(cfg.folder, path, cfg.includeSubfolders === true) ||
+				holdsFolderScope(cfg.folder, path),
+		);
+	}
+	const listed = (cfg.slides ?? []).map((slide) => slide.path);
+	return paths.some((path) => listed.some((entry) => pathTouches(entry, path)));
+}
+
+/** Fisher-Yates, in place — the shuffle behind the "random" order. */
+export function shufflePictures<T>(items: T[]): T[] {
+	for (let i = items.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[items[i], items[j]] = [items[j], items[i]];
+	}
+	return items;
+}
+
+/**
+ * The pictures in display order. Every comparison falls back to the path, so two
+ * files sharing a name or a timestamp keep a stable order instead of reshuffling
+ * themselves on every redraw. "manual" is the input order; "random" is a fresh
+ * shuffle. Never mutates its input.
+ */
+export function orderPictures(
+	pictures: SlideshowPicture[],
+	order: SlideshowOrder,
+): SlideshowPicture[] {
+	const sorted = [...pictures];
+	const byPath = (a: SlideshowPicture, b: SlideshowPicture) => a.path.localeCompare(b.path);
+	switch (order) {
+		case "manual":
+			return sorted;
+		case "random":
+			return shufflePictures(sorted);
+		case "name":
+			return sorted.sort((a, b) => a.name.localeCompare(b.name) || byPath(a, b));
+		case "nameDesc":
+			return sorted.sort((a, b) => b.name.localeCompare(a.name) || byPath(a, b));
+		case "created":
+			return sorted.sort((a, b) => a.created - b.created || byPath(a, b));
+		case "createdDesc":
+			return sorted.sort((a, b) => b.created - a.created || byPath(a, b));
+		case "modified":
+			return sorted.sort((a, b) => a.modified - b.modified || byPath(a, b));
+		case "modifiedDesc":
+			return sorted.sort((a, b) => b.modified - a.modified || byPath(a, b));
+	}
+}
+
+/** What a picture is called on screen: its own caption, or the file's basename. */
+export function pictureLabel(picture: SlideshowPicture): string {
+	return picture.caption?.trim() || picture.name;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ import type {
 /** The kind of content a dashboard card renders. */
 export type CardKind =
 	| "embed"
+	| "slideshow"
 	| "daily"
 	| "web"
 	| "bookmarks"
@@ -1026,6 +1027,79 @@ export interface EmbedView {
 	livePreview?: boolean;
 }
 
+/** One hand-picked picture in a "slideshow" card. Kept as its own object (rather
+ * than a bare path) so a picture can carry a caption and keep a stable identity
+ * while the list is reordered. */
+export interface SlideshowSlide {
+	id: string;
+	/** Vault path of the image file. */
+	path: string;
+	/** Caption shown over the picture; falls back to the file's basename. */
+	caption?: string;
+}
+
+/** Where a "slideshow" card takes its pictures from: the hand-picked `slides`
+ * list, or every image inside a folder. */
+export type SlideshowSource = "list" | "folder";
+
+/**
+ * The order a slideshow shows its pictures in.
+ *
+ * "manual" is the `slides` list's own order — the only order a folder source
+ * cannot honour, so it resolves to "name" there (see `slideshowOrder`).
+ * "random" reshuffles after every full pass, so nothing repeats until every
+ * picture has been shown.
+ */
+export type SlideshowOrder =
+	| "manual"
+	| "name"
+	| "nameDesc"
+	| "created"
+	| "createdDesc"
+	| "modified"
+	| "modifiedDesc"
+	| "random";
+
+/** How one picture gives way to the next. "none" is a cut. */
+export type SlideshowTransition = "none" | "fade" | "slide" | "zoom";
+
+/** How a picture fills the card: cropped to fill it edge to edge ("cover"), or
+ * scaled down whole with letterboxing ("contain"). */
+export type SlideshowFit = "cover" | "contain";
+
+/** Per-card configuration for a "slideshow" card — a picture embed that
+ * rotates. All fields are optional; the defaults noted below are the ones a
+ * freshly added card runs with. */
+export interface SlideshowConfig {
+	/** Where the pictures come from. Default "list". */
+	source?: SlideshowSource;
+	/** The hand-picked pictures, in list order (source "list"). */
+	slides?: SlideshowSlide[];
+	/** Vault folder every image is taken from (source "folder"). */
+	folder?: string;
+	/** Also take images from subfolders of `folder`. Default false. */
+	includeSubfolders?: boolean;
+	/** Display order. Default "manual" (a folder source: "name"). */
+	order?: SlideshowOrder;
+	/** Seconds each picture is shown. Default 8; 0 holds the first picture. */
+	intervalSec?: number;
+	/** How one picture gives way to the next. Default "fade". */
+	transition?: SlideshowTransition;
+	/** Transition length in milliseconds. Default 700. */
+	transitionMs?: number;
+	/** Slowly zoom the picture while it is shown (the "Ken Burns" effect).
+	 * Default false. */
+	kenBurns?: boolean;
+	/** How the picture fills the card. Default "cover". */
+	fit?: SlideshowFit;
+	/** Show the previous/pause/next controls on hover. Default true. */
+	controls?: boolean;
+	/** Show the picture's caption (or file name) over it. Default false. */
+	showCaption?: boolean;
+	/** Hold the current picture while the pointer is over the card. Default false. */
+	pauseOnHover?: boolean;
+}
+
 /** A single tile inside a "links" (launchpad) card. */
 export interface LinkItem {
 	id: string;
@@ -1062,6 +1136,9 @@ export interface DashboardCard {
 	/** kind === "embed": Bases view name to embed when target is a .base file;
 	 * omitted means the default view. */
 	baseView?: string;
+	/** kind === "slideshow": the pictures, where they come from, and how they
+	 * rotate. */
+	slideshow?: SlideshowConfig;
 	/** kind === "web": the web page URL to embed in an iframe. */
 	url?: string;
 	/** kind === "web": allow the framed page same-origin access. Off by default

--- a/src/widgeticon.ts
+++ b/src/widgeticon.ts
@@ -1,9 +1,7 @@
 import { setIcon, setTooltip, TFile } from "obsidian";
 import type { HomeView } from "./view";
+import { isImageFile } from "./filetypes";
 import { t } from "./i18n";
-
-/** Image file extensions a widget tile can use as its icon (#119). */
-const IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "avif", "ico"]);
 
 /**
  * Resolve an icon string to a vault image file, or null when it isn't one. A
@@ -16,7 +14,7 @@ export function resolveIconImage(view: HomeView, icon: string | undefined): TFil
 	const path = icon?.trim();
 	if (!path) return null;
 	const file = view.app.vault.getAbstractFileByPath(path);
-	return file instanceof TFile && IMAGE_EXTS.has(file.extension.toLowerCase()) ? file : null;
+	return file && isImageFile(file) ? file : null;
 }
 
 /**

--- a/styles.css
+++ b/styles.css
@@ -6512,6 +6512,256 @@ body.hearth-dv-resizing {
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
 }
 
+/* ---- Slideshow card --------------------------------------------------
+ *
+ * A picture embed that rotates. However many pictures a card has, only two
+ * layers exist — the one on screen and the one coming in — so what is
+ * composited never grows with the size of the folder. Every transition is a
+ * pair of animations on those two layers: the incoming one plays `is-in-*`, the
+ * outgoing one `is-out-*`, both with `both` fill so the pair holds its end state
+ * until the next swap clears the classes and starts over. The `is-trans-none`
+ * variant simply defines neither, which is the cut. */
+.hearth-card-body.hearth-slideshow-host {
+	padding: 0;
+	overflow: hidden;
+}
+
+.hearth-slideshow {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	/* Overwritten per card from the editor's transition length and hold time. */
+	--hearth-slide-ms: 700ms;
+	--hearth-slide-hold: 8000ms;
+}
+
+.hearth-slide {
+	position: absolute;
+	inset: 0;
+	opacity: 0;
+}
+
+.hearth-slide.is-active {
+	opacity: 1;
+	z-index: 2;
+}
+
+.hearth-slide-img {
+	display: block;
+	width: 100%;
+	height: 100%;
+}
+
+.hearth-slideshow.is-fit-cover .hearth-slide-img {
+	object-fit: cover;
+}
+
+.hearth-slideshow.is-fit-contain .hearth-slide-img {
+	object-fit: contain;
+}
+
+/* Crossfade */
+.hearth-slideshow.is-trans-fade > .hearth-slide.is-in-next,
+.hearth-slideshow.is-trans-fade > .hearth-slide.is-in-prev {
+	animation: hearth-slide-fade-in var(--hearth-slide-ms) ease both;
+}
+
+.hearth-slideshow.is-trans-fade > .hearth-slide.is-out-next,
+.hearth-slideshow.is-trans-fade > .hearth-slide.is-out-prev {
+	animation: hearth-slide-fade-out var(--hearth-slide-ms) ease both;
+}
+
+/* Slide. Both layers stay opaque and simply move, in the direction the step was
+ * taken — so stepping back with the controls slides back rather than forward. */
+.hearth-slideshow.is-trans-slide > .hearth-slide.is-in-next {
+	animation: hearth-slide-in-next var(--hearth-slide-ms) ease both;
+}
+
+.hearth-slideshow.is-trans-slide > .hearth-slide.is-out-next {
+	animation: hearth-slide-out-next var(--hearth-slide-ms) ease both;
+}
+
+.hearth-slideshow.is-trans-slide > .hearth-slide.is-in-prev {
+	animation: hearth-slide-in-prev var(--hearth-slide-ms) ease both;
+}
+
+.hearth-slideshow.is-trans-slide > .hearth-slide.is-out-prev {
+	animation: hearth-slide-out-prev var(--hearth-slide-ms) ease both;
+}
+
+/* Zoom: the new picture comes in slightly enlarged, the old one falls back. */
+.hearth-slideshow.is-trans-zoom > .hearth-slide.is-in-next,
+.hearth-slideshow.is-trans-zoom > .hearth-slide.is-in-prev {
+	animation: hearth-slide-zoom-in var(--hearth-slide-ms) ease both;
+}
+
+.hearth-slideshow.is-trans-zoom > .hearth-slide.is-out-next,
+.hearth-slideshow.is-trans-zoom > .hearth-slide.is-out-prev {
+	animation: hearth-slide-zoom-out var(--hearth-slide-ms) ease both;
+}
+
+@keyframes hearth-slide-fade-in {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+@keyframes hearth-slide-fade-out {
+	from { opacity: 1; }
+	to { opacity: 0; }
+}
+
+@keyframes hearth-slide-in-next {
+	from { opacity: 1; transform: translateX(100%); }
+	to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes hearth-slide-out-next {
+	from { opacity: 1; transform: translateX(0); }
+	to { opacity: 1; transform: translateX(-100%); }
+}
+
+@keyframes hearth-slide-in-prev {
+	from { opacity: 1; transform: translateX(-100%); }
+	to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes hearth-slide-out-prev {
+	from { opacity: 1; transform: translateX(0); }
+	to { opacity: 1; transform: translateX(100%); }
+}
+
+@keyframes hearth-slide-zoom-in {
+	from { opacity: 0; transform: scale(1.08); }
+	to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes hearth-slide-zoom-out {
+	from { opacity: 1; transform: scale(1); }
+	to { opacity: 0; transform: scale(0.94); }
+}
+
+/* Optional slow zoom into the picture on screen ("Ken Burns"), lasting exactly
+ * as long as the picture is held so it neither finishes early nor jumps. The
+ * animation restarts on its own: the class is removed from the layer and added
+ * back on every swap. */
+.hearth-slideshow.is-kenburns > .hearth-slide.is-active .hearth-slide-img {
+	animation: hearth-slide-kenburns var(--hearth-slide-hold) ease-out both;
+}
+
+@keyframes hearth-slide-kenburns {
+	from { transform: scale(1); }
+	to { transform: scale(1.09); }
+}
+
+/* The caption sits over the picture with a gradient scrim, so it stays readable
+ * on a light photo and a dark one alike. */
+.hearth-slide-caption {
+	position: absolute;
+	inset: auto 0 0 0;
+	z-index: 3;
+	padding: 22px 12px 9px;
+	color: #fff;
+	font-size: 0.76rem;
+	font-weight: 500;
+	line-height: 1.35;
+	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.65);
+	background: linear-gradient(to top, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0));
+	pointer-events: none;
+}
+
+/* Previous / pause / next and the position, revealed on hover or keyboard
+ * focus like the embed card's floating view switcher. */
+.hearth-slideshow-controls {
+	position: absolute;
+	right: 6px;
+	bottom: 6px;
+	z-index: 4;
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	padding: 2px;
+	border-radius: 8px;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-secondary);
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 140ms ease;
+}
+
+.hearth-card:hover .hearth-slideshow-controls,
+.hearth-slideshow-controls:focus-within {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+/* Nothing hovers on a touch screen, so there the controls are simply always
+ * there — dimmed rather than hidden. */
+@media (hover: none) {
+	.hearth-slideshow-controls {
+		opacity: 0.85;
+		pointer-events: auto;
+	}
+}
+
+.hearth-slideshow-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 3px;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	color: var(--text-muted);
+	cursor: pointer;
+	transition:
+		background 140ms ease,
+		color 140ms ease;
+}
+
+.hearth-slideshow-btn:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.hearth-slideshow-btn .svg-icon {
+	width: 15px;
+	height: 15px;
+}
+
+/* A paused slideshow says so: the play button it now shows is accented, so a
+ * card that has stopped rotating doesn't read as a broken one. */
+.hearth-slideshow-btn.is-paused {
+	color: var(--text-accent);
+}
+
+.hearth-slideshow-count {
+	padding: 0 6px 0 3px;
+	color: var(--text-muted);
+	font-size: 0.68rem;
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+}
+
+/* A reader who asked for less motion still gets the slideshow — it just stops
+ * moving: the sliding and zooming transitions become the crossfade, and the slow
+ * zoom is dropped. */
+@media (prefers-reduced-motion: reduce) {
+	.hearth-slideshow > .hearth-slide.is-in-next,
+	.hearth-slideshow > .hearth-slide.is-in-prev {
+		animation-name: hearth-slide-fade-in;
+	}
+
+	.hearth-slideshow > .hearth-slide.is-out-next,
+	.hearth-slideshow > .hearth-slide.is-out-prev {
+		animation-name: hearth-slide-fade-out;
+	}
+
+	.hearth-slideshow.is-kenburns > .hearth-slide.is-active .hearth-slide-img {
+		animation: none;
+	}
+}
+
 /* ---- Activity heatmap card ------------------------------------------ */
 .hearth-heatmap {
 	display: flex;

--- a/test/cards-registry.test.ts
+++ b/test/cards-registry.test.ts
@@ -42,6 +42,13 @@ describe("CARD_TEMPLATES (add-card menu)", () => {
 			{ id: "note", icon: "file-text", category: "notes", requires: null, build: { kind: "embed", title: "Note", target: "", w: 6, h: 3 } },
 			{ id: "daily", icon: "calendar", category: "notes", requires: null, build: { kind: "daily", w: 6, h: 4 } },
 			{ id: "image", icon: "image", category: "notes", requires: null, build: { kind: "embed", title: "Image", target: "", w: 4, h: 3 } },
+			{
+				id: "slideshow",
+				icon: "images",
+				category: "notes",
+				requires: null,
+				build: { kind: "slideshow", title: "Slideshow", slideshow: { slides: [] }, w: 4, h: 3 },
+			},
 			{ id: "canvas", icon: "layout-dashboard", category: "notes", requires: null, build: { kind: "embed", title: "Canvas", target: "", w: 6, h: 4 } },
 			{ id: "excalidraw", icon: "pen-tool", category: "notes", requires: null, build: { kind: "embed", title: "Drawing", target: "", w: 6, h: 4 } },
 			{ id: "base", icon: "database", category: "notes", requires: null, build: { kind: "embed", title: "Base", target: "", w: 6, h: 4 } },
@@ -177,6 +184,7 @@ function maximalCard(): DashboardCard {
 		links: [{ label: "A", href: "a" } as never],
 		commands: [{ id: "c", name: "C" }],
 		secondView: { target: "sv" },
+		slideshow: { slides: [{ id: "s1", path: "Photos/a.png", caption: "A" }] },
 		tasks: {
 			folders: ["f1"],
 			kanbanOrder: ["k1"],
@@ -228,6 +236,8 @@ describe("cloneCard deep-clone independence", () => {
 		copy.links![0].label = "B";
 		copy.commands![0].name = "D";
 		(copy.secondView as { target: string }).target = "sv2";
+		copy.slideshow!.slides![0].caption = "B";
+		copy.slideshow!.slides!.push({ id: "s2", path: "Photos/b.png" });
 		copy.tasks!.folders!.push("f2");
 		copy.tasks!.kanbanOrder!.push("k9");
 		copy.tasks!.kanbanHidden!.push("k9");
@@ -263,6 +273,7 @@ describe("cloneCard deep-clone independence", () => {
 		expect(orig.links).toEqual(pristine.links);
 		expect(orig.commands).toEqual(pristine.commands);
 		expect(orig.secondView).toEqual(pristine.secondView);
+		expect(orig.slideshow).toEqual(pristine.slideshow);
 		expect(orig.tasks).toEqual(pristine.tasks);
 		expect(orig.calendar).toEqual(pristine.calendar);
 		expect(orig.schedule).toEqual(pristine.schedule);
@@ -292,6 +303,7 @@ describe("liveness classification", () => {
 		);
 		expect(modes).toEqual({
 			embed: "watch-file",
+			slideshow: "vault",
 			daily: "watch-file",
 			web: "poll",
 			bookmarks: "static",

--- a/test/slideshow.test.ts
+++ b/test/slideshow.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { TFile } from "obsidian";
+import {
+	SLIDESHOW_DEFAULT_INTERVAL_SEC,
+	SLIDESHOW_DEFAULT_TRANSITION_MS,
+	SLIDESHOW_MAX_INTERVAL_SEC,
+	SLIDESHOW_MAX_TRANSITION_MS,
+	inSlideshowFolder,
+	normalizeFolderPath,
+	orderPictures,
+	pictureLabel,
+	shufflePictures,
+	slideshowIntervalMs,
+	slideshowOrder,
+	slideshowReactsTo,
+	slideshowSource,
+	slideshowTransitionMs,
+	type SlideshowPicture,
+} from "../src/slideshow";
+import type { VaultEvent } from "../src/cardevents";
+import type { DashboardCard, SlideshowConfig } from "../src/types";
+
+/**
+ * The slideshow card's pure half: which pictures a card shows, in what order,
+ * and which vault events are worth a redraw. Everything here is data in, data
+ * out — the vault reads and the DOM work around it are deliberately untested,
+ * per the "no Obsidian API mocks" rule.
+ */
+
+function picture(
+	path: string,
+	extra: Partial<SlideshowPicture> = {},
+): SlideshowPicture {
+	return {
+		path,
+		name: path.split("/").pop()!.replace(/\.[^.]+$/, ""),
+		created: 0,
+		modified: 0,
+		...extra,
+	};
+}
+
+/** A vault event carrying just the path(s) the predicate reads. */
+function event(kind: VaultEvent["kind"], path: string, oldPath?: string): VaultEvent {
+	return { kind, file: Object.assign(new TFile(), { path }), oldPath };
+}
+
+function card(slideshow: SlideshowConfig): DashboardCard {
+	return { id: "c", kind: "slideshow", x: 0, y: 0, w: 4, h: 3, slideshow };
+}
+
+describe("slideshow config resolution", () => {
+	it("defaults to the hand-picked list", () => {
+		expect(slideshowSource({})).toBe("list");
+		expect(slideshowSource({ source: "list" })).toBe("list");
+		expect(slideshowSource({ source: "folder" })).toBe("folder");
+	});
+
+	// "manual" means "the order the list is in", which a folder has none of — it
+	// would otherwise fall through to the vault's arbitrary child order.
+	it("resolves the list-only 'manual' order to by-name for a folder", () => {
+		expect(slideshowOrder({})).toBe("manual");
+		expect(slideshowOrder({ order: "manual" })).toBe("manual");
+		expect(slideshowOrder({ source: "folder" })).toBe("name");
+		expect(slideshowOrder({ source: "folder", order: "manual" })).toBe("name");
+		expect(slideshowOrder({ source: "folder", order: "random" })).toBe("random");
+	});
+
+	it("resolves the hold time, with 0 meaning 'do not rotate'", () => {
+		expect(slideshowIntervalMs({})).toBe(SLIDESHOW_DEFAULT_INTERVAL_SEC * 1000);
+		expect(slideshowIntervalMs({ intervalSec: 3 })).toBe(3000);
+		expect(slideshowIntervalMs({ intervalSec: 0 })).toBe(0);
+		// Nonsense from a hand-edited data.json must not produce a runaway timer.
+		expect(slideshowIntervalMs({ intervalSec: -5 })).toBe(0);
+		expect(slideshowIntervalMs({ intervalSec: Number.NaN })).toBe(0);
+		expect(slideshowIntervalMs({ intervalSec: 1e9 })).toBe(SLIDESHOW_MAX_INTERVAL_SEC * 1000);
+	});
+
+	it("resolves the transition length", () => {
+		expect(slideshowTransitionMs({})).toBe(SLIDESHOW_DEFAULT_TRANSITION_MS);
+		expect(slideshowTransitionMs({ transitionMs: 250 })).toBe(250);
+		expect(slideshowTransitionMs({ transitionMs: 0 })).toBe(0);
+		expect(slideshowTransitionMs({ transitionMs: -1 })).toBe(SLIDESHOW_DEFAULT_TRANSITION_MS);
+		expect(slideshowTransitionMs({ transitionMs: 99999 })).toBe(SLIDESHOW_MAX_TRANSITION_MS);
+	});
+
+	it("labels a picture with its caption, then its file name", () => {
+		expect(pictureLabel(picture("Photos/beach.jpg"))).toBe("beach");
+		expect(pictureLabel(picture("Photos/beach.jpg", { caption: "Sardinia" }))).toBe("Sardinia");
+		// A caption of only spaces is not a caption.
+		expect(pictureLabel(picture("Photos/beach.jpg", { caption: "   " }))).toBe("beach");
+	});
+});
+
+describe("folder scope", () => {
+	it("normalizes a folder path, with the vault root as the empty string", () => {
+		expect(normalizeFolderPath(undefined)).toBe("");
+		expect(normalizeFolderPath("/")).toBe("");
+		expect(normalizeFolderPath("  Photos/Trips/  ")).toBe("Photos/Trips");
+		expect(normalizeFolderPath("/Photos/")).toBe("Photos");
+	});
+
+	it("takes only direct children unless subfolders are asked for", () => {
+		expect(inSlideshowFolder("Photos", "Photos/a.png")).toBe(true);
+		expect(inSlideshowFolder("Photos", "Photos/Trips/a.png")).toBe(false);
+		expect(inSlideshowFolder("Photos", "Photos/Trips/a.png", true)).toBe(true);
+	});
+
+	it("does not mistake a sibling folder for the scope", () => {
+		// "PhotosOld/a.png" starts with "Photos" as a *string*, not as a folder.
+		expect(inSlideshowFolder("Photos", "PhotosOld/a.png", true)).toBe(false);
+		expect(inSlideshowFolder("Photos", "Photos", true)).toBe(false);
+	});
+
+	it("treats an empty scope as the vault root", () => {
+		expect(inSlideshowFolder(undefined, "a.png")).toBe(true);
+		expect(inSlideshowFolder("", "a.png")).toBe(true);
+		expect(inSlideshowFolder("/", "a.png")).toBe(true);
+		// Without subfolders, the root means the root only.
+		expect(inSlideshowFolder("", "Photos/a.png")).toBe(false);
+		expect(inSlideshowFolder("", "Photos/a.png", true)).toBe(true);
+	});
+});
+
+describe("orderPictures", () => {
+	const pictures = [
+		picture("Photos/c.png", { created: 300, modified: 100 }),
+		picture("Photos/a.png", { created: 200, modified: 300 }),
+		picture("Photos/b.png", { created: 100, modified: 200 }),
+	];
+	const paths = (list: SlideshowPicture[]) => list.map((p) => p.name);
+
+	it("keeps the list's own order for 'manual'", () => {
+		expect(paths(orderPictures(pictures, "manual"))).toEqual(["c", "a", "b"]);
+	});
+
+	it("sorts by name, both ways", () => {
+		expect(paths(orderPictures(pictures, "name"))).toEqual(["a", "b", "c"]);
+		expect(paths(orderPictures(pictures, "nameDesc"))).toEqual(["c", "b", "a"]);
+	});
+
+	it("sorts by creation and modification date, both ways", () => {
+		expect(paths(orderPictures(pictures, "created"))).toEqual(["b", "a", "c"]);
+		expect(paths(orderPictures(pictures, "createdDesc"))).toEqual(["c", "a", "b"]);
+		expect(paths(orderPictures(pictures, "modified"))).toEqual(["c", "b", "a"]);
+		expect(paths(orderPictures(pictures, "modifiedDesc"))).toEqual(["a", "b", "c"]);
+	});
+
+	// Two photos exported in the same second are common; without the path
+	// tie-break their order would depend on the engine's sort and could differ
+	// between redraws of the same card.
+	it("breaks ties on the path so the order is stable", () => {
+		const sameTime = [
+			picture("Photos/b.png", { created: 5 }),
+			picture("Photos/a.png", { created: 5 }),
+			picture("Album/a.png", { created: 5 }),
+		];
+		expect(orderPictures(sameTime, "created").map((p) => p.path)).toEqual([
+			"Album/a.png",
+			"Photos/a.png",
+			"Photos/b.png",
+		]);
+		// Same names, different folders: still deterministic.
+		expect(orderPictures(sameTime, "name").map((p) => p.path)).toEqual([
+			"Album/a.png",
+			"Photos/a.png",
+			"Photos/b.png",
+		]);
+	});
+
+	it("never mutates its input", () => {
+		const input = [...pictures];
+		orderPictures(input, "name");
+		orderPictures(input, "random");
+		expect(paths(input)).toEqual(["c", "a", "b"]);
+	});
+
+	it("shuffles every picture exactly once for 'random'", () => {
+		const shuffled = orderPictures(pictures, "random");
+		expect(shuffled).toHaveLength(pictures.length);
+		expect(paths(shuffled).sort()).toEqual(["a", "b", "c"]);
+	});
+
+	it("shuffles in place, keeping the same set", () => {
+		const items = [1, 2, 3, 4, 5];
+		expect(shufflePictures(items)).toBe(items);
+		expect([...items].sort()).toEqual([1, 2, 3, 4, 5]);
+	});
+});
+
+describe("slideshowReactsTo", () => {
+	// A slideshow redraw restarts the rotation, so the events that can't change
+	// which pictures exist must not trigger one — this is the whole reason the
+	// card has its own predicate instead of redrawing on every vault event.
+	it("ignores content edits and metadata reparses", () => {
+		const folderCard = card({ source: "folder", folder: "Photos" });
+		expect(slideshowReactsTo(folderCard, event("modify", "Photos/a.png"))).toBe(false);
+		expect(slideshowReactsTo(folderCard, event("meta", "Photos/a.png"))).toBe(false);
+		expect(slideshowReactsTo(folderCard, event("create", "Photos/a.png"))).toBe(true);
+		expect(slideshowReactsTo(folderCard, event("delete", "Photos/a.png"))).toBe(true);
+	});
+
+	it("watches the scope of a folder card", () => {
+		const shallow = card({ source: "folder", folder: "Photos" });
+		expect(slideshowReactsTo(shallow, event("create", "Photos/a.png"))).toBe(true);
+		expect(slideshowReactsTo(shallow, event("create", "Notes/a.png"))).toBe(false);
+		expect(slideshowReactsTo(shallow, event("create", "Photos/Trips/a.png"))).toBe(false);
+
+		const deep = card({ source: "folder", folder: "Photos", includeSubfolders: true });
+		expect(slideshowReactsTo(deep, event("create", "Photos/Trips/a.png"))).toBe(true);
+	});
+
+	// A folder rename arrives as one event for the folder, not one per file, so
+	// the card has to recognise its own scope moving out from under it.
+	it("notices its folder (or an ancestor) being renamed", () => {
+		const folderCard = card({ source: "folder", folder: "Photos/Trips" });
+		expect(slideshowReactsTo(folderCard, event("rename", "Trips", "Photos/Trips"))).toBe(true);
+		expect(slideshowReactsTo(folderCard, event("rename", "Album", "Photos"))).toBe(true);
+		expect(slideshowReactsTo(folderCard, event("rename", "Other", "Elsewhere"))).toBe(false);
+	});
+
+	it("watches only the listed pictures of a list card", () => {
+		const listCard = card({
+			slides: [
+				{ id: "1", path: "Photos/a.png" },
+				{ id: "2", path: "Album/b.png" },
+			],
+		});
+		expect(slideshowReactsTo(listCard, event("delete", "Photos/a.png"))).toBe(true);
+		expect(slideshowReactsTo(listCard, event("delete", "Photos/z.png"))).toBe(false);
+		// Renaming a listed picture: both the new and the old path count.
+		expect(slideshowReactsTo(listCard, event("rename", "Photos/c.png", "Album/b.png"))).toBe(true);
+		// Renaming a folder a listed picture lives in moves that picture too.
+		expect(slideshowReactsTo(listCard, event("rename", "Pics", "Photos"))).toBe(true);
+	});
+
+	it("stays quiet for a card with nothing configured", () => {
+		expect(slideshowReactsTo(card({}), event("create", "Photos/a.png"))).toBe(false);
+		expect(slideshowReactsTo({ id: "c", kind: "slideshow", x: 0, y: 0, w: 4, h: 3 }, event("create", "a.png"))).toBe(false);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds a **Slideshow** card (Notes & files → Slideshow): the image embed with more
than one picture, shown in turn on a timer.

**Two sources.** Either a hand-picked list — added one at a time from an
image-only picker, each entry with its own optional caption, reorderable by hand,
with a bulk "add a folder's pictures" button as a starting point — or a folder,
optionally including its subfolders, so a card fills itself as photos are dropped
in. The folder editor shows how many images the folder yields right now, so you
can tell it (and the subfolder toggle) is the one you meant.

**Order.** List order, name (A→Z / Z→A), date created or modified (either
direction), or random. A shuffled card reshuffles between passes, so it shows
everything once per round without settling into one running order forever. A
folder source resolves "list order" to by-name, since a folder has none.

**How pictures change.** A cut, a crossfade, a slide (in the direction stepped)
or a zoom, over a configurable length, plus an optional slow zoom into each
picture while it is held ("Ken Burns"). Pictures fill the card or fit whole inside
it; the caption can be drawn over them; hovering reveals previous / pause / next
with the position; and there's an optional button that opens the picture on screen
in its own tab, like the embed card's.

Implementation notes worth a reviewer's attention:

- **Two `<img>` layers regardless of picture count** — the one on screen and the
  one coming in. A folder of 500 photos decodes two of them, and every transition
  is a CSS animation on that pair (`.hearth-slide` in styles.css).
- **Liveness is `vault` with its own `shouldRedraw`.** A redraw restarts the
  rotation, so only existence events (create/delete/rename) inside the card's
  folder — or on a listed picture, including an ancestor-folder rename — trigger
  one; a note being saved never does. Rotation position and the pause state
  survive redraws via a `WeakMap` keyed on the card, as `activeEmbedView` does.
- **Low power and reduced motion.** Low power holds one picture rather than
  rotating (it is a timed refresh, and the setting promises to stop those — the
  effects list in Settings gained a bullet for it); `prefers-reduced-motion` turns
  slide and zoom into the crossfade and drops the slow zoom. Manual controls keep
  working in both cases.
- **The pure half lives in `src/slideshow.ts`** — ordering, folder scope, the
  interval/transition clamps and the redraw predicate, with no Obsidian imports —
  because the card module imports `editors.ts`, which sits in an import cycle with
  the card registry, and a test importing the card module directly gets a
  half-built registry. `src/cards/README.md` documents that for the next card.

Three supporting changes, all in service of the card:

- `cardOverlayButton` in `cardbodies.ts` — the daily and embed cards' "open this
  file" button was copy-pasted twice and would have been a third time.
- `isImageFile` / `IMAGE_EXTENSIONS` in `filetypes.ts`, replacing the private
  extension list in `widgeticon.ts` so one list drives the search filter, widget
  tile icons and the slideshow.
- `FolderPickerModal` in `pickers.ts`, alongside the existing file and command
  pickers.
- `sanitizeSlideshow` in `layout.ts`, so a slideshow card survives a layout
  export/import round-trip with its numbers clamped to the same bounds the card
  enforces.

## Related issue

None — there's no open issue for this; it came in as a direct request. Happy to
split or trim if the scope is more than you want in one card.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault

On that last box: the card was built against the codebase's own patterns and is
covered by 21 new unit tests over the pure logic (`test/slideshow.test.ts`), plus
the registry tests, with `npm run typecheck`, `npm run lint` (0 errors) and
`npm run build` clean — but it has not been exercised in a real vault, so the
rendering, the transitions and the controls want a look on a live board before
this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZJaXa1pW8TGWtR9wiKCds)_