### PR TITLE
Add a banner layout for the dashboard background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
+- **A board that wears its background as a banner.** **Appearance → Background →
+  Background layout** offers a second way to show the backdrop you already have:
+  instead of filling the view, it is cropped into a strip across the top of the
+  board — a cover image, the way one sits above a note — and the cards sit below
+  it on your theme's own surface.
+
+  It is the same background either way. The kind, the value, the opacity and the
+  blur all mean exactly what they meant before, a live weather sky included, so
+  switching between the two is one dropdown and loses nothing. What the banner
+  adds is its own shape: **how tall** the strip is, whether its lower edge
+  **fades** into the page or ends on a line, and whether it **lines up with the
+  content** or runs edge to edge.
+
+  Boards choose for themselves. A dashboard that overrides the background now
+  overrides how it is worn too, so one board can carry a cover image while the
+  next keeps the vault's wallpaper. On a fit-to-page board the grid simply takes
+  the height the banner leaves it, and low power mode is unchanged — it still
+  replaces the whole backdrop with its flat colour.
+
 - **A slideshow card.** **Notes & files → Slideshow** is the image embed with
   more than one picture: it shows them in turn, on a timer you set. Choose the
   pictures one by one — each can carry its own caption, and the list can be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,18 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   **fades** into the page or ends on a line, and whether it **lines up with the
   content** or runs edge to edge.
 
-  Boards choose for themselves. A dashboard that overrides the background now
-  overrides how it is worn too, so one board can carry a cover image while the
-  next keeps the vault's wallpaper. On a fit-to-page board the grid simply takes
-  the height the banner leaves it, and low power mode is unchanged — it still
-  replaces the whole backdrop with its flat colour.
+  **Every board chooses for itself**, in its own settings under **Background**.
+  The layout and each part of the banner's shape are separate overrides, and
+  each one either follows the vault or doesn't — so a board can wear the
+  wallpaper you already have as a banner without restating the picture, keep a
+  full background while the rest of the vault has moved to banners, or set its
+  own height and let the fade and width follow along. Every control says which
+  it is doing, and resets to following the vault.
+
+  On a fit-to-page board the grid simply takes the height the banner leaves it.
+  Low power mode still replaces the picture with its flat colour, but it now
+  leaves the *layout* alone: a bannered board keeps its banner, so toggling the
+  mode no longer moves every card on it.
 
 - **A slideshow card.** **Notes & files → Slideshow** is the image embed with
   more than one picture: it shows them in turn, on a timer you set. Choose the

--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ calls**.
   thunder — and keep it whatever the weather is doing, which needs no location
   and never goes online. All with opacity and blur.
   Ships with a soft ambient default.
+- **Banner or full background** — wear that same backdrop either way: filling
+  the whole view, or as a **banner** across the top of the board — a cover
+  image, the way one sits above a note — with the cards below it on your
+  theme's own surface. Set the height, fade the lower edge into the page, and
+  choose whether it lines up with the content or runs edge to edge. Per board,
+  too, so one dashboard can carry a cover while the next keeps the wallpaper.
 - **Frosted glass** — card opacity and backdrop blur at three levels (global →
   per-dashboard → per-card). Merged cards blur as one seamless sheet.
 - **Card corner radius** — from the default 14 px down to sharp 0 px.

--- a/README.md
+++ b/README.md
@@ -220,8 +220,10 @@ calls**.
   the whole view, or as a **banner** across the top of the board — a cover
   image, the way one sits above a note — with the cards below it on your
   theme's own surface. Set the height, fade the lower edge into the page, and
-  choose whether it lines up with the content or runs edge to edge. Per board,
-  too, so one dashboard can carry a cover while the next keeps the wallpaper.
+  choose whether it lines up with the content or runs edge to edge. Each of
+  those is its own per-board override, so one dashboard can show the vault's
+  background as a banner while the next keeps it as a wallpaper — no picture
+  restated either way.
 - **Frosted glass** — card opacity and backdrop blur at three levels (global →
   per-dashboard → per-card). Merged cards blur as one seamless sheet.
 - **Card corner radius** — from the default 14 px down to sharp 0 px.

--- a/src/background.ts
+++ b/src/background.ts
@@ -7,7 +7,12 @@ import {
 	skyGroupCode,
 } from "./sky";
 import type { HomeView } from "./view";
