### PR TITLE
fix(cards): hold a live redraw while a field inside the card has focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,16 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   was simply impossible until you zoomed back out. Guides now come from where
   the cards actually are on screen. A dragged card also no longer jolts to a
   different position the instant it starts moving.
+- **Cards wait for you to finish typing before they refresh.** A card that
+  tracks a file redraws when that file changes on disk — but if the thing
+  changing it was you, typing into a field the card itself is showing, the
+  redraw took the field (and your cursor) with it. Plugin-rendered inputs inside
+  an embedded note are the clearest case: every write went back into the note,
+  and a moment later the card reloaded under your hands, so finishing a sentence
+  meant clicking back in over and over. A card now holds a refresh while a field
+  inside it has focus and catches up once you click away — exactly when you want
+  it to. The same wait applies to **Live refresh on vault changes**, which
+  rebuilt the whole board out from under the same field.
 
 ## [2.0.0]
 

--- a/src/cardfocus.ts
+++ b/src/cardfocus.ts
@@ -1,0 +1,101 @@
+import type { Component } from "obsidian";
+
+/**
+ * Keeping an event-driven redraw from destroying the element that holds the
+ * caret (#212).
+ *
+ * A card can render focusable content it doesn't own — anything a plugin puts
+ * inside an embed — and that content is often what writes to the very file the
+ * card watches, so typing into it schedules the redraw that then wipes it. The
+ * card's own focusable pieces were already safe (the editable embed's textarea
+ * skips its sync while focused, the tasks card's inline-add form waits for a
+ * real `focusout`); this generalises that rule to the whole card body, and to
+ * the board-level live refresh one level up.
+ *
+ * The decision is split so it can be unit-tested without a DOM: {@link
+ * createFocusHold} is the pure hold/release state machine, and the predicates
+ * below are the only part that touches elements.
+ */
+
+/** Elements a redraw must not pull out from under the user while they hold
+ * focus: the native text-entry controls plus contenteditable hosts (Obsidian's
+ * own live-preview editors, and whatever a plugin renders into an embed). */
+const TEXT_ENTRY_SELECTOR =
+	"input, textarea, select, [contenteditable]:not([contenteditable='false'])";
+
+/** The focused element in the document `root` actually lives in. Read through
+ * `ownerDocument` rather than the global `document` so a board in a popped-out
+ * window is judged against its own document. */
+function activeIn(root: HTMLElement): Element | null {
+	return root.ownerDocument?.activeElement ?? null;
+}
+
+/** True while a text-entry element inside `root` has focus — the one state in
+ * which redrawing would take the caret with it. */
+export function holdsTextEntryFocus(root: HTMLElement): boolean {
+	const active = activeIn(root);
+	if (!active || active === root || !root.contains(active)) return false;
+	return active.matches(TEXT_ENTRY_SELECTOR);
+}
+
+/** True once focus sits outside `root` entirely. Deliberately stricter than
+ * "no longer typing": a held redraw stays held while focus moves to a button
+ * *inside* the card, because tearing that button out between its `focusout`
+ * and its `click` would swallow the click. */
+export function focusHasLeft(root: HTMLElement): boolean {
+	const active = activeIn(root);
+	return !active || !root.contains(active);
+}
+
+/**
+ * The pure half: a redraw that can be held. `request` runs the redraw unless
+ * the user is typing, in which case it is remembered; `release` runs a
+ * remembered redraw once focus has left. Only ever one catch-up draw, however
+ * many events were held.
+ */
+export function createFocusHold(draw: () => void): {
+	request(typing: boolean): void;
+	release(left: boolean): void;
+} {
+	let pending = false;
+	return {
+		request(typing: boolean): void {
+			if (typing) {
+				pending = true;
+				return;
+			}
+			pending = false;
+			draw();
+		},
+		release(left: boolean): void {
+			if (!pending || !left) return;
+			pending = false;
+			draw();
+		},
+	};
+}
+
+/**
+ * Wrap a redraw so it never fires while a field inside `root` is being typed
+ * into: it is held, and runs once — as a single catch-up — after focus leaves.
+ * Returns the wrapped redraw. `component` scopes the listener to the render
+ * that owns `root`.
+ *
+ * Only for redraws the *vault* asks for. A redraw the user asked for (the
+ * embed's view switcher) must still be immediate, so it keeps calling `draw`.
+ */
+export function deferRedrawWhileTyping(
+	root: HTMLElement,
+	draw: () => void,
+	component: Component,
+): () => void {
+	const hold = createFocusHold(draw);
+	component.registerDomEvent(root, "focusout", () => {
+		// `focusout` fires before the next element takes focus, and moving
+		// between two fields inside the card is not leaving it — so decide on the
+		// next tick, from where focus actually landed. Same shape as the tasks
+		// card's inline-add form.
+		window.setTimeout(() => hold.release(focusHasLeft(root)), 0);
+	});
+	return () => hold.request(holdsTextEntryFocus(root));
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -5,6 +5,7 @@ import {
 	type TAbstractFile,
 } from "obsidian";
 import { emptyState } from "./cardbodies";
+import { deferRedrawWhileTyping } from "./cardfocus";
 import { confirmAction } from "./ui";
 import { t } from "./i18n";
 import type { HomeView } from "./view";
@@ -271,12 +272,25 @@ function mountCardBody(
 		return draw;
 	}
 
+	// Redraws the vault asks for are held while a field inside the card body has
+	// focus, and run once after focus leaves (#212). `editableInPlace` below
+	// covers only the card's *own* textarea; a card also renders focusable
+	// content it doesn't own — anything a plugin puts inside an embed — and that
+	// content is typically what writes the file the card watches, so typing into
+	// it schedules the redraw that destroys it. The returned `draw` stays
+	// un-held: a redraw the user asked for must still be immediate.
+	//
+	// A factory (rather than one shared value) so only the card kinds that
+	// actually redraw from events register the focusout listener — static and
+	// poll cards never call it.
+	const createLiveDraw = () => deferRedrawWhileTyping(body, draw, parent);
+
 	if (live.mode === "watch-file") {
 		// Editable cards sync content edits in their textarea, so don't redraw on
 		// modify (it would drop the cursor) — but still redraw on existence changes.
 		// An embed can switch between a read-only and an editable view, so this is
 		// evaluated per event against whichever view is currently shown.
-		watchCardFile(view, card, events, draw, () => !live.editableInPlace(card), live.watchedPath);
+		watchCardFile(view, card, events, createLiveDraw(), () => !live.editableInPlace(card), live.watchedPath);
 		return draw;
 	}
 
@@ -285,7 +299,10 @@ function mountCardBody(
 	// them — debounced — whenever the vault or its metadata changes.
 	if (live.mode === "vault") {
 		const shouldRedraw = live.shouldRedraw;
-		const redraw = debounce(draw, 400, true);
+		// Held the same way: a dataview/search card can host a plugin's input
+		// just as an embed can. The hold is inside the debounce so it is decided
+		// when the redraw fires, not when it was scheduled.
+		const redraw = debounce(createLiveDraw(), 400, true);
 		events.subscribe((ev) => {
 			// A folder-scoped tasks card reads nothing outside its folders, so
 			// events that provably can't change its content are skipped instead

--- a/src/main.ts
+++ b/src/main.ts
@@ -405,7 +405,10 @@ export default class HearthPlugin extends Plugin {
 		if (lowPowerActive(this.settings)) return;
 		this.app.workspace.getLeavesOfType(VIEW_TYPE_HOME).forEach((leaf) => {
 			const view = leaf.view;
-			if (view instanceof HomeView && !view.arrangeMode) view.render();
+			// liveRender, not render: a rebuild triggered by a vault write must not
+			// destroy a field the user is typing into — including the field whose
+			// own writes triggered it (#212).
+			if (view instanceof HomeView && !view.arrangeMode) view.liveRender();
 		});
 	}
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -5,6 +5,7 @@ import { renderDashboard } from "./dashboard";
 import { renderDashboardSwitcher } from "./dashboards";
 import { renderMobileActionBar } from "./mobileactions";
 import { applyBackground, renderBanner } from "./background";
+import { deferRedrawWhileTyping } from "./cardfocus";
 import {
 	bannerActive,
 	effectiveFitToPage,
@@ -44,6 +45,9 @@ export class HomeView extends ItemView {
 	hideHeaderInArrange = false;
 	/** Per-render child component so embeds/markdown get cleaned up on re-render. */
 	private renderChild: Component | null = null;
+	/** {@link liveRender}'s focus-held re-render, built on first use (the
+	 * listener it registers lives on `contentEl`, which outlives every render). */
+	private heldLiveRender: (() => void) | null = null;
 
 	constructor(leaf: WorkspaceLeaf, plugin: HearthPlugin) {
 		super(leaf);
@@ -124,6 +128,19 @@ export class HomeView extends ItemView {
 			this.removeChild(this.renderChild);
 			this.renderChild = null;
 		}
+	}
+
+	/**
+	 * The vault-driven re-render behind the "Live refresh on vault changes"
+	 * setting. Identical to {@link render}, except that it is held while the user
+	 * is typing into a field on the board and runs once after focus leaves
+	 * (#212) — otherwise the board rebuild takes the focused input with it, one
+	 * level above the same guard on each card's own redraw. Every other caller
+	 * re-renders on something the user just did, so they keep calling `render`.
+	 */
+	liveRender(): void {
+		this.heldLiveRender ??= deferRedrawWhileTyping(this.contentEl, () => this.render(), this);
+		this.heldLiveRender();
 	}
 
 	/** Full rebuild of the view. Cheap enough to call on any settings change. */

--- a/test/cardfocus.test.ts
+++ b/test/cardfocus.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { createFocusHold, focusHasLeft, holdsTextEntryFocus } from "../src/cardfocus";
+
+/**
+ * The focus guard that keeps a vault-driven redraw from destroying the element
+ * holding the caret (#212), tested without a DOM: the predicates run against
+ * minimal element stand-ins, the hold/release machine is pure.
+ */
+
+/** A stand-in for the card body / view container: it owns a document whose
+ * `activeElement` we set per case, and reports containment for the elements
+ * listed as its descendants. */
+function root(active: Element | null, inside: Element[] = []): HTMLElement {
+	const el = {
+		ownerDocument: { activeElement: active },
+		contains: (other: Element | null) => other === el || inside.includes(other as Element),
+	};
+	return el as unknown as HTMLElement;
+}
+
+/** A stand-in for a focused element: only `matches` is ever called on it. */
+function el(selectorsItMatches: string[] = []): Element {
+	return {
+		matches: (sel: string) => selectorsItMatches.some((s) => sel.includes(s)),
+	} as unknown as Element;
+}
+
+const input = () => el(["input"]);
+const textarea = () => el(["textarea"]);
+const editable = () => el(["contenteditable"]);
+const button = () => el([]);
+
+describe("holdsTextEntryFocus", () => {
+	it("holds for a text-entry element inside the card — the reported case", () => {
+		for (const focused of [input(), textarea(), editable()]) {
+			expect(holdsTextEntryFocus(root(focused, [focused]))).toBe(true);
+		}
+	});
+
+	it("does not hold for a focused non-text element inside the card", () => {
+		const focused = button();
+		expect(holdsTextEntryFocus(root(focused, [focused]))).toBe(false);
+	});
+
+	it("does not hold for an input focused somewhere else on the board", () => {
+		expect(holdsTextEntryFocus(root(input(), []))).toBe(false);
+	});
+
+	it("does not hold with nothing focused, or with the card itself focused", () => {
+		expect(holdsTextEntryFocus(root(null))).toBe(false);
+		// A card body that carries focus itself (a tabindex, a scroll container)
+		// is not a field anyone is typing into, however it answers `matches`.
+		const self: Record<string, unknown> = { contains: () => true, matches: () => true };
+		self.ownerDocument = { activeElement: self };
+		expect(holdsTextEntryFocus(self as unknown as HTMLElement)).toBe(false);
+	});
+});
+
+describe("focusHasLeft", () => {
+	it("is true only once focus sits outside the card", () => {
+		const inside = input();
+		expect(focusHasLeft(root(inside, [inside]))).toBe(false);
+		expect(focusHasLeft(root(el(), []))).toBe(true);
+		expect(focusHasLeft(root(null))).toBe(true);
+	});
+
+	it("keeps a held redraw held while focus moves to a button inside the card", () => {
+		// Tearing that button out between its focusout and its click would
+		// swallow the click, so "not typing any more" is not enough to flush.
+		const btn = button();
+		expect(focusHasLeft(root(btn, [btn]))).toBe(false);
+	});
+});
+
+describe("createFocusHold", () => {
+	it("draws immediately when nothing is being typed into", () => {
+		const draw = vi.fn();
+		const hold = createFocusHold(draw);
+		hold.request(false);
+		expect(draw).toHaveBeenCalledTimes(1);
+	});
+
+	it("holds while typing and catches up once — however many events were held", () => {
+		const draw = vi.fn();
+		const hold = createFocusHold(draw);
+		hold.request(true);
+		hold.request(true);
+		hold.request(true);
+		expect(draw).not.toHaveBeenCalled();
+		hold.release(true);
+		expect(draw).toHaveBeenCalledTimes(1);
+	});
+
+	it("stays held while focus has not left, and does not draw twice on a second release", () => {
+		const draw = vi.fn();
+		const hold = createFocusHold(draw);
+		hold.request(true);
+		hold.release(false);
+		expect(draw).not.toHaveBeenCalled();
+		hold.release(true);
+		hold.release(true);
+		expect(draw).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not draw on focusout when nothing was held", () => {
+		const draw = vi.fn();
+		createFocusHold(draw).release(true);
+		expect(draw).not.toHaveBeenCalled();
+	});
+
+	it("clears the held redraw when a live one runs, so leaving does not redraw again", () => {
+		const draw = vi.fn();
+		const hold = createFocusHold(draw);
+		hold.request(true); // typed into, held
+		hold.request(false); // focus moved on, a later event drew live
+		expect(draw).toHaveBeenCalledTimes(1);
+		hold.release(true);
+		expect(draw).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Stops a vault-driven redraw from destroying the element that holds the caret.

A `watch-file` card redraws when its tracked file changes on disk — and the write is often the user's own, typed into focusable content the card renders but does not own (a Meta Bind input inside an embedded note, writing back to that note's frontmatter). Typing scheduled the redraw that then wiped the field, so finishing a sentence meant clicking back in repeatedly.

`liveness.editableInPlace` looks like it covers this but doesn't: it is a *config* predicate, not a focus one, and it only ever described the card's own in-place textarea. A non-editable embed therefore takes the "always redraw on modify" path (`dashboard.ts` `watchCardFile`). One level up, `runLiveRefresh` in `main.ts` had no guard at all and rebuilt the entire board over the same field whenever **Live refresh on vault changes** was on.

**The fix** — a new `src/cardfocus.ts`:

- a redraw is **held** while a text-entry element (`input`, `textarea`, `select`, `contenteditable`) inside the root has focus;
- it runs **once**, as a single catch-up, after focus leaves the root *entirely* — deliberately stricter than "no longer typing", so a button inside the card is never torn out between its `focusout` and its `click`;
- the `focusout` decision is deferred a tick and re-checked from where focus actually landed, the same shape as the tasks card's inline-add form.

Applied to the `watch-file` and `vault` card redraws (a dataview/search card can host a plugin's input just as an embed can) and to a new `HomeView.liveRender()` used by the live-refresh setting. Redraws the *user* asks for stay immediate: the embed's view switcher and every settings change keep calling `render`/`draw` directly. `editableInPlace` is left in place — it is still the right early-out for the card's own textarea, and the new guard subsumes it at runtime.

The hold/release logic is a pure state machine (`createFocusHold`) so it is unit-testable without a DOM, matching how `cardevents.ts` keeps its decisions testable; the two focus predicates are the only part that touches elements. 11 new tests in `test/cardfocus.test.ts`.

Also adds a **Fixed** entry to the unreleased 2.1.0 changelog section.

## Related issue

Closes #212

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (plus `npm run lint` — no new warnings — and `npm test`, 670 passing)
- [x] I've tested this in an actual vault — **not done**: no Obsidian/Meta Bind available in this environment. The pure decision layer is covered by tests, but the DOM wiring (`focusout` on the card body / `contentEl`, and the popped-out-window `ownerDocument` path) wants a manual pass against the issue's `Repro.md` before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVbwcNNxVRsMhGN6iKJaKh)_