-import { type BackgroundConfig, effectiveBackground } from "./types";
+import {
+	type BackgroundConfig,
+	clampBannerHeight,
+	effectiveBackground,
+	effectiveMaxWidth,
+} from "./types";
 import { cachedWeather, loadWeather, type WeatherRequest } from "./weather";
 
 /**
@@ -22,6 +27,13 @@ const DEFAULT_BG_URL =
  * Apply the optional, customizable background as a separate layer behind the
  * content so opacity/blur don't affect the foreground. Uses the active
  * dashboard's override when set, otherwise the global default.
+ *
+ * This is the full-view wallpaper; {@link renderBanner} is the strip at the top
+ * of the content. Which one a board gets is the view's call rather than this
+ * function's, because the configured layout isn't the only input: mobile-only
+ * mode has no content column to head and so asks for the wallpaper whatever the
+ * layout says. `render()` therefore calls exactly one of the two, and this one
+ * paints whenever it is called.
  */
 export function applyBackground(
 	view: HomeView,
@@ -29,11 +41,71 @@ export function applyBackground(
 	component: Component,
 ): void {
 	const bg = effectiveBackground(view.plugin.settings);
-	if (bg.kind === "none") return;
-	// "default" uses the bundled Hearth background; no value field needed.
-	if (bg.kind !== "default" && !bg.value) return;
+	if (!paintable(bg)) return;
 
-	const layer = root.createDiv("hearth-bg");
+	paintBackground(view, root.createDiv("hearth-bg"), bg, component);
+}
+
+/**
+ * Draw the board's backdrop as a banner: a strip across the top of the content,
+ * the way a cover image sits above a note.
+ *
+ * It is the same background the wallpaper mode paints — same kinds, same
+ * opacity and blur, live weather sky included — put in a box of its own instead
+ * of behind everything. That box is a normal element in the scroll flow, so the
+ * rest of the board sits below it on the theme's own surface, and on a
+ * fit-to-page board the grid simply gets the height the banner leaves it.
+ *
+ * Returns the banner element, or null when there is nothing to draw (no
+ * background configured, or the board isn't in banner mode).
+ */
+export function renderBanner(
+	view: HomeView,
+	parent: HTMLElement,
+	component: Component,
+): HTMLElement | null {
+	const bg = effectiveBackground(view.plugin.settings);
+	if (bg.layout !== "banner") return null;
+	if (!paintable(bg)) return null;
+
+	const banner = parent.createDiv("hearth-banner");
+	banner.style.height = `${clampBannerHeight(bg.bannerHeight)}px`;
+	banner.toggleClass("is-faded", bg.bannerFade !== false);
+	// Full width means "as wide as the pane"; otherwise the banner lines up with
+	// the content column, which is the same max-width `.hearth-inner` uses.
+	const full = bg.bannerFullWidth === true;
+	banner.toggleClass("is-full-width", full);
+	if (!full) banner.style.maxWidth = `${effectiveMaxWidth(view.plugin.settings)}px`;
+
+	const layer = banner.createDiv("hearth-bg");
+	// A blurred layer goes soft at its own edges. Behind a whole view that is
+	// barely visible; cropped into a strip it is a pale halo down all four
+	// sides, so grow the layer past the crop and let the softness fall outside.
+	if (bg.blur > 0) layer.style.inset = `-${Math.ceil(bg.blur * 2)}px`;
+
+	paintBackground(view, layer, bg, component);
+	return banner;
+}
+
+/** Whether a background config has anything to paint. "default" ships its own
+ * image so it needs no value; every other kind but "none" needs one. */
+function paintable(bg: BackgroundConfig): boolean {
+	if (bg.kind === "none") return false;
+	return bg.kind === "default" || !!bg.value;
+}
+
+/**
+ * Paint a resolved background into `layer`. Shared by the wallpaper and the
+ * banner: the two differ only in where that layer sits and how big it is, so
+ * everything about *what* is drawn — the opacity, the blur, the colour, the
+ * image URL, the live sky — lives here once.
+ */
+function paintBackground(
+	view: HomeView,
+	layer: HTMLElement,
+	bg: BackgroundConfig,
+	component: Component,
+): void {
 	layer.style.opacity = String(bg.opacity);
 	if (bg.blur > 0) layer.style.filter = `blur(${bg.blur}px)`;
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -7,12 +7,7 @@ import {
 	skyGroupCode,
 } from "./sky";
 import type { HomeView } from "./view";
-import {
-	type BackgroundConfig,
-	clampBannerHeight,
-	effectiveBackground,
-	effectiveMaxWidth,
-} from "./types";
+import { type BackgroundConfig, effectiveBackground, effectiveMaxWidth } from "./types";
 import { cachedWeather, loadWeather, type WeatherRequest } from "./weather";
 
 /**
@@ -69,13 +64,14 @@ export function renderBanner(
 	if (!paintable(bg)) return null;
 
 	const banner = parent.createDiv("hearth-banner");
-	banner.style.height = `${clampBannerHeight(bg.bannerHeight)}px`;
-	banner.toggleClass("is-faded", bg.bannerFade !== false);
+	banner.style.height = `${bg.bannerHeight}px`;
+	banner.toggleClass("is-faded", bg.bannerFade);
 	// Full width means "as wide as the pane"; otherwise the banner lines up with
 	// the content column, which is the same max-width `.hearth-inner` uses.
-	const full = bg.bannerFullWidth === true;
-	banner.toggleClass("is-full-width", full);
-	if (!full) banner.style.maxWidth = `${effectiveMaxWidth(view.plugin.settings)}px`;
+	banner.toggleClass("is-full-width", bg.bannerFullWidth);
+	if (!bg.bannerFullWidth) {
+		banner.style.maxWidth = `${effectiveMaxWidth(view.plugin.settings)}px`;
+	}
 
 	const layer = banner.createDiv("hearth-bg");
 	// A blurred layer goes soft at its own edges. Behind a whole view that is

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -7,10 +7,10 @@ import {
 	type Dashboard,
 	type DashboardHeaderConfig,
 	type HeaderAlign,
-	BANNER_HEIGHT_DEFAULT,
 	BANNER_HEIGHT_MAX,
 	BANNER_HEIGHT_MIN,
 	CARD_RADIUS_MAX,
+	clampBannerHeight,
 	CARD_BORDER_WIDTH_MAX,
 	HEADER_MARGIN_TOP_MAX,
 	HEADER_MARGIN_TOP_MIN,
@@ -168,6 +168,12 @@ function showDashboardMenu(
 					copy.cardBorderWidth = dash.cardBorderWidth;
 				if (dash.header) copy.header = { ...dash.header };
 				if (dash.background) copy.background = { ...dash.background };
+				if (dash.backgroundLayout != null)
+					copy.backgroundLayout = dash.backgroundLayout;
+				if (dash.bannerHeight != null) copy.bannerHeight = dash.bannerHeight;
+				if (dash.bannerFade != null) copy.bannerFade = dash.bannerFade;
+				if (dash.bannerFullWidth != null)
+					copy.bannerFullWidth = dash.bannerFullWidth;
 				// linkedWorkspace is intentionally not copied: two dashboards
 				// linked to the same workspace would race on auto-switch.
 				const i = s.dashboards.findIndex((d) => d.id === dash.id);
@@ -795,6 +801,12 @@ class DashboardSettingsModal extends HearthTabbedModal {
 				});
 			});
 
+		// How the board wears its backdrop is settable whether or not the board
+		// overrides *what* that backdrop is — the two are separate overrides, so
+		// this comes before the early return below and a board using the vault's
+		// background can still choose to show it as a banner.
+		this.bannerControls(containerEl);
+
 		if (!bg || bg.kind === "none") return;
 
 		// The weather sky stores a place, not a typed-in value, so it gets the
@@ -851,80 +863,162 @@ class DashboardSettingsModal extends HearthTabbedModal {
 			1,
 			DEFAULT_DASH_BG_BLUR,
 		);
-
-		this.bannerControls(containerEl, bg);
 	}
 
 	/**
-	 * Wallpaper or banner, for this board alone — and, once it is a banner, the
-	 * shape of the strip. A board that overrides the background overrides how it
-	 * is worn too, so one dashboard can carry a cover image while the next keeps
-	 * the vault's wallpaper.
+	 * How this board wears its backdrop — full view or banner, and the banner's
+	 * shape — as overrides in their own right, each falling back to the global
+	 * setting.
+	 *
+	 * They are deliberately not tied to the background override above. A board
+	 * that keeps the vault's background can still show it as a banner, and a
+	 * board that overrides the picture can still wear it however the vault does.
 	 */
-	private bannerControls(containerEl: HTMLElement, bg: BackgroundConfig): void {
+	private bannerControls(containerEl: HTMLElement): void {
+		const dash = this.dash;
+		const s = this.view.plugin.settings;
 		const strings = t().dashboards.modal;
+		const globalLayout = s.backgroundLayout ?? "full";
+		const labels = t().dashboards.backgroundLayoutOptions;
 
 		new Setting(containerEl)
 			.setName(strings.backgroundLayout)
-			.setDesc(strings.backgroundLayoutDesc)
+			.setDesc(
+				dash.backgroundLayout
+					? t().dashboards.modal.overriding
+					: t().dashboards.modal.usingGlobal(labels[globalLayout]),
+			)
 			.addDropdown((d) => {
-				const labels = t().dashboards.backgroundLayoutOptions;
+				d.addOption("global", t().dashboards.useGlobal);
 				(Object.keys(labels) as BackgroundLayout[]).forEach((k) => {
 					d.addOption(k, labels[k]);
 				});
-				d.setValue(bg.layout ?? "full").onChange((v) => {
-					bg.layout = v as BackgroundLayout;
-					// Same lift as the global setting: a banner is the picture
-					// itself, not a backdrop for something else, so wallpaper-ish
-					// opacity and blur would hand the reader a grey smear.
-					if (v === "banner") {
-						if (bg.opacity <= 0.5) bg.opacity = 1;
-						if (bg.blur > 0) bg.blur = 0;
+				d.setValue(dash.backgroundLayout ?? "global").onChange((v) => {
+					dash.backgroundLayout =
+						v === "global" ? undefined : (v as BackgroundLayout);
+					// Same lift as the global setting, but only on a background
+					// this board actually owns: a banner is the picture itself,
+					// not a backdrop for something else, so wallpaper-ish opacity
+					// and blur would hand the reader a grey smear. A board riding
+					// the global background is left alone — its opacity and blur
+					// belong to every other board too.
+					if (v === "banner" && dash.background) {
+						if (dash.background.opacity <= 0.5) dash.background.opacity = 1;
+						if (dash.background.blur > 0) dash.background.blur = 0;
 					}
 					this.commit();
 					this.render();
 				});
 			});
 
-		if (bg.layout !== "banner") return;
+		// The strip's shape is worth showing whenever this board ends up with a
+		// banner — whether it chose one itself or inherits one from the vault.
+		if ((dash.backgroundLayout ?? globalLayout) !== "banner") return;
 
-		this.bgNumber(
+		this.dashNumber(
 			containerEl,
 			strings.bannerHeight,
-			bg,
 			"bannerHeight",
 			BANNER_HEIGHT_MIN,
 			BANNER_HEIGHT_MAX,
 			10,
-			BANNER_HEIGHT_DEFAULT,
+			clampBannerHeight(s.bannerHeight),
 		);
-
-		new Setting(containerEl)
-			.setName(strings.bannerFade)
-			.addToggle((tg) =>
-				tg.setValue(bg.bannerFade !== false).onChange((v) => {
-					bg.bannerFade = v;
-					this.commit();
-				}),
-			);
-
-		new Setting(containerEl)
-			.setName(strings.bannerFullWidth)
-			.addToggle((tg) =>
-				tg.setValue(bg.bannerFullWidth === true).onChange((v) => {
-					bg.bannerFullWidth = v;
-					this.commit();
-				}),
-			);
+		this.dashToggle(containerEl, strings.bannerFade, "bannerFade", s.bannerFade !== false);
+		this.dashToggle(
+			containerEl,
+			strings.bannerFullWidth,
+			"bannerFullWidth",
+			s.bannerFullWidth === true,
+		);
 	}
 
-	/** A per-dashboard background slider (opacity/blur/banner height) with a
-	 * reset button that restores the factory default `def`. */
+	/** A board-level numeric override with a reset button that clears it back to
+	 * the global value, rather than to a hard-coded factory number: these
+	 * overrides *are* "unset = follow the vault", so reset means unset. */
+	private dashNumber(
+		containerEl: HTMLElement,
+		name: string,
+		key: "bannerHeight",
+		min: number,
+		max: number,
+		step: number,
+		globalValue: number,
+	): void {
+		const dash = this.dash;
+		const setting = new Setting(containerEl)
+			.setName(name)
+			.setDesc(
+				dash[key] == null
+					? t().dashboards.modal.usingGlobal(globalValue)
+					: t().dashboards.modal.overriding,
+			);
+		setting.addSlider((sl) => {
+			sl.setLimits(min, max, step)
+				.setValue(dash[key] ?? globalValue)
+				.setDynamicTooltip()
+				.onChange((v) => {
+					dash[key] = v;
+					this.commit();
+				});
+			setting.addExtraButton((b) =>
+				b
+					.setIcon("rotate-ccw")
+					.setTooltip(t().dashboards.modal.clearOverride)
+					.onClick(() => {
+						dash[key] = undefined;
+						sl.setValue(globalValue);
+						this.commit();
+						this.render();
+					}),
+			);
+		});
+	}
+
+	/** A board-level boolean override: a toggle plus a reset that clears it back
+	 * to following the global setting. */
+	private dashToggle(
+		containerEl: HTMLElement,
+		name: string,
+		key: "bannerFade" | "bannerFullWidth",
+		globalValue: boolean,
+	): void {
+		const dash = this.dash;
+		const setting = new Setting(containerEl)
+			.setName(name)
+			.setDesc(
+				dash[key] == null
+					? t().dashboards.modal.usingGlobal(
+							globalValue ? t().dashboards.on : t().dashboards.off,
+						)
+					: t().dashboards.modal.overriding,
+			);
+		setting.addToggle((tg) =>
+			tg.setValue(dash[key] ?? globalValue).onChange((v) => {
+				dash[key] = v;
+				this.commit();
+				this.render();
+			}),
+		);
+		setting.addExtraButton((b) =>
+			b
+				.setIcon("rotate-ccw")
+				.setTooltip(t().dashboards.modal.clearOverride)
+				.onClick(() => {
+					dash[key] = undefined;
+					this.commit();
+					this.render();
+				}),
+		);
+	}
+
+	/** A per-dashboard background slider (opacity/blur) with a reset button that
+	 * restores the factory default `def`. */
 	private bgNumber(
 		containerEl: HTMLElement,
 		name: string,
 		bg: BackgroundConfig,
-		key: "opacity" | "blur" | "bannerHeight",
+		key: "opacity" | "blur",
 		min: number,
 		max: number,
 		step: number,
@@ -933,10 +1027,7 @@ class DashboardSettingsModal extends HearthTabbedModal {
 		const setting = new Setting(containerEl).setName(name);
 		setting.addSlider((sl) => {
 			sl.setLimits(min, max, step)
-				// `bannerHeight` is optional on a background saved before banners
-				// existed (and on one that has never been in banner mode), so the
-				// slider starts from the factory value rather than from nothing.
-				.setValue(bg[key] ?? def)
+				.setValue(bg[key])
 				// Show the live value in a tooltip. On our declared minAppVersion
 				// (1.8.7) sliders don't yet render the value inline, so this is
 				// how the current opacity/blur stays visible while dragging.

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -3,9 +3,13 @@ import type { HomeView } from "./view";
 import {
 	type BackgroundConfig,
 	type BackgroundKind,
+	type BackgroundLayout,
 	type Dashboard,
 	type DashboardHeaderConfig,
 	type HeaderAlign,
+	BANNER_HEIGHT_DEFAULT,
+	BANNER_HEIGHT_MAX,
+	BANNER_HEIGHT_MIN,
 	CARD_RADIUS_MAX,
 	CARD_BORDER_WIDTH_MAX,
 	HEADER_MARGIN_TOP_MAX,
@@ -847,15 +851,80 @@ class DashboardSettingsModal extends HearthTabbedModal {
 			1,
 			DEFAULT_DASH_BG_BLUR,
 		);
+
+		this.bannerControls(containerEl, bg);
 	}
 
-	/** A per-dashboard background slider (opacity/blur) with a reset button that
-	 * restores the factory default `def`. */
+	/**
+	 * Wallpaper or banner, for this board alone — and, once it is a banner, the
+	 * shape of the strip. A board that overrides the background overrides how it
+	 * is worn too, so one dashboard can carry a cover image while the next keeps
+	 * the vault's wallpaper.
+	 */
+	private bannerControls(containerEl: HTMLElement, bg: BackgroundConfig): void {
+		const strings = t().dashboards.modal;
+
+		new Setting(containerEl)
+			.setName(strings.backgroundLayout)
+			.setDesc(strings.backgroundLayoutDesc)
+			.addDropdown((d) => {
+				const labels = t().dashboards.backgroundLayoutOptions;
+				(Object.keys(labels) as BackgroundLayout[]).forEach((k) => {
+					d.addOption(k, labels[k]);
+				});
+				d.setValue(bg.layout ?? "full").onChange((v) => {
+					bg.layout = v as BackgroundLayout;
+					// Same lift as the global setting: a banner is the picture
+					// itself, not a backdrop for something else, so wallpaper-ish
+					// opacity and blur would hand the reader a grey smear.
+					if (v === "banner") {
+						if (bg.opacity <= 0.5) bg.opacity = 1;
+						if (bg.blur > 0) bg.blur = 0;
+					}
+					this.commit();
+					this.render();
+				});
+			});
+
+		if (bg.layout !== "banner") return;
+
+		this.bgNumber(
+			containerEl,
+			strings.bannerHeight,
+			bg,
+			"bannerHeight",
+			BANNER_HEIGHT_MIN,
+			BANNER_HEIGHT_MAX,
+			10,
+			BANNER_HEIGHT_DEFAULT,
+		);
+
+		new Setting(containerEl)
+			.setName(strings.bannerFade)
+			.addToggle((tg) =>
+				tg.setValue(bg.bannerFade !== false).onChange((v) => {
+					bg.bannerFade = v;
+					this.commit();
+				}),
+			);
+
+		new Setting(containerEl)
+			.setName(strings.bannerFullWidth)
+			.addToggle((tg) =>
+				tg.setValue(bg.bannerFullWidth === true).onChange((v) => {
+					bg.bannerFullWidth = v;
+					this.commit();
+				}),
+			);
+	}
+
+	/** A per-dashboard background slider (opacity/blur/banner height) with a
+	 * reset button that restores the factory default `def`. */
 	private bgNumber(
 		containerEl: HTMLElement,
 		name: string,
 		bg: BackgroundConfig,
-		key: "opacity" | "blur",
+		key: "opacity" | "blur" | "bannerHeight",
 		min: number,
 		max: number,
 		step: number,
@@ -864,7 +933,10 @@ class DashboardSettingsModal extends HearthTabbedModal {
 		const setting = new Setting(containerEl).setName(name);
 		setting.addSlider((sl) => {
 			sl.setLimits(min, max, step)
-				.setValue(bg[key])
+				// `bannerHeight` is optional on a background saved before banners
+				// existed (and on one that has never been in banner mode), so the
+				// slider starts from the factory value rather than from nothing.
+				.setValue(bg[key] ?? def)
 				// Show the live value in a tooltip. On our declared minAppVersion
 				// (1.8.7) sliders don't yet render the value inline, so this is
 				// how the current opacity/blur stays visible while dragging.

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -936,23 +936,28 @@ function sanitizeBackground(raw: unknown): BackgroundConfig | undefined {
 	const r = raw as Record<string, unknown>;
 	const kinds: BackgroundKind[] = ["none", "color", "image", "url", "weather"];
 	if (!kinds.includes(r.kind as BackgroundKind)) return undefined;
-	const bg: BackgroundConfig = {
+	return {
 		kind: r.kind as BackgroundKind,
 		value: str(r.value) ?? "",
 		opacity: Math.max(0, Math.min(1, num(r.opacity, 0.15))),
 		blur: Math.max(0, Math.min(40, num(r.blur, 0))),
 	};
-	// Banner fields stay absent when the export has none, so a board imported
-	// from an older file resolves to the full-view wallpaper it was saved as.
-	if (r.layout === "banner" || r.layout === "full") bg.layout = r.layout;
+}
+
+/** Read a board's banner overrides off an imported dashboard. Each stays absent
+ * when the file has nothing for it, so an imported board falls back to the
+ * global setting exactly as an unset override should. */
+function applyBannerOverrides(dash: Dashboard, r: Record<string, unknown>): void {
+	if (r.backgroundLayout === "banner" || r.backgroundLayout === "full") {
+		dash.backgroundLayout = r.backgroundLayout;
+	}
 	if (typeof r.bannerHeight === "number") {
-		bg.bannerHeight = clampBannerHeight(r.bannerHeight);
+		dash.bannerHeight = clampBannerHeight(r.bannerHeight);
 	}
-	if (typeof r.bannerFade === "boolean") bg.bannerFade = r.bannerFade;
+	if (typeof r.bannerFade === "boolean") dash.bannerFade = r.bannerFade;
 	if (typeof r.bannerFullWidth === "boolean") {
-		bg.bannerFullWidth = r.bannerFullWidth;
+		dash.bannerFullWidth = r.bannerFullWidth;
 	}
-	return bg;
 }
 
 function sanitizeDashboard(
@@ -1081,6 +1086,7 @@ function sanitizeDashboard(
 	}
 	const bg = sanitizeBackground(r.background);
 	if (bg) dash.background = bg;
+	applyBannerOverrides(dash, r);
 	return dash;
 }
 

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -40,6 +40,7 @@ import {
 	type TasksConfig,
 	activeDashboard,
 	CARD_BORDER_WIDTH_MAX,
+	clampBannerHeight,
 } from "./types";
 import { CARD_KINDS } from "./cards";
 import { isEmbeddableBaseViewName } from "./bases";
@@ -155,6 +156,10 @@ export function exportSettings(s: HomeSettings): string {
 		backgroundValue: s.backgroundValue,
 		backgroundOpacity: s.backgroundOpacity,
 		backgroundBlur: s.backgroundBlur,
+		backgroundLayout: s.backgroundLayout,
+		bannerHeight: s.bannerHeight,
+		bannerFade: s.bannerFade,
+		bannerFullWidth: s.bannerFullWidth,
 		// Low power mode overrides the four above rather than replacing them, so
 		// it has to travel with them — otherwise an export taken while it is on
 		// would describe a look the importing vault doesn't show.
@@ -931,12 +936,23 @@ function sanitizeBackground(raw: unknown): BackgroundConfig | undefined {
 	const r = raw as Record<string, unknown>;
 	const kinds: BackgroundKind[] = ["none", "color", "image", "url", "weather"];
 	if (!kinds.includes(r.kind as BackgroundKind)) return undefined;
-	return {
+	const bg: BackgroundConfig = {
 		kind: r.kind as BackgroundKind,
 		value: str(r.value) ?? "",
 		opacity: Math.max(0, Math.min(1, num(r.opacity, 0.15))),
 		blur: Math.max(0, Math.min(40, num(r.blur, 0))),
 	};
+	// Banner fields stay absent when the export has none, so a board imported
+	// from an older file resolves to the full-view wallpaper it was saved as.
+	if (r.layout === "banner" || r.layout === "full") bg.layout = r.layout;
+	if (typeof r.bannerHeight === "number") {
+		bg.bannerHeight = clampBannerHeight(r.bannerHeight);
+	}
+	if (typeof r.bannerFade === "boolean") bg.bannerFade = r.bannerFade;
+	if (typeof r.bannerFullWidth === "boolean") {
+		bg.bannerFullWidth = r.bannerFullWidth;
+	}
+	return bg;
 }
 
 function sanitizeDashboard(
@@ -1286,6 +1302,16 @@ function applySettings(s: HomeSettings, data: Record<string, unknown>): void {
 	}
 	if (typeof data.backgroundBlur === "number") {
 		s.backgroundBlur = Math.max(0, Math.min(40, data.backgroundBlur));
+	}
+	if (data.backgroundLayout === "full" || data.backgroundLayout === "banner") {
+		s.backgroundLayout = data.backgroundLayout;
+	}
+	if (typeof data.bannerHeight === "number") {
+		s.bannerHeight = clampBannerHeight(data.bannerHeight);
+	}
+	if (typeof data.bannerFade === "boolean") s.bannerFade = data.bannerFade;
+	if (typeof data.bannerFullWidth === "boolean") {
+		s.bannerFullWidth = data.bannerFullWidth;
 	}
 	if (typeof data.lowPower === "boolean") s.lowPower = data.lowPower;
 	const lowPowerColor = str(data.lowPowerBackgroundColor)?.trim();

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -223,13 +223,14 @@ export const en = {
 			opacity: "Opacity",
 			blur: "Blur",
 			backgroundLayout: "Background layout",
-			backgroundLayoutDesc:
-				"Fill this board with the background, or wear it as a banner across " +
-				"the top.",
 			bannerHeight: "Banner height",
 			bannerFade: "Fade the lower edge",
 			bannerFullWidth: "Full width",
+			clearOverride: "Follow the global setting",
 		},
+		useGlobal: "Use global default",
+		on: "on",
+		off: "off",
 		backgroundLayoutOptions: {
 			full: "Full background",
 			banner: "Banner",
@@ -433,7 +434,8 @@ export const en = {
 			layoutDesc:
 				"Fill the whole view with the background, or wear it as a banner — " +
 				"a strip across the top of the board, the way a cover image sits " +
-				"above a note — with the cards below it on the theme's own surface.",
+				"above a note — with the cards below it on the theme's own surface. " +
+				"Each board can override this in its own settings.",
 			layoutLabels: {
 				full: "Full background",
 				banner: "Banner",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -222,6 +222,17 @@ export const en = {
 			backgroundValue: "Background value",
 			opacity: "Opacity",
 			blur: "Blur",
+			backgroundLayout: "Background layout",
+			backgroundLayoutDesc:
+				"Fill this board with the background, or wear it as a banner across " +
+				"the top.",
+			bannerHeight: "Banner height",
+			bannerFade: "Fade the lower edge",
+			bannerFullWidth: "Full width",
+		},
+		backgroundLayoutOptions: {
+			full: "Full background",
+			banner: "Banner",
 		},
 		backgroundOptions: {
 			default: "Use global default",
@@ -418,6 +429,23 @@ export const en = {
 				"How much the background shows through. Lower is more subtle.",
 			blur: "Blur",
 			blurDesc: "Background blur in pixels.",
+			layout: "Background layout",
+			layoutDesc:
+				"Fill the whole view with the background, or wear it as a banner — " +
+				"a strip across the top of the board, the way a cover image sits " +
+				"above a note — with the cards below it on the theme's own surface.",
+			layoutLabels: {
+				full: "Full background",
+				banner: "Banner",
+			},
+			bannerHeight: "Banner height",
+			bannerHeightDesc: "How tall the banner strip is, in pixels.",
+			bannerFade: "Fade the lower edge",
+			bannerFadeDesc:
+				"Let the banner dissolve into the page instead of ending on a hard line.",
+			bannerFullWidth: "Full width",
+			bannerFullWidthDesc:
+				"Run the banner edge to edge instead of lining it up with the content below.",
 			labels: {
 				default: "Hearth default",
 				none: "None",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,7 +5,7 @@ import { hasFileIconPlugin } from "./fileicons";
 import { FILE_TYPE_GROUPS, fileTypeLabel } from "./filetypes";
 import { CommandPickerModal } from "./pickers";
 import { configuredPlaces, renderSkySource } from "./placepicker";
-import { type BackgroundKind, CARD_BORDER_WIDTH_MAX, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, LOW_POWER_BACKGROUND, type MobileActionButton, OPEN_IN_MODES, OPEN_SOURCES, type OpenIn, type OpenInRule, type OpenOutsideRule } from "./types";
+import { BANNER_HEIGHT_MAX, BANNER_HEIGHT_MIN, type BackgroundKind, type BackgroundLayout, CARD_BORDER_WIDTH_MAX, clampBannerHeight, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, LOW_POWER_BACKGROUND, type MobileActionButton, OPEN_IN_MODES, OPEN_SOURCES, type OpenIn, type OpenInRule, type OpenOutsideRule } from "./types";
 import { exportLayout, exportSettings, importLayout, importSettings } from "./layout";
 import { confirmAction, downloadTextFile, makeClickable, pickTextFile } from "./ui";
 import { isOmnisearchAvailable, OMNISEARCH_PLUGIN_ID } from "./omnisearch";
@@ -27,6 +27,7 @@ type NumericSettingKey =
 	| "maxWidth"
 	| "backgroundOpacity"
 	| "backgroundBlur"
+	| "bannerHeight"
 	| "cardOpacity"
 	| "cardBlur"
 	| "cardRadius"
@@ -886,7 +887,80 @@ export class HomeSettingTab extends PluginSettingTab {
 					});
 				this.addSliderReset(blur, sl, "backgroundBlur");
 			});
+
+			this.bannerSection(containerEl);
 		}
+	}
+
+	/**
+	 * Where the background is painted: across the whole view, or as a banner
+	 * strip at the top of the board. The banner's own shape (height, fade,
+	 * width) only appears once it is the mode in force — there is nothing to
+	 * tune about a strip that isn't being drawn.
+	 */
+	private bannerSection(containerEl: HTMLElement): void {
+		const s = this.plugin.settings;
+		const strings = t().settings.background;
+
+		new Setting(containerEl)
+			.setName(strings.layout)
+			.setDesc(strings.layoutDesc)
+			.addDropdown((d) => {
+				(Object.keys(strings.layoutLabels) as BackgroundLayout[]).forEach((k) => {
+					d.addOption(k, strings.layoutLabels[k]);
+				});
+				d.setValue(s.backgroundLayout).onChange((v) => {
+					s.backgroundLayout = v as BackgroundLayout;
+					// A wallpaper is dimmed and softened so the board on top of it
+					// stays readable — that is what the 0.35/2 defaults are for. A
+					// banner has nothing on top of it: it is the picture itself, and
+					// at those values it arrives as a grey smear. So lift it once on
+					// the way in, only from wallpaper-ish values, with both sliders
+					// right above to put it back.
+					if (v === "banner") {
+						if (s.backgroundOpacity <= 0.5) s.backgroundOpacity = 1;
+						if (s.backgroundBlur > 0) s.backgroundBlur = 0;
+					}
+					void this.save();
+					this.rerender();
+				});
+			});
+
+		if (s.backgroundLayout !== "banner") return;
+
+		const height = new Setting(containerEl)
+			.setName(strings.bannerHeight)
+			.setDesc(strings.bannerHeightDesc);
+		height.addSlider((sl) => {
+			sl.setLimits(BANNER_HEIGHT_MIN, BANNER_HEIGHT_MAX, 10)
+				.setValue(clampBannerHeight(s.bannerHeight))
+				.setDynamicTooltip()
+				.onChange(async (v) => {
+					s.bannerHeight = v;
+					await this.save();
+				});
+			this.addSliderReset(height, sl, "bannerHeight");
+		});
+
+		new Setting(containerEl)
+			.setName(strings.bannerFade)
+			.setDesc(strings.bannerFadeDesc)
+			.addToggle((tg) =>
+				tg.setValue(s.bannerFade !== false).onChange(async (v) => {
+					s.bannerFade = v;
+					await this.save();
+				}),
+			);
+
+		new Setting(containerEl)
+			.setName(strings.bannerFullWidth)
+			.setDesc(strings.bannerFullWidthDesc)
+			.addToggle((tg) =>
+				tg.setValue(s.bannerFullWidth === true).onChange(async (v) => {
+					s.bannerFullWidth = v;
+					await this.save();
+				}),
+			);
 	}
 
 	/** The weather sky's own controls: where it is, and whether it moves. The

--- a/src/types.ts
+++ b/src/types.ts
@@ -1297,6 +1297,36 @@ export type BackgroundKind =
  * decode, opacity layer or blur behind it. */
 export const LOW_POWER_BACKGROUND = "#4a4459";
 
+/**
+ * Where the background is painted.
+ *
+ * "full" is the classic Hearth board: the backdrop fills the whole view and the
+ * cards float on top of it. "banner" turns the same backdrop into a strip
+ * across the top of the content — a cover image, the way a note's banner works
+ * — and leaves the rest of the board on the theme's own surface, so the cards
+ * read against a plain background instead of a picture.
+ *
+ * Both modes share one background configuration: the kind, value, opacity and
+ * blur mean exactly the same thing in each, so switching between them is a
+ * single dropdown and never loses what was set up.
+ */
+export type BackgroundLayout = "full" | "banner";
+
+/** How tall a banner is by default, in pixels: big enough to read as a cover
+ * image, short enough that the first row of cards is still on screen. */
+export const BANNER_HEIGHT_DEFAULT = 220;
+/** Banner height bounds. The floor keeps a banner from collapsing into a line;
+ * the ceiling keeps it from pushing the whole board off the fold. */
+export const BANNER_HEIGHT_MIN = 60;
+export const BANNER_HEIGHT_MAX = 600;
+
+/** Clamp a banner height to {@link BANNER_HEIGHT_MIN}..{@link BANNER_HEIGHT_MAX},
+ * falling back to the default for a missing or non-numeric value. */
+export function clampBannerHeight(h: number | undefined): number {
+	if (typeof h !== "number" || Number.isNaN(h)) return BANNER_HEIGHT_DEFAULT;
+	return Math.max(BANNER_HEIGHT_MIN, Math.min(BANNER_HEIGHT_MAX, Math.round(h)));
+}
+
 /** A self-contained background configuration (used for per-dashboard overrides
  * as well as the global default). */
 export interface BackgroundConfig {
@@ -1306,6 +1336,17 @@ export interface BackgroundConfig {
 	value: string;
 	opacity: number;
 	blur: number;
+	/** Full-view wallpaper or a banner strip at the top. Undefined = "full", so
+	 * every background saved before banners existed keeps its look. */
+	layout?: BackgroundLayout;
+	/** Banner height in pixels; only read when `layout` is "banner". */
+	bannerHeight?: number;
+	/** Fade the banner's lower edge into the page instead of cutting it off with
+	 * a hard line. Undefined = faded (the default look). */
+	bannerFade?: boolean;
+	/** Let the banner run edge to edge instead of lining up with the content
+	 * column. Undefined = aligned with the content. */
+	bannerFullWidth?: boolean;
 }
 
 /** A named dashboard: one arrangeable board of cards. The vault can hold several
@@ -1461,6 +1502,16 @@ export interface HomeSettings {
 	backgroundValue: string;
 	backgroundOpacity: number;
 	backgroundBlur: number;
+	/** Paint the background across the whole view, or as a banner strip at the
+	 * top of the content. See {@link BackgroundLayout}. */
+	backgroundLayout: BackgroundLayout;
+	/** Banner height in pixels; only used when `backgroundLayout` is "banner". */
+	bannerHeight: number;
+	/** Fade the banner's lower edge into the page. Default true. */
+	bannerFade: boolean;
+	/** Run the banner edge to edge rather than aligning it with the content
+	 * column. Default false. */
+	bannerFullWidth: boolean;
 	/** Let the "weather" background drift, fall and twinkle. Default true; low
 	 * power mode replaces the whole background anyway, and a reader who has
 	 * asked their OS for reduced motion gets a still sky regardless. */
@@ -1629,6 +1680,12 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	 * the image is still recognizable, not a wash of colour. */
 	backgroundOpacity: 0.35,
 	backgroundBlur: 2,
+	/* The wallpaper board is what Hearth has always been, so it stays the
+	 * default; the banner is a choice, not an upgrade. */
+	backgroundLayout: "full",
+	bannerHeight: BANNER_HEIGHT_DEFAULT,
+	bannerFade: true,
+	bannerFullWidth: false,
 
 	openOnStartup: true,
 	replaceNewTabs: true,
@@ -2019,19 +2076,42 @@ export function setCardPinned(s: HomeSettings, card: DashboardCard, pinned: bool
 }
 
 /** Effective background for the active board (per-dashboard override or global,
- * or the flat low power colour when that mode is on). */
+ * or the flat low power colour when that mode is on).
+ *
+ * The banner fields come back resolved — never undefined — so callers can paint
+ * from the result without repeating the fallbacks. */
 export function effectiveBackground(s: HomeSettings): BackgroundConfig {
 	// Overrides the per-dashboard background too: the point is that no board can
 	// pull in a wallpaper while low power mode is on.
 	if (lowPowerActive(s)) return lowPowerBackground(s);
-	return (
-		activeDashboard(s).background ?? {
-			kind: s.backgroundKind,
-			value: s.backgroundValue,
-			opacity: s.backgroundOpacity,
-			blur: s.backgroundBlur,
-		}
-	);
+	const bg = activeDashboard(s).background;
+	if (bg) {
+		return {
+			...bg,
+			layout: bg.layout ?? "full",
+			bannerHeight: clampBannerHeight(bg.bannerHeight),
+			bannerFade: bg.bannerFade !== false,
+			bannerFullWidth: bg.bannerFullWidth === true,
+		};
+	}
+	return {
+		kind: s.backgroundKind,
+		value: s.backgroundValue,
+		opacity: s.backgroundOpacity,
+		blur: s.backgroundBlur,
+		layout: s.backgroundLayout ?? "full",
+		bannerHeight: clampBannerHeight(s.bannerHeight),
+		bannerFade: s.bannerFade !== false,
+		bannerFullWidth: s.bannerFullWidth === true,
+	};
+}
+
+/** Whether the active board paints its backdrop as a banner rather than as a
+ * full-view wallpaper. A "none" background has nothing to put in a banner, so
+ * it reports false and the board is drawn without one. */
+export function bannerActive(s: HomeSettings): boolean {
+	const bg = effectiveBackground(s);
+	return bg.layout === "banner" && bg.kind !== "none";
 }
 
 /**
@@ -2099,6 +2179,13 @@ export function migrateSettings(s: HomeSettings, raw: Record<string, unknown>): 
 	}
 	if (typeof s.backgroundOpacity !== "number") s.backgroundOpacity = 0.35;
 	if (typeof s.backgroundBlur !== "number") s.backgroundBlur = 2;
+	// Banner mode is purely additive: settings saved before it existed have none
+	// of these keys, and defaulting them to the full-view wallpaper leaves every
+	// existing board looking exactly as it did.
+	if (s.backgroundLayout !== "banner") s.backgroundLayout = "full";
+	s.bannerHeight = clampBannerHeight(s.bannerHeight);
+	if (typeof s.bannerFade !== "boolean") s.bannerFade = true;
+	if (typeof s.bannerFullWidth !== "boolean") s.bannerFullWidth = false;
 	// Fit-to-page is the default for fresh installs; existing users keep their
 	// choice (only backfill when the field is missing entirely).
 	if (typeof raw.fitToPage !== "boolean") s.fitToPage = true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1328,7 +1328,13 @@ export function clampBannerHeight(h: number | undefined): number {
 }
 
 /** A self-contained background configuration (used for per-dashboard overrides
- * as well as the global default). */
+ * as well as the global default).
+ *
+ * This is *what the backdrop is* and nothing else. How a board wears it — full
+ * view or banner, and the banner's shape — is deliberately not in here: those
+ * are their own per-dashboard overrides ({@link BannerOverrides}) so a board can
+ * turn the vault's background into a banner without having to restate the
+ * picture. {@link effectiveBackground} joins the two. */
 export interface BackgroundConfig {
 	kind: BackgroundKind;
 	/** A CSS colour, a vault image path, a URL, or — for "weather" — a packed
@@ -1336,17 +1342,41 @@ export interface BackgroundConfig {
 	value: string;
 	opacity: number;
 	blur: number;
-	/** Full-view wallpaper or a banner strip at the top. Undefined = "full", so
-	 * every background saved before banners existed keeps its look. */
-	layout?: BackgroundLayout;
-	/** Banner height in pixels; only read when `layout` is "banner". */
+}
+
+/**
+ * How a board wears its background, as *overrides*: every field is optional and
+ * falls back to the global setting, the same way `gridColumns`, `maxWidth` and
+ * `cardOpacity` already do.
+ *
+ * Kept separate from {@link BackgroundConfig} on purpose. A board's background
+ * override is all-or-nothing — take it and you restate the kind, the value, the
+ * opacity and the blur — and making the banner part of it would have meant a
+ * board could only have a banner by re-specifying the whole picture. These
+ * override independently, so "the vault's background, but as a banner on this
+ * board" is one dropdown.
+ */
+export interface BannerOverrides {
+	/** Full-view wallpaper or a banner strip at the top. */
+	backgroundLayout?: BackgroundLayout;
+	/** Banner height in pixels; only read when the layout resolves to "banner". */
 	bannerHeight?: number;
 	/** Fade the banner's lower edge into the page instead of cutting it off with
-	 * a hard line. Undefined = faded (the default look). */
+	 * a hard line. */
 	bannerFade?: boolean;
 	/** Let the banner run edge to edge instead of lining up with the content
-	 * column. Undefined = aligned with the content. */
+	 * column. */
 	bannerFullWidth?: boolean;
+}
+
+/** A background resolved for painting: what the backdrop is, plus how this
+ * board wears it, with every fallback already applied. What
+ * {@link effectiveBackground} hands to the renderer. */
+export interface ResolvedBackground extends BackgroundConfig {
+	layout: BackgroundLayout;
+	bannerHeight: number;
+	bannerFade: boolean;
+	bannerFullWidth: boolean;
 }
 
 /** A named dashboard: one arrangeable board of cards. The vault can hold several
@@ -1374,7 +1404,7 @@ export interface DashboardHeaderConfig {
 	spacingBelow?: number;
 }
 
-export interface Dashboard {
+export interface Dashboard extends BannerOverrides {
 	id: string;
 	name: string;
 	/** Optional emoji/short text shown on the switcher button instead of its
@@ -1387,6 +1417,9 @@ export interface Dashboard {
 	/** Optional overrides; when omitted the global setting is used. */
 	gridColumns?: number;
 	rowHeight?: number;
+	/** Override *what* the backdrop is for this board. Independent of the
+	 * banner overrides inherited from {@link BannerOverrides}, which say how it
+	 * is worn — a board can override either, both, or neither. */
 	background?: BackgroundConfig;
 	/** Override "fit to page" for this board (undefined = use global). */
 	fitToPage?: boolean;
@@ -2075,40 +2108,46 @@ export function setCardPinned(s: HomeSettings, card: DashboardCard, pinned: bool
 	}
 }
 
-/** Effective background for the active board (per-dashboard override or global,
- * or the flat low power colour when that mode is on).
+/**
+ * Effective background for the active board: what the backdrop is, and how the
+ * board wears it, with every fallback applied.
  *
- * The banner fields come back resolved — never undefined — so callers can paint
- * from the result without repeating the fallbacks. */
-export function effectiveBackground(s: HomeSettings): BackgroundConfig {
-	// Overrides the per-dashboard background too: the point is that no board can
-	// pull in a wallpaper while low power mode is on.
-	if (lowPowerActive(s)) return lowPowerBackground(s);
-	const bg = activeDashboard(s).background;
-	if (bg) {
-		return {
-			...bg,
-			layout: bg.layout ?? "full",
-			bannerHeight: clampBannerHeight(bg.bannerHeight),
-			bannerFade: bg.bannerFade !== false,
-			bannerFullWidth: bg.bannerFullWidth === true,
-		};
-	}
+ * The two halves resolve *separately*, which is the whole point of splitting
+ * them. A board can override the picture and keep the global layout, override
+ * the layout and keep the global picture, or override both — so "the vault's
+ * wallpaper, but as a banner on this one board" needs no picture restated.
+ */
+export function effectiveBackground(s: HomeSettings): ResolvedBackground {
+	const dash = activeDashboard(s);
+	// Low power replaces the backdrop — and only the backdrop. The layout is not
+	// a paint cost, and swapping it would move every card on the board the
+	// moment the mode is toggled, which is exactly what the mode promises not to
+	// do. So a bannered board keeps its banner and simply fills it with the flat
+	// colour. The per-dashboard background is overridden along with the global
+	// one: no board may pull in a wallpaper while the mode is on.
+	const source = lowPowerActive(s)
+		? lowPowerBackground(s)
+		: (dash.background ?? {
+				kind: s.backgroundKind,
+				value: s.backgroundValue,
+				opacity: s.backgroundOpacity,
+				blur: s.backgroundBlur,
+			});
+
 	return {
-		kind: s.backgroundKind,
-		value: s.backgroundValue,
-		opacity: s.backgroundOpacity,
-		blur: s.backgroundBlur,
-		layout: s.backgroundLayout ?? "full",
-		bannerHeight: clampBannerHeight(s.bannerHeight),
-		bannerFade: s.bannerFade !== false,
-		bannerFullWidth: s.bannerFullWidth === true,
+		...source,
+		layout: dash.backgroundLayout ?? s.backgroundLayout ?? "full",
+		bannerHeight: clampBannerHeight(dash.bannerHeight ?? s.bannerHeight),
+		bannerFade: (dash.bannerFade ?? s.bannerFade) !== false,
+		bannerFullWidth: (dash.bannerFullWidth ?? s.bannerFullWidth) === true,
 	};
 }
 
 /** Whether the active board paints its backdrop as a banner rather than as a
  * full-view wallpaper. A "none" background has nothing to put in a banner, so
- * it reports false and the board is drawn without one. */
+ * it reports false and the board is drawn without one. Low power mode does not
+ * change the answer — it swaps what fills the banner, not whether there is one
+ * (see {@link effectiveBackground}). */
 export function bannerActive(s: HomeSettings): boolean {
 	const bg = effectiveBackground(s);
 	return bg.layout === "banner" && bg.kind !== "none";

--- a/src/view.ts
+++ b/src/view.ts
@@ -4,8 +4,9 @@ import { renderHeader } from "./header";
 import { renderDashboard } from "./dashboard";
 import { renderDashboardSwitcher } from "./dashboards";
 import { renderMobileActionBar } from "./mobileactions";
-import { applyBackground } from "./background";
+import { applyBackground, renderBanner } from "./background";
 import {
+	bannerActive,
 	effectiveFitToPage,
 	effectiveMaxWidth,
 	effectiveShowSearch,
@@ -167,10 +168,23 @@ export class HomeView extends ItemView {
 			renderCards(this.plugin.settings).length === 0;
 		root.toggleClass("hearth-empty-board", emptyBoard);
 
-		applyBackground(this, root, child);
+		// The backdrop is painted one of two ways. As a wallpaper it goes behind
+		// everything, so it is laid down before the scroll area; as a banner it is
+		// a strip at the top of the content, so it is the scroll area's first
+		// child and the board flows below it.
+		//
+		// Mobile-only mode is the one board with nothing for a banner to head: it
+		// is a centred search field and nothing else, so the same background is
+		// painted as a wallpaper there rather than as a strip floating above a
+		// launcher.
+		const banner = !mobileOnly && bannerActive(this.plugin.settings);
+		root.toggleClass("hearth-has-banner", banner);
+		if (!banner) applyBackground(this, root, child);
 
 		const scroll = root.createDiv("hearth-scroll");
 		scroll.toggleClass("hearth-fit", effectiveFitToPage(this.plugin.settings));
+
+		if (banner) renderBanner(this, scroll, child);
 
 		const inner = scroll.createDiv("hearth-inner");
 		inner.style.maxWidth = `${effectiveMaxWidth(this.plugin.settings)}px`;

--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,58 @@
 	pointer-events: none;
 }
 
+/* ---- Banner ----------------------------------------------------------
+ *
+ * The other way to wear a background: instead of filling the view, the same
+ * backdrop is cropped into a strip at the top of the content — a cover image,
+ * the way a note's banner works — and the board sits below it on the theme's
+ * own surface.
+ *
+ * It is a real element in the scroll flow rather than a fixed layer, which is
+ * what makes it cost nothing anywhere else: it scrolls away with the content,
+ * and on a fit-to-page board the grid simply gets whatever height is left.
+ * Everything inside it is the wallpaper's own `.hearth-bg` layer, so opacity,
+ * blur and the live weather sky all behave identically in both modes. */
+.hearth-banner {
+	position: relative;
+	/* Never squeezed by the flex column that fit-to-page/empty-board mode turns
+	 * the scroll area into: the height the reader set is the height they get. */
+	flex: 0 0 auto;
+	width: 100%;
+	margin: 0 auto var(--hearth-inner-gap, 28px);
+	border-radius: 12px;
+	/* Crops the layer inside to the strip — including a blurred layer's soft
+	 * edges, which are deliberately grown past this box (see renderBanner). */
+	overflow: hidden;
+	/* Decoration, not a target: clicks belong to whatever is under it. */
+	pointer-events: none;
+}
+
+/* Full-bleed: cancel the scroll area's own padding so the strip runs to the
+ * pane's edges, and drop the corner radius that only makes sense inset. */
+.hearth-banner.is-full-width {
+	max-width: none;
+	width: auto;
+	margin-top: calc(-1 * var(--hearth-scroll-pad-top, 4vh));
+	margin-left: calc(-1 * var(--hearth-scroll-pad-x, 24px));
+	margin-right: calc(-1 * var(--hearth-scroll-pad-x, 24px));
+	border-radius: 0;
+}
+
+/* Fade the lower edge into the page instead of ending on a hard line. Masking
+ * the layer (not the banner) keeps the crop above intact. */
+.hearth-banner.is-faded > .hearth-bg {
+	-webkit-mask-image: linear-gradient(to bottom, #000 55%, transparent 100%);
+	mask-image: linear-gradient(to bottom, #000 55%, transparent 100%);
+}
+
+/* On a fitted board the banner and the grid share one screen, so cap the strip
+ * before it can eat the whole board — a height meant for a scrolling board
+ * shouldn't leave nothing to fit. */
+.hearth-fit .hearth-banner {
+	max-height: 60%;
+}
+
 /* ---- Low power mode ---------------------------------------------------
  *
  * The paint-cost half of the setting. Everything with a value behind it — the
@@ -80,7 +132,11 @@
 	z-index: 1;
 	height: 100%;
 	overflow-y: auto;
-	padding: 4vh 24px 48px;
+	/* Kept in variables so a full-bleed banner can cancel exactly this padding,
+	 * whichever spacing mode is in force (see .hearth-banner.is-full-width). */
+	--hearth-scroll-pad-x: 24px;
+	--hearth-scroll-pad-top: 4vh;
+	padding: var(--hearth-scroll-pad-top) var(--hearth-scroll-pad-x) 48px;
 }
 
 .hearth-scroll.hearth-fit {
@@ -113,6 +169,15 @@
 .hearth-fit .hearth-inner {
 	height: 100%;
 	min-height: 0;
+}
+
+/* With a banner above it the inner is no longer alone in the fitted column, and
+ * `height: 100%` would resolve against the whole scroll area — overflowing (and
+ * clipping the bottom row of cards) by exactly the banner's height. Take the
+ * remainder instead. */
+.hearth-view.hearth-has-banner .hearth-fit .hearth-inner {
+	height: auto;
+	flex: 1 1 auto;
 }
 
 /* ---- Header --------------------------------------------------------- */
@@ -5580,10 +5645,12 @@
 /* ---- Compact spacing ----------------------------------------------- */
 
 .hearth-compact .hearth-scroll {
-	padding: 1.5vh 14px 24px;
-}
-
-.hearth-compact .hearth-inner {
+	--hearth-scroll-pad-x: 14px;
+	--hearth-scroll-pad-top: 1.5vh;
+	padding: var(--hearth-scroll-pad-top) var(--hearth-scroll-pad-x) 24px;
+	/* Declared on the scroll area rather than on .hearth-inner so the banner —
+	 * inner's sibling, not its child — inherits the compact gap too and keeps
+	 * the same distance from the content as everything else. */
 	--hearth-inner-gap: 16px;
 }
 

--- a/test/banner.test.ts
+++ b/test/banner.test.ts
@@ -66,10 +66,9 @@ describe("effectiveBackground banner fields", () => {
 		});
 	});
 
-	it("fills a per-dashboard override's missing banner fields", () => {
+	it("takes the board's picture and the global layout when only the picture is overridden", () => {
 		const s = settings();
 		s.backgroundLayout = "banner";
-		// A background saved before banners existed: layout and the rest absent.
 		s.dashboards[0].background = {
 			kind: "image",
 			value: "Attachments/board.png",
@@ -77,33 +76,97 @@ describe("effectiveBackground banner fields", () => {
 			blur: 12,
 		};
 
-		// The override carries its own layout, so it stays a wallpaper even
-		// though the global default has moved to banners.
 		expect(effectiveBackground(s)).toEqual({
 			kind: "image",
 			value: "Attachments/board.png",
 			opacity: 0.8,
 			blur: 12,
-			layout: "full",
+			layout: "banner",
 			bannerHeight: BANNER_HEIGHT_DEFAULT,
 			bannerFade: true,
 			bannerFullWidth: false,
 		});
 	});
+});
 
-	it("lets one board wear a banner while the vault keeps its wallpaper", () => {
+/**
+ * The reason the layout is its own override rather than a field on the
+ * background: a board must be able to change how the backdrop is worn without
+ * restating what the backdrop is, and vice versa.
+ */
+describe("per-dashboard banner overrides", () => {
+	it("lets a board wear the vault's own background as a banner", () => {
+		const s = settings();
+		s.dashboards[0].backgroundLayout = "banner";
+
+		// Nothing about the picture was restated on the board...
+		expect(s.dashboards[0].background).toBeUndefined();
+		expect(s.backgroundLayout).toBe("full");
+
+		// ...yet the board shows the vault's background, as a banner.
+		const bg = effectiveBackground(s);
+		expect(bannerActive(s)).toBe(true);
+		expect(bg.value).toBe("https://example.com/cover.png");
+		expect(bg.layout).toBe("banner");
+	});
+
+	it("lets a board keep the wallpaper while the vault has moved to banners", () => {
+		const s = settings();
+		s.backgroundLayout = "banner";
+		s.dashboards[0].backgroundLayout = "full";
+
+		expect(bannerActive(s)).toBe(false);
+		expect(effectiveBackground(s).layout).toBe("full");
+	});
+
+	it("overrides each part of the banner's shape on its own", () => {
+		const s = settings();
+		s.backgroundLayout = "banner";
+		s.bannerHeight = 200;
+		s.bannerFade = true;
+		s.bannerFullWidth = false;
+		// Only the height and the fade are the board's; the width still follows.
+		s.dashboards[0].bannerHeight = 400;
+		s.dashboards[0].bannerFade = false;
+
+		const bg = effectiveBackground(s);
+		expect(bg.bannerHeight).toBe(400);
+		expect(bg.bannerFade).toBe(false);
+		expect(bg.bannerFullWidth).toBe(false);
+	});
+
+	it("falls back to the global value once an override is cleared", () => {
+		const s = settings();
+		s.backgroundLayout = "banner";
+		s.bannerHeight = 300;
+		s.dashboards[0].bannerHeight = 120;
+		expect(effectiveBackground(s).bannerHeight).toBe(120);
+
+		s.dashboards[0].bannerHeight = undefined;
+		expect(effectiveBackground(s).bannerHeight).toBe(300);
+	});
+
+	it("clamps a board's height the same way the global one is clamped", () => {
+		const s = settings();
+		s.backgroundLayout = "banner";
+		s.dashboards[0].bannerHeight = 9000;
+		expect(effectiveBackground(s).bannerHeight).toBe(BANNER_HEIGHT_MAX);
+	});
+
+	it("combines a board's own picture with a board's own layout", () => {
 		const s = settings();
 		s.dashboards[0].background = {
 			kind: "url",
 			value: "https://example.com/board-cover.png",
 			opacity: 1,
 			blur: 0,
-			layout: "banner",
-			bannerHeight: 320,
 		};
+		s.dashboards[0].backgroundLayout = "banner";
+		s.dashboards[0].bannerHeight = 320;
 
 		expect(s.backgroundLayout).toBe("full");
 		expect(bannerActive(s)).toBe(true);
+		expect(effectiveBackground(s).value).toBe("https://example.com/board-cover.png");
 		expect(effectiveBackground(s).bannerHeight).toBe(320);
 	});
 });
@@ -126,11 +189,25 @@ describe("bannerActive", () => {
 		expect(bannerActive(s)).toBe(false);
 	});
 
-	it("stays off under low power, which replaces the whole backdrop", () => {
+	// Low power swaps what fills the banner, not whether there is one: changing
+	// the layout would move every card on the board the moment the mode is
+	// toggled, which is the one thing the mode promises not to do.
+	it("survives low power, which replaces the picture but not the layout", () => {
 		const s = settings();
 		s.backgroundLayout = "banner";
 		s.lowPower = true;
-		expect(bannerActive(s)).toBe(false);
+
+		expect(bannerActive(s)).toBe(true);
+		expect(effectiveBackground(s).kind).toBe("color");
+		expect(effectiveBackground(s).layout).toBe("banner");
+	});
+
+	it("keeps a board-level banner under low power too", () => {
+		const s = settings();
+		s.dashboards[0].backgroundLayout = "banner";
+		s.lowPower = true;
+
+		expect(bannerActive(s)).toBe(true);
 		expect(effectiveBackground(s).kind).toBe("color");
 	});
 });

--- a/test/banner.test.ts
+++ b/test/banner.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import {
+	BANNER_HEIGHT_DEFAULT,
+	BANNER_HEIGHT_MAX,
+	BANNER_HEIGHT_MIN,
+	bannerActive,
+	clampBannerHeight,
+	DEFAULT_SETTINGS,
+	effectiveBackground,
+	migrateSettings,
+	type HomeSettings,
+} from "../src/types";
+
+/**
+ * Banner mode is a *layout* on top of the existing background, not a second
+ * background: the kind, value, opacity and blur mean the same thing whichever
+ * way the backdrop is worn, and switching between them must never lose what was
+ * configured.
+ *
+ * These tests pin the two things the rest of the code relies on: that
+ * `effectiveBackground` always reports resolved banner fields (so nothing has
+ * to repeat the fallbacks), and that a board only counts as bannered when there
+ * is actually something to put in the strip.
+ */
+
+function settings(): HomeSettings {
+	const s: HomeSettings = structuredClone(DEFAULT_SETTINGS);
+	s.backgroundKind = "url";
+	s.backgroundValue = "https://example.com/cover.png";
+	s.dashboards = [{ id: "d1", name: "Dashboard 1", cards: [] }];
+	s.activeDashboardId = "d1";
+	return s;
+}
+
+describe("clampBannerHeight", () => {
+	it("keeps a sane height, rounds, and bounds the rest", () => {
+		expect(clampBannerHeight(300)).toBe(300);
+		expect(clampBannerHeight(220.4)).toBe(220);
+		expect(clampBannerHeight(BANNER_HEIGHT_MIN - 50)).toBe(BANNER_HEIGHT_MIN);
+		expect(clampBannerHeight(BANNER_HEIGHT_MAX + 50)).toBe(BANNER_HEIGHT_MAX);
+	});
+
+	it("falls back to the default for a missing or unusable value", () => {
+		expect(clampBannerHeight(undefined)).toBe(BANNER_HEIGHT_DEFAULT);
+		expect(clampBannerHeight(Number.NaN)).toBe(BANNER_HEIGHT_DEFAULT);
+	});
+});
+
+describe("effectiveBackground banner fields", () => {
+	it("resolves the global banner settings", () => {
+		const s = settings();
+		s.backgroundLayout = "banner";
+		s.bannerHeight = 1000;
+		s.bannerFade = false;
+		s.bannerFullWidth = true;
+
+		expect(effectiveBackground(s)).toEqual({
+			kind: "url",
+			value: "https://example.com/cover.png",
+			opacity: DEFAULT_SETTINGS.backgroundOpacity,
+			blur: DEFAULT_SETTINGS.backgroundBlur,
+			layout: "banner",
+			bannerHeight: BANNER_HEIGHT_MAX,
+			bannerFade: false,
+			bannerFullWidth: true,
+		});
+	});
+
+	it("fills a per-dashboard override's missing banner fields", () => {
+		const s = settings();
+		s.backgroundLayout = "banner";
+		// A background saved before banners existed: layout and the rest absent.
+		s.dashboards[0].background = {
+			kind: "image",
+			value: "Attachments/board.png",
+			opacity: 0.8,
+			blur: 12,
+		};
+
+		// The override carries its own layout, so it stays a wallpaper even
+		// though the global default has moved to banners.
+		expect(effectiveBackground(s)).toEqual({
+			kind: "image",
+			value: "Attachments/board.png",
+			opacity: 0.8,
+			blur: 12,
+			layout: "full",
+			bannerHeight: BANNER_HEIGHT_DEFAULT,
+			bannerFade: true,
+			bannerFullWidth: false,
+		});
+	});
+
+	it("lets one board wear a banner while the vault keeps its wallpaper", () => {
+		const s = settings();
+		s.dashboards[0].background = {
+			kind: "url",
+			value: "https://example.com/board-cover.png",
+			opacity: 1,
+			blur: 0,
+			layout: "banner",
+			bannerHeight: 320,
+		};
+
+		expect(s.backgroundLayout).toBe("full");
+		expect(bannerActive(s)).toBe(true);
+		expect(effectiveBackground(s).bannerHeight).toBe(320);
+	});
+});
+
+describe("bannerActive", () => {
+	it("is off for the classic full-view background", () => {
+		expect(bannerActive(settings())).toBe(false);
+	});
+
+	it("is on once the layout says so", () => {
+		const s = settings();
+		s.backgroundLayout = "banner";
+		expect(bannerActive(s)).toBe(true);
+	});
+
+	it("stays off with no background to put in the strip", () => {
+		const s = settings();
+		s.backgroundLayout = "banner";
+		s.backgroundKind = "none";
+		expect(bannerActive(s)).toBe(false);
+	});
+
+	it("stays off under low power, which replaces the whole backdrop", () => {
+		const s = settings();
+		s.backgroundLayout = "banner";
+		s.lowPower = true;
+		expect(bannerActive(s)).toBe(false);
+		expect(effectiveBackground(s).kind).toBe("color");
+	});
+});
+
+describe("migrateSettings and banners", () => {
+	it("defaults a pre-banner install to the full-view background", () => {
+		const s = settings();
+		// Simulate a data.json written before banner mode existed.
+		delete (s as Partial<HomeSettings>).backgroundLayout;
+		delete (s as Partial<HomeSettings>).bannerHeight;
+		delete (s as Partial<HomeSettings>).bannerFade;
+		delete (s as Partial<HomeSettings>).bannerFullWidth;
+
+		migrateSettings(s, {});
+
+		expect(s.backgroundLayout).toBe("full");
+		expect(s.bannerHeight).toBe(BANNER_HEIGHT_DEFAULT);
+		expect(s.bannerFade).toBe(true);
+		expect(s.bannerFullWidth).toBe(false);
+		expect(bannerActive(s)).toBe(false);
+	});
+
+	it("keeps a chosen banner and repairs an out-of-range height", () => {
+		const s = settings();
+		s.backgroundLayout = "banner";
+		s.bannerHeight = 5;
+
+		migrateSettings(s, {});
+
+		expect(s.backgroundLayout).toBe("banner");
+		expect(s.bannerHeight).toBe(BANNER_HEIGHT_MIN);
+	});
+
+	it("repairs a wrong-typed layout rather than trusting it", () => {
+		const s = settings();
+		(s as unknown as Record<string, unknown>).backgroundLayout = "cover";
+
+		migrateSettings(s, {});
+
+		expect(s.backgroundLayout).toBe("full");
+	});
+});

--- a/test/lowpower.test.ts
+++ b/test/lowpower.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	BANNER_HEIGHT_DEFAULT,
 	DEFAULT_SETTINGS,
 	effectiveAutoRefreshMinutes,
 	effectiveBackground,
@@ -65,6 +66,12 @@ describe("effectiveBackground under low power", () => {
 			value: "https://example.com/wallpaper.png",
 			opacity: 0.4,
 			blur: 6,
+			// Resolved rather than configured: effectiveBackground always reports
+			// the banner fields so callers never repeat the fallbacks.
+			layout: "full",
+			bannerHeight: BANNER_HEIGHT_DEFAULT,
+			bannerFade: true,
+			bannerFullWidth: false,
 		});
 
 		s.lowPower = true;
@@ -107,6 +114,10 @@ describe("effectiveBackground under low power", () => {
 			value: "Attachments/board.png",
 			opacity: 0.8,
 			blur: 12,
+			layout: "full",
+			bannerHeight: BANNER_HEIGHT_DEFAULT,
+			bannerFade: true,
+			bannerFullWidth: false,
 		});
 	});
 });

--- a/test/lowpower.test.ts
+++ b/test/lowpower.test.ts
@@ -80,6 +80,13 @@ describe("effectiveBackground under low power", () => {
 			value: LOW_POWER_BACKGROUND,
 			opacity: 1,
 			blur: 0,
+			// The mode replaces the picture, not the shape of the board: the
+			// layout is not a paint cost, and changing it would move every card
+			// on a bannered board the moment the mode is toggled.
+			layout: "full",
+			bannerHeight: BANNER_HEIGHT_DEFAULT,
+			bannerFade: true,
+			bannerFullWidth: false,
 		});
 
 		s.lowPower = false;


### PR DESCRIPTION
## What does this PR do?

Adds a second way to wear the background you already have: instead of filling the view, it is cropped into a strip across the top of the board — a cover image, the way one sits above a note — with the cards below it on the theme's own surface.

**Appearance → Background → Background layout** picks between *Full background* (unchanged default) and *Banner*. When it's a banner, three more controls appear: **height** (60–600 px), whether the **lower edge fades** into the page or ends on a line, and whether it **lines up with the content** or runs edge to edge. The same controls live in each board's Background tab, so one dashboard can carry a cover image while the next keeps the vault's wallpaper.

It is deliberately a *layout* on top of the existing background rather than a second background type. Kind, value, opacity and blur all keep their meaning — the live weather sky included — so switching between the two is one dropdown and loses nothing. Switching to banner does lift opacity to 1 and blur to 0, and only from wallpaper-ish values: the same one-time lift the weather sky already does, because a banner *is* the picture rather than a backdrop for something on top of it.

How it's put together:

- `src/background.ts` — `paintBackground` now holds everything about *what* is drawn; `applyBackground` (wallpaper) and the new `renderBanner` differ only in where the layer sits and how big it is.
- `src/view.ts` calls exactly one of the two. The layout setting isn't the only input: mobile-only mode is a centred search field with nothing for a banner to head, so it keeps the wallpaper regardless.
- The strip is a real element in the scroll flow, not a fixed layer, so it scrolls with the content and a fit-to-page board gives the grid the height it leaves. That needed one CSS fix — `.hearth-fit .hearth-inner`'s `height: 100%` would otherwise have overflowed by exactly the banner's height and clipped the bottom row of cards.
- A blurred banner layer is grown past the crop so its soft edges fall outside instead of haloing all four sides.
- Low power mode is untouched: it still replaces the whole backdrop with its flat colour, banner or not.
- Every background saved before this defaults to the full-view wallpaper it was, and the banner fields ride along in settings/layout export and import.

## Related issue

None — opened from a direct request rather than a filed issue.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [x] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

README and CHANGELOG are updated as part of the change; there was no prior issue.

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault

Not vault-tested — no Obsidian in this environment. Instead: `npm test` passes (653 tests, with a new `test/banner.test.ts` covering height clamping, background resolution, per-board override and migration) and `npm run lint` reports 0 errors. The layout itself was rendered in Chromium against the real `styles.css` using Hearth's DOM structure, and the flex geometry measured in both modes — a 220 px content-width banner with the grid taking the remainder, and a full-bleed one at 0,0 across the full pane, cancelling the scroll padding in both normal and compact spacing. Worth a look in a real vault before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbuXYjQcAXvbMbtinqny2g)_