### PR TITLE
Add a first-run setup wizard that builds the first dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,44 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
+- **A setup wizard that builds your first dashboard.** A new install no longer
+  lands on a generic starter grid and a wallpaper nobody chose. Hearth asks
+  instead — a title and logo, a card style and a background, what you actually
+  use the vault for, how it should behave on startup — and lays out a board from
+  the answers.
+
+  **It looks before it asks.** Every supported plugin that is installed and
+  enabled in *your* vault is offered on its own step, each with the single
+  concrete thing accepting it will do: TaskNotes and Kanban configure a Tasks
+  card, Dataview and Datacore add a card seeded with an editable query, Git adds
+  a Git card, Omnisearch becomes the search bar's engine, Iconic/Iconize turn on
+  your own file icons, a `.base` in the vault gets embedded, and Daily notes and
+  Bookmarks add the matching cards. Nothing is installed and nothing is changed
+  inside the other plugin.
+
+  **TaskNotes is read properly, not merely noticed.** Its field names are
+  remappable and its statuses are user-defined, so Hearth reads the running
+  plugin's own configuration — the status, due and priority properties, and
+  every status it counts as complete — and copies them across. The step shows
+  you exactly what it found. A vault that renamed `due` to `deadline`, or that
+  treats "cancelled" as finished, gets a Tasks card that is right on its first
+  render instead of one that silently shows nothing.
+
+  **Nothing is written until you say so.** The last step draws the board to
+  scale and lists every card with the answer that put it there. A board too tall
+  to squeeze onto one screen is set to scroll rather than being scaled down to
+  nothing — as an override on that board alone.
+
+  Run it again any time from **Settings → Hearth → About → Build a dashboard**
+  or the **Set up Hearth** command. Run that way it **always adds a new
+  dashboard** and never touches an existing one, so it is safe to press just to
+  see what it would make. Only the first-run prompt offers to replace the
+  untouched starter board.
+
+  Existing vaults are never interrupted: the wizard is offered only to an
+  install with no saved Hearth settings at all, and dismissing it counts as an
+  answer, so it can't nag.
+
 - **A board that wears its background as a banner.** **Appearance → Background →
   Background layout** offers a second way to show the backdrop you already have:
   instead of filling the view, it is cropped into a strip across the top of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   to squeeze onto one screen is set to scroll rather than being scaled down to
   nothing — as an override on that board alone.
 
+  **And it says so on the way out.** The wizard's closing note is that the board
+  it just built is a starting point rather than a preset: enough to show what
+  Hearth can do for you, but only a fraction of what there is. Every card can be
+  moved, resized, retitled, recoloured, reconfigured or thrown out, and there is
+  a great deal more in the settings than the wizard asks about — so go and edit
+  all of it to your liking.
+
   Run it again any time from **Settings → Hearth → About → Build a dashboard**
   or the **Set up Hearth** command. Run that way it **always adds a new
   dashboard** and never touches an existing one, so it is safe to press just to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,12 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   to squeeze onto one screen is set to scroll rather than being scaled down to
   nothing — as an override on that board alone.
 
-  **And it says so on the way out.** The wizard's closing note is that the board
-  it just built is a starting point rather than a preset: enough to show what
-  Hearth can do for you, but only a fraction of what there is. Every card can be
-  moved, resized, retitled, recoloured, reconfigured or thrown out, and there is
-  a great deal more in the settings than the wizard asks about — so go and edit
-  all of it to your liking.
+  **And it says so up front.** The final step *opens* by saying that the board
+  it is about to build is a starting point rather than a preset: enough to show
+  what Hearth can do for you, but only a fraction of what there is. Every card
+  can be moved, resized, retitled, recoloured, reconfigured or thrown out, and
+  there is a great deal more in the settings than the wizard asks about — so go
+  and edit all of it to your liking.
 
   Run it again any time from **Settings → Hearth → About → Build a dashboard**
   or the **Set up Hearth** command. Run that way it **always adds a new

--- a/README.md
+++ b/README.md
@@ -42,6 +42,39 @@ Think of it as a new-tab dashboard, start page and command launcher in one.
 4. Hit **Arrange** (top-right) to add, move, resize and configure cards right
    on the board.
 
+## Setup wizard
+
+On a fresh install Hearth offers to build your first dashboard for you. It asks
+a handful of questions — a title, a look, what you use your vault for — and lays
+out a board from the answers rather than dropping you on a generic starter grid.
+
+It also **looks at what you already have**. Every supported plugin that is
+installed and enabled is offered with the one thing accepting it will do:
+
+| Found | What Hearth does with it |
+| --- | --- |
+| **TaskNotes** | Adds a Tasks card on the TaskNotes source, using TaskNotes' *own* field names and completed statuses |
+| **Kanban** | Adds a Tasks card showing your board as draggable columns |
+| **Dataview** / **Datacore** | Adds a card, seeded with an editable query |
+| **Git** | Adds a Git card with status, commit and sync |
+| **Omnisearch** | Makes it the engine behind Hearth's search bar |
+| **Iconic** / **Iconize** | Shows the file icons you already set |
+| **Bases** | Embeds a base from your vault |
+| **Daily notes** / **Bookmarks** | Adds the matching card |
+
+The TaskNotes case is the one worth calling out: its field names are
+user-remappable and its statuses user-defined, so Hearth reads them from the
+plugin and copies them across. A vault that renamed `due` to `deadline` gets a
+Tasks card that works on its first render.
+
+The last step previews the board — a scale drawing plus a list of every card and
+why it's there — before anything is written. Nothing is applied until you press
+**Build my dashboard**.
+
+You can run it again any time from **Settings → Hearth → About → Build a
+dashboard**, or the **Set up Hearth** command. Run that way it *always* adds a
+new dashboard: every board you already have is left exactly as it is.
+
 ## Search
 
 The search field is keyboard-first, with four transparent modes:

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -21,6 +21,7 @@ export const en = {
 		newDrawing: "Create new Excalidraw drawing",
 		recordVoice: "Start/stop voice recording",
 		openDailyNote: "Open today's daily note",
+		runSetup: "Set up Hearth (first-run wizard)",
 		switchDashboard: (n: number) => `Switch to dashboard ${n}`,
 		nextDashboard: "Next dashboard",
 		previousDashboard: "Previous dashboard",
@@ -95,6 +96,296 @@ export const en = {
 		intro: "Thanks for updating! Here's what's changed since you last checked.",
 		close: "Got it",
 		footer: "Full details live in the plugin's README.",
+	},
+
+	// ---- First-run setup wizard ----------------------------------------
+	setup: {
+		/** Short labels on the progress rail. */
+		stepNames: {
+			welcome: "Welcome",
+			vault: "Your vault",
+			look: "Look",
+			purpose: "What for",
+			integrations: "Integrations",
+			behaviour: "Behaviour",
+			finish: "Finish",
+		},
+		/** The heading at the top of each step. */
+		stepTitles: {
+			welcome: "Welcome to Hearth",
+			vault: "Name your home screen",
+			look: "Pick a look",
+			purpose: "What do you use your vault for?",
+			integrations: "Found in your vault",
+			behaviour: "How Hearth behaves",
+			finish: "Here's your dashboard",
+		},
+		/** The line under each heading. */
+		stepDescs: {
+			welcome: "A few questions, then Hearth builds your first dashboard.",
+			vault: "The title and logo across the top of the board.",
+			look: "You can change any of this later in Settings → Appearance.",
+			purpose: "Pick as many as you like — each one adds cards to your board.",
+			integrations:
+				"Hearth found these already installed. Turn on the ones you'd like it to use.",
+			behaviour: "What happens when Obsidian starts and when you open a note.",
+			finish: "Nothing has been changed yet. Here's what will be built.",
+		},
+		nav: {
+			back: "Back",
+			next: "Next",
+			finish: "Build my dashboard",
+			skip: "Skip setup",
+		},
+		welcome: {
+			lead:
+				"Hearth turns a tab into a home screen for your vault — search, a dashboard " +
+				"of cards, and a launcher. This wizard sets up a board that fits how you " +
+				"actually work, so you're not starting from a blank grid.",
+			bullets: [
+				{
+					icon: "layout-dashboard",
+					title: "A dashboard built for you",
+					desc: "Tell Hearth what you use your vault for and it picks the cards.",
+				},
+				{
+					icon: "plug",
+					title: "Your plugins, already wired up",
+					desc:
+						"Hearth looks for TaskNotes, Dataview, Git and more, and offers to " +
+						"connect them — reading their own settings so cards work right away.",
+				},
+				{
+					icon: "palette",
+					title: "A look you choose",
+					desc: "Background, card style and density, set in one step.",
+				},
+			],
+			detected: (names: string) => `Found in this vault: ${names}.`,
+			detectedNone:
+				"No supported plugins detected yet — that's fine, Hearth works on its own " +
+				"and you can connect them later.",
+		},
+		vault: {
+			title: "Title",
+			titleDesc: "Shown large across the top of the dashboard.",
+			showTitle: "Show the title",
+			showTitleDesc: "Turn off for a board with no heading at all.",
+			logo: "Logo",
+			logoDesc:
+				"An emoji or a couple of characters shown beside the title. Leave empty for " +
+				"the Hearth crystal.",
+			themeColor: "Follow the theme's accent colour",
+			themeColorDesc: "Which parts of the brand mark take your theme's colour.",
+			themeColorOptions: {
+				none: "Neither",
+				icon: "The icon",
+				title: "The title",
+				both: "Both",
+			},
+			showSearch: "Show the search bar",
+			showSearchDesc: "The search and command field under the title.",
+		},
+		look: {
+			surfaceHeading: "Cards",
+			backgroundHeading: "Background",
+			color: "Colour",
+			colorDesc: "The flat colour painted behind the board.",
+			weatherDesc:
+				"A live sky for a place, or one condition pinned and kept. Pick where it " +
+				"comes from below.",
+			layout: "Where the background goes",
+			layoutDesc:
+				"Behind the whole board, or as a banner strip across the top with your " +
+				"cards on the theme's own surface below it.",
+			layoutFull: "Behind everything",
+			layoutBanner: "A banner at the top",
+			compact: "Compact spacing",
+			compactDesc: "Tighten the gaps so more fits on screen.",
+		},
+		surfaces: {
+			glass: {
+				icon: "layers",
+				name: "Frosted",
+				desc: "Translucent cards with a soft blur of the background behind them.",
+			},
+			solid: {
+				icon: "square",
+				name: "Solid",
+				desc: "Opaque panels. Easiest to read over a busy photograph.",
+			},
+			minimal: {
+				icon: "minus",
+				name: "Minimal",
+				desc: "No card surface at all — content floating on the background.",
+			},
+		},
+		backgrounds: {
+			default: {
+				icon: "image",
+				name: "Hearth's wallpaper",
+				desc: "The image that ships with Hearth.",
+			},
+			weather: {
+				icon: "cloud-sun",
+				name: "Live sky",
+				desc: "A sky drawn from the weather where you are — or one you pin.",
+			},
+			color: {
+				icon: "paintbrush",
+				name: "A flat colour",
+				desc: "One colour, no image. The lightest option there is.",
+			},
+			none: {
+				icon: "ban",
+				name: "None",
+				desc: "Your theme's own background, untouched.",
+			},
+		},
+		purposes: {
+			daily: {
+				name: "Daily notes & journaling",
+				desc: "Today's note front and centre, with a calendar to move between days.",
+			},
+			tasks: {
+				name: "Tasks & to-dos",
+				desc: "A task list, read from your checkboxes or from a task plugin.",
+			},
+			planning: {
+				name: "Planning & calendar",
+				desc: "A full month/week/day calendar, including any subscribed feeds.",
+			},
+			browsing: {
+				name: "Finding my notes",
+				desc: "What you touched recently, plus a shelf of favourites.",
+			},
+			capture: {
+				name: "Quick capture & launching",
+				desc: "Tiles for the notes and commands you reach for constantly.",
+			},
+			insights: {
+				name: "Vault statistics",
+				desc: "How big the vault is and how active you've been.",
+			},
+			reading: {
+				name: "Reading & feeds",
+				desc: "An RSS card for the sites you follow.",
+			},
+			ambience: {
+				name: "A bit of life",
+				desc: "Weather, and a small pet that lives on your board.",
+			},
+		},
+		purpose: {
+			count: (n: number) =>
+				n === 1 ? "That's 1 card so far." : `That's ${n} cards so far.`,
+		},
+		integrations: {
+			lead:
+				"Each one Hearth turns on here is configured for you — nothing is installed " +
+				"or changed in the other plugin.",
+			recommended: "Recommended",
+			effects: {
+				tasknotes:
+					"Add a Tasks card reading your TaskNotes tasks, using the field names and " +
+					"completed statuses TaskNotes is set to.",
+				kanban: "Add a Tasks card showing your Kanban board as columns you can drag between.",
+				dataview: "Add a Dataview card, seeded with a query you can edit.",
+				datacore: "Add a Datacore card ready for a query.",
+				git: "Add a Git card showing your repository's status, with commit and sync buttons.",
+				omnisearch: "Use Omnisearch as the engine behind Hearth's search bar.",
+				fileIcons: "Show the per-file icons you've already set, instead of Hearth's file-type icons.",
+				bases: "Add a card embedding a base from your vault.",
+				dailyNotes: "Add a card showing today's daily note, editable in place.",
+				bookmarks: "Add a card listing your bookmarks.",
+			},
+			taskNotesTitle: "Read from your TaskNotes settings",
+			taskNotesStatus: "Status field",
+			taskNotesDue: "Due field",
+			taskNotesPriority: "Priority field",
+			taskNotesDone: "Counts as done",
+			taskNotesDoneNone: "none defined — Hearth will use \"done\"",
+		},
+		behaviour: {
+			openOnStartup: "Open Hearth when Obsidian starts",
+			openOnStartupDesc: "Your dashboard is the first thing you see.",
+			replaceNewTabs: "Use Hearth for new empty tabs",
+			replaceNewTabsDesc: "A new tab opens on the dashboard instead of the empty state.",
+			focusSearch: "Focus the search field on open",
+			focusSearchDesc: "Start typing the moment a Hearth tab opens. Desktop only.",
+			openIn: "Open notes in",
+			openInDesc: "Where a note goes when you open one from the dashboard.",
+		},
+		finish: {
+			empty:
+				"No cards were selected. You can still finish — the board will be empty and " +
+				"you can add cards from the dashboard's Arrange button.",
+			target: "Where this board goes",
+			targetDesc:
+				"Replace the dashboard you're on, or add this as a new one you can switch to.",
+			targetReplace: "Replace my current dashboard",
+			targetNew: "Add it as a new dashboard",
+			targetForcedNew:
+				"This will be added as a new dashboard. Every board you already have is " +
+				"left exactly as it is — nothing is replaced or removed.",
+			name: "Dashboard name",
+			nameDesc: "Shown in the dashboard switcher.",
+			/** Seed for the new dashboard's name; numbered if already taken. */
+			defaultName: "Home",
+			reassurance:
+				"Every card can be moved, resized, reconfigured or removed afterwards — and " +
+				"you can run this wizard again any time from Settings → About.",
+		},
+		plan: {
+			/** Fallback names for planned cards that carry no title of their own. */
+			names: {
+				clock: "Clock & greeting",
+				daily: "Today's note",
+				tasks: "Tasks",
+				schedule: "Calendar",
+				calendar: "Mini calendar",
+				recent: "Recent files",
+				favorites: "Favorites",
+				bookmarks: "Bookmarks",
+				links: "Links",
+				commands: "Commands",
+				stats: "Vault statistics",
+				heatmap: "Activity",
+				rss: "Reading",
+				weather: "Weather",
+				pet: "Pet",
+				dataview: "Dataview",
+				datacore: "Datacore",
+				git: "Git",
+				base: "Base",
+			},
+			/** Why each card is on the board, shown beside it in the review list. */
+			reasons: {
+				always: "Every Hearth board starts with one",
+				daily: "Daily notes & journaling",
+				dailyNotes: "Daily notes is enabled",
+				tasks: "Tasks & to-dos",
+				tasknotes: "Set up for TaskNotes",
+				kanban: "Reading your Kanban board",
+				planning: "Planning & calendar",
+				browsing: "Finding my notes",
+				bookmarks: "Bookmarks is enabled",
+				capture: "Quick capture & launching",
+				insights: "Vault statistics",
+				reading: "Reading & feeds",
+				ambience: "A bit of life",
+				dataview: "Dataview is installed",
+				datacore: "Datacore is installed",
+				git: "Git is installed",
+				bases: "A base was found in your vault",
+			},
+		},
+		notice: {
+			done: (n: number) =>
+				n === 1
+					? "Hearth: your dashboard is ready — 1 card added."
+					: `Hearth: your dashboard is ready — ${n} cards added.`,
+		},
 	},
 
 	// ---- File pickers --------------------------------------------------
@@ -323,6 +614,16 @@ export const en = {
 		about: {
 			heading: "About Hearth",
 			headingDesc: "Project links, support and version.",
+			setup: "Set up Hearth",
+			setupDesc:
+				"Answer a few questions about how you work and what's installed, and Hearth " +
+				"builds a dashboard to match. It's added as a new board — nothing you " +
+				"already have is changed.",
+			setupAgain: "Build a dashboard",
+			setupAgainDesc:
+				"Run the setup wizard again to generate another dashboard. It's always " +
+				"added as a new board, so your existing dashboards are never touched.",
+			setupButton: "Start setup",
 			whatsNew: "What's new",
 			whatsNewDesc: "Read the release notes for this and every past version.",
 			whatsNewButton: "View changelog",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -332,18 +332,18 @@ export const en = {
 			nameDesc: "Shown in the dashboard switcher.",
 			/** Seed for the new dashboard's name; numbered if already taken. */
 			defaultName: "Home",
-			outroTitle: "A starting point, not a preset",
-			outroLead:
+			calloutTitle: "A starting point, not a preset",
+			calloutLead:
 				"This board should be a solid start — enough to show you what Hearth can " +
 				"do for you.",
-			outroCustomize:
+			calloutBody:
 				"But Hearth is built above all to be heavily customizable, and this wizard " +
 				"only touches a fraction of it. Every card can be moved, resized, retitled, " +
 				"recoloured, reconfigured or thrown out, boards can be added and switched " +
 				"between, and there is a great deal more in the settings than was asked " +
 				"about here. Dig around in there and edit everything to your liking — that " +
 				"is what Hearth is for.",
-			outroHint:
+			calloutHint:
 				"Arrange (top-right of the board) edits the cards; Settings → Hearth has the " +
 				"rest. You can run this wizard again any time from Settings → About.",
 		},

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -332,9 +332,20 @@ export const en = {
 			nameDesc: "Shown in the dashboard switcher.",
 			/** Seed for the new dashboard's name; numbered if already taken. */
 			defaultName: "Home",
-			reassurance:
-				"Every card can be moved, resized, reconfigured or removed afterwards — and " +
-				"you can run this wizard again any time from Settings → About.",
+			outroTitle: "A starting point, not a preset",
+			outroLead:
+				"This board should be a solid start — enough to show you what Hearth can " +
+				"do for you.",
+			outroCustomize:
+				"But Hearth is built above all to be heavily customizable, and this wizard " +
+				"only touches a fraction of it. Every card can be moved, resized, retitled, " +
+				"recoloured, reconfigured or thrown out, boards can be added and switched " +
+				"between, and there is a great deal more in the settings than was asked " +
+				"about here. Dig around in there and edit everything to your liking — that " +
+				"is what Hearth is for.",
+			outroHint:
+				"Arrange (top-right of the board) edits the cards; Settings → Hearth has the " +
+				"rest. You can run this wizard again any time from Settings → About.",
 		},
 		plan: {
 			/** Fallback names for planned cards that carry no title of their own. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { openFile } from "./opener";
 import { EXCALIDRAW_PLUGIN_ID } from "./filetypes";
 import { setLanguage, t } from "./i18n";
 import { maybeShowWhatsNew } from "./whatsnew";
+import { maybeRunSetup, openSetupWizard } from "./onboarding";
 import { clearContentSearchCache } from "./query";
 
 /** Core "Audio recorder" plugin id, used by the "Record voice" mobile action. */
@@ -107,6 +108,15 @@ export default class HearthPlugin extends Plugin {
 			callback: () => this.openDailyNote(),
 		});
 
+		// Like the settings button, and for the same reason: run on demand the
+		// wizard builds an *additional* dashboard and never overwrites one. Only
+		// the first-run prompt may offer to replace the starter board.
+		this.addCommand({
+			id: "run-setup",
+			name: t().commands.runSetup,
+			callback: () => openSetupWizard(this, { forceNewDashboard: true }),
+		});
+
 		this.registerDashboardCommands();
 
 		this.addSettingTab(new HomeSettingTab(this.app, this));
@@ -144,7 +154,10 @@ export default class HearthPlugin extends Plugin {
 			if (this.settings.openOnStartup) void this.activateView();
 			// Pop the release-notes dialog after an update (but not on a fresh
 			// install). Runs once layout is ready so it doesn't fight startup.
-			void maybeShowWhatsNew(this);
+			// The setup wizard is the fresh install's counterpart and is offered
+			// after it, so the two can never stack: on a first run the changelog
+			// is silently seeded and only the wizard appears.
+			void maybeShowWhatsNew(this).then(() => maybeRunSetup(this));
 		});
 	}
 

--- a/src/onboarding/detect.ts
+++ b/src/onboarding/detect.ts
@@ -1,0 +1,282 @@
+/**
+ * What the setup wizard can find in a vault before it asks a single question.
+ *
+ * The wizard's promise is that it does the looking: rather than presenting a
+ * list of everything Hearth *could* talk to (that is the Integrations
+ * catalogue's job — see `src/integrations.ts`), it reports only what is
+ * actually installed and enabled *here*, and offers to wire each one up.
+ *
+ * Everything in this module is either a plain probe of the running app or a
+ * pure function of what a probe returned, so the interesting part — reading
+ * TaskNotes' own configuration well enough that a Tasks card works on the
+ * first render — is unit-testable without an Obsidian instance.
+ */
+import type { App, TFile } from "obsidian";
+import { DATACORE_PLUGIN_ID } from "../datacore";
+import { DATAVIEW_PLUGIN_ID } from "../dataview";
+import { ICONIC_PLUGIN_ID, ICONIZE_PLUGIN_ID } from "../fileicons";
+import { GIT_PLUGIN_ID } from "../git";
+import { OMNISEARCH_PLUGIN_ID } from "../omnisearch";
+import { TASKNOTES_PLUGIN_ID, readTaskNotesSetup, type TaskNotesSetup } from "../tasknotes";
+
+/** Community plugin id for the Kanban plugin, whose boards the Tasks card can
+ * read as a task source. Declared here rather than in `cards/tasks.ts` because
+ * that module identifies a board by its frontmatter key, not by the plugin. */
+export const KANBAN_PLUGIN_ID = "obsidian-kanban";
+
+/**
+ * The integrations the wizard offers to set up.
+ *
+ * Deliberately a *subset* of `INTEGRATIONS`: an entry earns a place here only
+ * when accepting it has a concrete, automatic effect — a card added and
+ * configured, or a setting flipped. Anything Hearth merely tolerates (Canvas,
+ * Excalidraw, the file explorer) has nothing for the wizard to do and would
+ * only be a question with no answer worth giving.
+ */
+export type SetupIntegrationId =
+	| "tasknotes"
+	| "kanban"
+	| "dataview"
+	| "datacore"
+	| "git"
+	| "omnisearch"
+	| "fileIcons"
+	| "bases"
+	| "dailyNotes"
+	| "bookmarks";
+
+/** One integration found in this vault, ready to be offered. */
+export interface DetectedIntegration {
+	id: SetupIntegrationId;
+	/** The name to show — the installed plugin's own display name where one is
+	 * available, so a renamed or forked build still reads correctly. */
+	name: string;
+	/** Whether accepting it is on by default. Set for the ones whose effect is
+	 * unambiguous (a field mapping, a search engine); left off for the ones that
+	 * add a card the user may not want. */
+	recommended: boolean;
+}
+
+/** Everything the wizard learned about the vault in one pass. */
+export interface SetupDetection {
+	/** The vault's name, used to seed the dashboard title. */
+	vaultName: string;
+	/** Integrations found, in offer order. */
+	integrations: DetectedIntegration[];
+	/** TaskNotes' own configuration, read from the running plugin. Null when
+	 * TaskNotes isn't enabled. */
+	taskNotes: TaskNotesSetup | null;
+	/** Path of a `.base` file to embed, when Bases is available and the vault
+	 * has one. */
+	basePath: string | null;
+	/** Path of a Kanban board note, when one exists. */
+	kanbanPath: string | null;
+}
+
+/** Whether a community plugin is installed *and* on. */
+function pluginEnabled(app: App, id: string): boolean {
+	try {
+		return app.plugins?.enabledPlugins?.has(id) === true;
+	} catch {
+		return false;
+	}
+}
+
+/** Whether a core (internal) plugin is on. Returns false for an id this
+ * Obsidian version doesn't know — Bases only exists in 1.9+. */
+function corePluginEnabled(app: App, id: string): boolean {
+	try {
+		return app.internalPlugins?.getPluginById(id)?.enabled === true;
+	} catch {
+		return false;
+	}
+}
+
+/** An installed plugin's own display name, falling back to `fallback` when the
+ * manifest can't be read. */
+function pluginName(app: App, id: string, fallback: string): string {
+	try {
+		// `manifests` is an Obsidian internal typed only as far as "some object
+		// per id", so the display name is read defensively rather than assumed.
+		const manifest = app.plugins?.manifests?.[id] as { name?: unknown } | undefined;
+		const name = manifest?.name;
+		return typeof name === "string" && name.trim() ? name : fallback;
+	} catch {
+		return fallback;
+	}
+}
+
+/** The first file in the vault matching `test`, or null. Never throws: this
+ * runs while the wizard is being built. */
+function findFile(app: App, test: (file: TFile) => boolean): TFile | null {
+	try {
+		return app.vault.getFiles().find(test) ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** The frontmatter key the Kanban plugin writes into a board note. */
+const KANBAN_FRONTMATTER_KEY = "kanban-plugin";
+
+/** A Kanban board note in the vault, or null. Looks at frontmatter rather than
+ * the plugin, because a board is readable whether or not Kanban is enabled —
+ * which is exactly why Hearth can read one at all. */
+function findKanbanBoard(app: App): string | null {
+	const file = findFile(app, (f) => {
+		if (f.extension !== "md") return false;
+		const fm = app.metadataCache.getFileCache(f)?.frontmatter;
+		return !!fm && KANBAN_FRONTMATTER_KEY in fm;
+	});
+	return file?.path ?? null;
+}
+
+/**
+ * Look through the vault once and report everything the wizard can offer.
+ *
+ * Every probe is guarded: several read Obsidian internals (`plugins.manifests`,
+ * `internalPlugins`) that a given version may not expose, and a throw here
+ * would take down the wizard before it ever drew a step.
+ */
+export function detectSetup(app: App): SetupDetection {
+	const integrations: DetectedIntegration[] = [];
+
+	const taskNotesOn = pluginEnabled(app, TASKNOTES_PLUGIN_ID);
+	if (taskNotesOn) {
+		integrations.push({
+			id: "tasknotes",
+			name: pluginName(app, TASKNOTES_PLUGIN_ID, "TaskNotes"),
+			recommended: true,
+		});
+	}
+
+	const kanbanPath = findKanbanBoard(app);
+	// Offered on the strength of a board existing, not of the plugin being on:
+	// Hearth parses the note itself. But never alongside TaskNotes — one Tasks
+	// card has one source, and TaskNotes is the richer of the two.
+	if (kanbanPath && !taskNotesOn) {
+		integrations.push({
+			id: "kanban",
+			name: pluginName(app, KANBAN_PLUGIN_ID, "Kanban"),
+			recommended: false,
+		});
+	}
+
+	if (pluginEnabled(app, DATAVIEW_PLUGIN_ID)) {
+		integrations.push({
+			id: "dataview",
+			name: pluginName(app, DATAVIEW_PLUGIN_ID, "Dataview"),
+			recommended: false,
+		});
+	}
+
+	if (pluginEnabled(app, DATACORE_PLUGIN_ID)) {
+		integrations.push({
+			id: "datacore",
+			name: pluginName(app, DATACORE_PLUGIN_ID, "Datacore"),
+			recommended: false,
+		});
+	}
+
+	if (pluginEnabled(app, GIT_PLUGIN_ID)) {
+		integrations.push({
+			id: "git",
+			name: pluginName(app, GIT_PLUGIN_ID, "Git"),
+			recommended: false,
+		});
+	}
+
+	if (pluginEnabled(app, OMNISEARCH_PLUGIN_ID)) {
+		integrations.push({
+			id: "omnisearch",
+			name: pluginName(app, OMNISEARCH_PLUGIN_ID, "Omnisearch"),
+			recommended: true,
+		});
+	}
+
+	// Iconic and Iconize are interchangeable as far as Hearth is concerned —
+	// both feed the one "use the icons you already set" switch — so they are
+	// offered as a single row named after whichever is actually installed.
+	const iconic = pluginEnabled(app, ICONIC_PLUGIN_ID);
+	const iconize = pluginEnabled(app, ICONIZE_PLUGIN_ID);
+	if (iconic || iconize) {
+		integrations.push({
+			id: "fileIcons",
+			name: iconic
+				? pluginName(app, ICONIC_PLUGIN_ID, "Iconic")
+				: pluginName(app, ICONIZE_PLUGIN_ID, "Iconize"),
+			recommended: true,
+		});
+	}
+
+	const basePath = corePluginEnabled(app, "bases")
+		? (findFile(app, (f) => f.extension === "base")?.path ?? null)
+		: null;
+	if (basePath) {
+		integrations.push({ id: "bases", name: "Bases", recommended: false });
+	}
+
+	if (corePluginEnabled(app, "daily-notes")) {
+		integrations.push({ id: "dailyNotes", name: "Daily notes", recommended: true });
+	}
+
+	if (corePluginEnabled(app, "bookmarks")) {
+		integrations.push({ id: "bookmarks", name: "Bookmarks", recommended: false });
+	}
+
+	return {
+		vaultName: safeVaultName(app),
+		integrations,
+		taskNotes: taskNotesOn ? readTaskNotesSetup(app) : null,
+		basePath,
+		kanbanPath,
+	};
+}
+
+/** The vault's name, or "" when it can't be read. */
+function safeVaultName(app: App): string {
+	try {
+		return app.vault.getName() || "";
+	} catch {
+		return "";
+	}
+}
+
+/**
+ * The slice of TaskNotes' configuration Hearth needs to mirror, reduced to the
+ * four settings a Tasks card reads.
+ *
+ * This is the whole point of detecting TaskNotes rather than merely noticing
+ * it: its field names are user-remappable and its statuses are user-defined,
+ * so a Tasks card switched to the TaskNotes source without this shows nothing
+ * at all in a vault that renamed `due` to `deadline`. Copying the mapping
+ * across at setup time means the card works on its first render.
+ */
+export interface TaskNotesImport {
+	statusField: string;
+	dueField: string;
+	priorityField: string;
+	/** The single status written when a task is completed. */
+	doneValue: string;
+	/** Every status TaskNotes counts as complete, so a card treats "cancelled"
+	 * as finished too rather than showing it as outstanding forever. */
+	doneStatuses: string[];
+}
+
+/**
+ * Reduce a parsed TaskNotes configuration to the mapping Hearth stores.
+ *
+ * Pure, and total: a vault whose TaskNotes defines no completed status at all
+ * still yields a usable `doneValue` (its documented default, "done"), because
+ * a Tasks card with an empty done-value can never mark anything complete.
+ */
+export function taskNotesImport(setup: TaskNotesSetup): TaskNotesImport {
+	const doneStatuses = setup.statuses.filter((s) => s.isCompleted).map((s) => s.value);
+	return {
+		statusField: setup.fields.status,
+		dueField: setup.fields.due,
+		priorityField: setup.fields.priority,
+		doneValue: doneStatuses[0] ?? "done",
+		doneStatuses,
+	};
+}

--- a/src/onboarding/index.ts
+++ b/src/onboarding/index.ts
@@ -1,0 +1,44 @@
+/**
+ * First-run setup: the wizard that builds a new user's first dashboard.
+ *
+ * Three modules, split by what they need:
+ *
+ *  - `detect.ts` — what this vault already has (plugins, a TaskNotes
+ *    configuration, a Kanban board, a base). Probes the app; the interesting
+ *    reductions are pure.
+ *  - `plan.ts` — what the answers mean: which cards, configured how, laid out
+ *    where, and which settings change. Entirely pure, and tested.
+ *  - `wizard.ts` — the asking. Obsidian UI only.
+ *
+ * Import from here rather than reaching into the modules directly.
+ */
+export { detectSetup, taskNotesImport } from "./detect";
+export type {
+	DetectedIntegration,
+	SetupDetection,
+	SetupIntegrationId,
+	TaskNotesImport,
+} from "./detect";
+export {
+	applySetup,
+	boardRows,
+	defaultAnswers,
+	isUntouchedStarterBoard,
+	planCards,
+	PURPOSE_ICONS,
+	SETUP_BACKGROUNDS,
+	SETUP_PURPOSES,
+	SETUP_SURFACES,
+	SURFACE_PRESETS,
+} from "./plan";
+export type {
+	PlannedCard,
+	SetupAnswers,
+	SetupBackground,
+	SetupOutcome,
+	SetupPurpose,
+	SetupSurface,
+	SetupTarget,
+} from "./plan";
+export { maybeRunSetup, openSetupWizard, SetupWizardModal } from "./wizard";
+export type { SetupWizardOptions } from "./wizard";

--- a/src/onboarding/plan.ts
+++ b/src/onboarding/plan.ts
@@ -1,0 +1,706 @@
+/**
+ * Turning the wizard's answers into a dashboard.
+ *
+ * Everything here is pure: answers plus a detection snapshot go in, a board and
+ * a settings patch come out. The wizard (`wizard.ts`) only collects the answers
+ * and draws the result — none of the decisions below depend on Obsidian, so all
+ * of them are unit-testable, which matters because this is the one code path a
+ * new user's very first impression of Hearth is built by.
+ *
+ * The two halves are deliberately separate:
+ *
+ *  - {@link planCards} decides *what board to build* — which cards, configured
+ *    how, laid out where.
+ *  - {@link applySetup} decides *what to change in settings* — the look, the
+ *    behaviour, the integration wiring — and installs the board.
+ *
+ * so the review step can show the first without committing the second.
+ */
+import { ensureLayout } from "../grid";
+import {
+	type BackgroundLayout,
+	type DashboardCard,
+	type Dashboard,
+	type HomeSettings,
+	type OpenIn,
+	newDashboardId,
+} from "../types";
+import type { SetupDetection, SetupIntegrationId } from "./detect";
+import { taskNotesImport } from "./detect";
+
+/**
+ * What a user says they want Hearth *for*.
+ *
+ * The wizard asks this instead of asking which cards to add, because a new user
+ * has no idea what a "heatmap card" is and every idea of whether they journal.
+ * Each purpose maps to a small, opinionated group of cards below.
+ */
+export type SetupPurpose =
+	| "daily"
+	| "tasks"
+	| "planning"
+	| "browsing"
+	| "capture"
+	| "insights"
+	| "reading"
+	| "ambience";
+
+/** Every purpose, in the order the wizard lists them. */
+export const SETUP_PURPOSES: readonly SetupPurpose[] = [
+	"daily",
+	"tasks",
+	"planning",
+	"browsing",
+	"capture",
+	"insights",
+	"reading",
+	"ambience",
+];
+
+/** The Lucide icon shown on each purpose tile. */
+export const PURPOSE_ICONS: Record<SetupPurpose, string> = {
+	daily: "sun",
+	tasks: "list-todo",
+	planning: "calendar-range",
+	browsing: "compass",
+	capture: "zap",
+	insights: "bar-chart-3",
+	reading: "rss",
+	ambience: "sparkles",
+};
+
+/** How much chrome the cards wear. Three named looks rather than four sliders:
+ * the sliders all still exist in settings, this just picks a coherent set. */
+export type SetupSurface = "glass" | "solid" | "minimal";
+
+/** Every surface, in the order the wizard lists them. */
+export const SETUP_SURFACES: readonly SetupSurface[] = ["glass", "solid", "minimal"];
+
+/** The card-surface settings each named look resolves to. */
+export const SURFACE_PRESETS: Record<
+	SetupSurface,
+	Pick<HomeSettings, "cardOpacity" | "cardBlur" | "cardRadius" | "cardBorderWidth">
+> = {
+	// Hearth's signature: translucent cards over the wallpaper, frosted.
+	glass: { cardOpacity: 0.5, cardBlur: 7, cardRadius: 14, cardBorderWidth: 1 },
+	// Opaque panels. Reads best against a busy photograph, and costs no blur.
+	solid: { cardOpacity: 1, cardBlur: 0, cardRadius: 12, cardBorderWidth: 1 },
+	// No card surface at all: content floating straight on the background.
+	minimal: { cardOpacity: 0, cardBlur: 0, cardRadius: 8, cardBorderWidth: 0 },
+};
+
+/** What the wizard offers as a backdrop. A vault image and a custom URL are
+ * deliberately absent — both need a path the wizard can't guess, and both are
+ * one dropdown away in settings afterwards. */
+export type SetupBackground = "default" | "weather" | "color" | "none";
+
+/** Every background choice, in wizard order. */
+export const SETUP_BACKGROUNDS: readonly SetupBackground[] = [
+	"default",
+	"weather",
+	"color",
+	"none",
+];
+
+/**
+ * The backdrop's opacity and blur per choice.
+ *
+ * Not one set of numbers for all of them: a photograph needs to be pushed well
+ * back to keep text legible, while a flat colour is *already* legible and
+ * fading it only makes it muddy.
+ */
+const BACKGROUND_TUNING: Record<SetupBackground, { opacity: number; blur: number }> = {
+	default: { opacity: 0.35, blur: 2 },
+	weather: { opacity: 0.6, blur: 0 },
+	color: { opacity: 1, blur: 0 },
+	none: { opacity: 0.35, blur: 2 },
+};
+
+/** Where the built board goes. */
+export type SetupTarget = "replace" | "new";
+
+/** Everything the wizard collects, in one object. Seeded by
+ * {@link defaultAnswers} and mutated in place as the user moves through the
+ * steps, so going back never loses an answer. */
+export interface SetupAnswers {
+	// ---- Step: your vault ----
+	title: string;
+	showTitle: boolean;
+	logo: string;
+	themeColorTarget: HomeSettings["themeColorTarget"];
+
+	// ---- Step: the look ----
+	surface: SetupSurface;
+	compact: boolean;
+	background: SetupBackground;
+	/** CSS colour used when `background` is "color". */
+	backgroundColor: string;
+	/** Packed sky value used when `background` is "weather" (see sky.ts). Empty
+	 * until a place or a fixed condition is picked. */
+	skyValue: string;
+	backgroundLayout: BackgroundLayout;
+
+	// ---- Step: what for ----
+	purposes: SetupPurpose[];
+
+	// ---- Step: integrations ----
+	integrations: SetupIntegrationId[];
+
+	// ---- Step: behaviour ----
+	openOnStartup: boolean;
+	replaceNewTabs: boolean;
+	focusSearchOnOpen: boolean;
+	showSearch: boolean;
+	openIn: OpenIn;
+
+	// ---- Step: finish ----
+	target: SetupTarget;
+	dashboardName: string;
+}
+
+/**
+ * The answers a vault starts the wizard with.
+ *
+ * Every default is either Hearth's own default or something the detection pass
+ * discovered, so a user who clicks straight through to the end still gets a
+ * sensible, working board rather than an empty one.
+ */
+export function defaultAnswers(
+	settings: HomeSettings,
+	detection: SetupDetection,
+): SetupAnswers {
+	const has = (id: SetupIntegrationId): boolean =>
+		detection.integrations.some((i) => i.id === id);
+
+	const purposes: SetupPurpose[] = ["daily", "browsing"];
+	// Someone who already runs a task plugin is telling us what they use their
+	// vault for more clearly than any question could.
+	if (has("tasknotes") || has("kanban")) purposes.push("tasks");
+
+	return {
+		title: detection.vaultName || settings.title,
+		showTitle: true,
+		logo: "",
+		themeColorTarget: "none",
+
+		surface: "glass",
+		compact: false,
+		background: "default",
+		backgroundColor: "#1e1b2e",
+		skyValue: "",
+		backgroundLayout: "full",
+
+		purposes,
+
+		integrations: detection.integrations.filter((i) => i.recommended).map((i) => i.id),
+
+		openOnStartup: true,
+		replaceNewTabs: true,
+		focusSearchOnOpen: false,
+		showSearch: true,
+		openIn: "tab",
+
+		target: "replace",
+		dashboardName: "Home",
+	};
+}
+
+/** Whether an integration was accepted. */
+function accepted(answers: SetupAnswers, id: SetupIntegrationId): boolean {
+	return answers.integrations.includes(id);
+}
+
+/** Whether a purpose was chosen. */
+function wants(answers: SetupAnswers, purpose: SetupPurpose): boolean {
+	return answers.purposes.includes(purpose);
+}
+
+/**
+ * One card the plan may include: what it is, how big it starts, and why.
+ *
+ * `reason` is not decoration — the review step lists it, so the board arrives
+ * explained rather than merely arrived. It names the answer that put the card
+ * there, keyed into the locale table.
+ */
+export interface PlannedCard {
+	/** Stable blueprint id, unique within a plan. Used to dedupe and to key the
+	 * review list; not the card's own id. */
+	id: string;
+	/** Locale key under `setup.plan.reasons` explaining why it's here. */
+	reason: string;
+	/** The card itself, id assigned and position packed. */
+	card: DashboardCard;
+}
+
+/** A planned card before it has an id or a packed position. */
+type CardDraft = Omit<DashboardCard, "id">;
+
+/** The default grid width a plan lays out against — Hearth's own default, so a
+ * board built here lines up with one built by hand. */
+const PLAN_COLUMNS = 12;
+
+/**
+ * Decide which cards the board gets, configured and laid out.
+ *
+ * Order matters twice over: it is the order the review step lists them in, and
+ * — because the packer is a left-to-right shelf fill — it is what puts the
+ * clock across the top and the big working cards on the second row.
+ *
+ * `newId` is injectable so tests get stable ids; it defaults to the same
+ * scheme the card picker uses.
+ */
+export function planCards(
+	answers: SetupAnswers,
+	detection: SetupDetection,
+	newId: (index: number) => string = defaultCardId,
+): PlannedCard[] {
+	const drafts: { id: string; reason: string; card: CardDraft }[] = [];
+	const add = (id: string, reason: string, card: CardDraft): void => {
+		if (drafts.some((p) => p.id === id)) return;
+		drafts.push({ id, reason, card });
+	};
+
+	// The clock spans the top on every board the wizard builds. It is the one
+	// card that is unambiguously good on a home screen regardless of what the
+	// vault is for, and a full-width strip is what makes the board read as a
+	// home screen rather than a grid of widgets.
+	add("clock", "always", { kind: "clock", title: "", x: -1, y: -1, w: 12, h: 2 });
+
+	if (wants(answers, "daily") || accepted(answers, "dailyNotes")) {
+		add("daily", wants(answers, "daily") ? "daily" : "dailyNotes", {
+			kind: "daily",
+			title: "Today",
+			x: -1,
+			y: -1,
+			w: 6,
+			h: 5,
+		});
+	}
+
+	if (wants(answers, "tasks") || accepted(answers, "tasknotes") || accepted(answers, "kanban")) {
+		add("tasks", taskReason(answers), {
+			kind: "tasks",
+			title: "Tasks",
+			x: -1,
+			y: -1,
+			w: 6,
+			h: 5,
+			tasks: planTasksConfig(answers, detection),
+		});
+	}
+
+	if (wants(answers, "planning")) {
+		add("schedule", "planning", {
+			kind: "schedule",
+			title: "Calendar",
+			x: -1,
+			y: -1,
+			w: 8,
+			h: 6,
+			schedule: accepted(answers, "tasknotes")
+				? { taskNotes: { enabled: true } }
+				: {},
+		});
+	} else if (wants(answers, "daily")) {
+		// No full calendar, but a board with a daily note on it still wants a
+		// month at a glance to move between days.
+		add("calendar", "daily", {
+			kind: "calendar",
+			title: "Calendar",
+			x: -1,
+			y: -1,
+			w: 4,
+			h: 4,
+		});
+	}
+
+	if (wants(answers, "browsing")) {
+		add("recent", "browsing", {
+			kind: "recent",
+			title: "Recent",
+			count: 8,
+			x: -1,
+			y: -1,
+			w: 4,
+			h: 4,
+		});
+		add("favorites", "browsing", {
+			kind: "favorites",
+			title: "Favorites",
+			x: -1,
+			y: -1,
+			w: 4,
+			h: 3,
+		});
+	}
+
+	if (accepted(answers, "bookmarks")) {
+		add("bookmarks", "bookmarks", {
+			kind: "bookmarks",
+			title: "Bookmarks",
+			x: -1,
+			y: -1,
+			w: 4,
+			h: 3,
+		});
+	}
+
+	if (wants(answers, "capture")) {
+		add("links", "capture", { kind: "links", title: "Links", links: [], x: -1, y: -1, w: 6, h: 2 });
+		add("commands", "capture", {
+			kind: "commands",
+			title: "Commands",
+			commands: [],
+			x: -1,
+			y: -1,
+			w: 6,
+			h: 2,
+		});
+	}
+
+	if (wants(answers, "insights")) {
+		add("stats", "insights", { kind: "stats", title: "Vault", x: -1, y: -1, w: 4, h: 2 });
+		add("heatmap", "insights", {
+			kind: "heatmap",
+			title: "Activity",
+			heatmap: {},
+			x: -1,
+			y: -1,
+			w: 8,
+			h: 3,
+		});
+	}
+
+	if (wants(answers, "reading")) {
+		add("rss", "reading", {
+			kind: "rss",
+			title: "Reading",
+			rss: { sources: [] },
+			x: -1,
+			y: -1,
+			w: 4,
+			h: 5,
+		});
+	}
+
+	if (wants(answers, "ambience")) {
+		add("weather", "ambience", {
+			kind: "weather",
+			title: "Weather",
+			weather: {},
+			x: -1,
+			y: -1,
+			w: 4,
+			h: 3,
+		});
+		add("pet", "ambience", { kind: "pet", title: "Pet", pet: {}, x: -1, y: -1, w: 3, h: 4 });
+	}
+
+	if (accepted(answers, "dataview")) {
+		add("dataview", "dataview", {
+			kind: "dataview",
+			title: "Dataview",
+			// Seeded with a query rather than left blank: an empty Dataview card
+			// is indistinguishable from a broken one, and "the notes I touched
+			// most recently" is both obviously useful and obviously editable.
+			dataview: { query: "LIST\nSORT file.mtime DESC\nLIMIT 10", language: "dql" },
+			x: -1,
+			y: -1,
+			w: 4,
+			h: 4,
+		});
+	}
+
+	if (accepted(answers, "datacore")) {
+		add("datacore", "datacore", {
+			kind: "datacore",
+			title: "Datacore",
+			datacore: {},
+			x: -1,
+			y: -1,
+			w: 4,
+			h: 4,
+		});
+	}
+
+	if (accepted(answers, "git")) {
+		add("git", "git", { kind: "git", title: "Git", git: {}, x: -1, y: -1, w: 4, h: 4 });
+	}
+
+	if (accepted(answers, "bases") && detection.basePath) {
+		add("base", "bases", {
+			kind: "embed",
+			title: baseTitle(detection.basePath),
+			target: detection.basePath,
+			x: -1,
+			y: -1,
+			w: 6,
+			h: 5,
+		});
+	}
+
+	// Pack once, over the whole plan, so the geometry the review step previews
+	// is exactly the geometry the board is saved with.
+	const cards: DashboardCard[] = drafts.map((draft, i) => ({ ...draft.card, id: newId(i) }));
+	ensureLayout(cards, PLAN_COLUMNS);
+	return drafts.map((draft, i) => ({ id: draft.id, reason: draft.reason, card: cards[i] }));
+}
+
+/** Why the Tasks card is on the board — the integration that asked for it takes
+ * precedence over the generic purpose, since it is the more specific answer. */
+function taskReason(answers: SetupAnswers): string {
+	if (accepted(answers, "tasknotes")) return "tasknotes";
+	if (accepted(answers, "kanban")) return "kanban";
+	return "tasks";
+}
+
+/**
+ * Configure the Tasks card for whichever source the vault actually has.
+ *
+ * The TaskNotes branch is the reason this feature exists: switching the source
+ * is one line, but a card pointed at TaskNotes without its *completed* statuses
+ * shows every cancelled task as outstanding, and one pointed at a vault that
+ * renamed its fields shows nothing at all. Both are read from the plugin.
+ */
+function planTasksConfig(
+	answers: SetupAnswers,
+	detection: SetupDetection,
+): DashboardCard["tasks"] {
+	if (accepted(answers, "tasknotes") && detection.taskNotes) {
+		const imported = taskNotesImport(detection.taskNotes);
+		return {
+			source: "tasknotes",
+			// Only stored when TaskNotes actually defines completed statuses;
+			// otherwise the card falls back to the single global done-value,
+			// which `applySetup` has just synced from the same place.
+			...(imported.doneStatuses.length
+				? { taskNotesDoneStatuses: imported.doneStatuses }
+				: {}),
+		};
+	}
+	if (accepted(answers, "kanban") && detection.kanbanPath) {
+		return { source: "kanban", kanbanFile: detection.kanbanPath, layout: "kanban" };
+	}
+	return {};
+}
+
+/** A readable title for an embedded base: its file name without the extension. */
+function baseTitle(path: string): string {
+	const name = path.split("/").pop() ?? path;
+	return name.replace(/\.base$/i, "") || "Base";
+}
+
+/** Card ids in the same shape the card picker mints them. */
+function defaultCardId(index: number): string {
+	return `card-${Date.now().toString(36)}-${index}-${Math.floor(Math.random() * 1e4)}`;
+}
+
+/** What {@link applySetup} did, so the wizard can report it. */
+export interface SetupOutcome {
+	/** Id of the dashboard the board landed on. */
+	dashboardId: string;
+	/** How many cards it holds. */
+	cardCount: number;
+	/** True when an existing board's cards were replaced rather than a new
+	 * dashboard created. */
+	replaced: boolean;
+}
+
+/**
+ * Write the wizard's answers into settings and install the planned board.
+ *
+ * Mutates `settings` in place — the same contract `migrateSettings` has — and
+ * leaves persisting to the caller, so the wizard saves once at the end rather
+ * than after every step.
+ */
+export function applySetup(
+	settings: HomeSettings,
+	answers: SetupAnswers,
+	detection: SetupDetection,
+	planned: PlannedCard[] = planCards(answers, detection),
+): SetupOutcome {
+	applyHeader(settings, answers);
+	applyLook(settings, answers);
+	applyBehaviour(settings, answers);
+	applyIntegrations(settings, answers, detection);
+
+	const cards = planned.map((p) => p.card);
+	const outcome = installBoard(settings, answers, cards);
+
+	settings.setupStatus = "done";
+	return outcome;
+}
+
+function applyHeader(settings: HomeSettings, answers: SetupAnswers): void {
+	settings.title = answers.title.trim() || settings.title;
+	settings.showTitle = answers.showTitle;
+	settings.logo = answers.logo.trim();
+	settings.themeColorTarget = answers.themeColorTarget;
+	settings.showSearch = answers.showSearch;
+}
+
+function applyLook(settings: HomeSettings, answers: SetupAnswers): void {
+	const surface = SURFACE_PRESETS[answers.surface];
+	settings.cardOpacity = surface.cardOpacity;
+	settings.cardBlur = surface.cardBlur;
+	settings.cardRadius = surface.cardRadius;
+	settings.cardBorderWidth = surface.cardBorderWidth;
+	settings.compact = answers.compact;
+
+	const tuning = BACKGROUND_TUNING[answers.background];
+	settings.backgroundOpacity = tuning.opacity;
+	settings.backgroundBlur = tuning.blur;
+	settings.backgroundLayout = answers.backgroundLayout;
+
+	switch (answers.background) {
+		case "default":
+			settings.backgroundKind = "default";
+			settings.backgroundValue = "";
+			break;
+		case "color":
+			settings.backgroundKind = "color";
+			settings.backgroundValue = answers.backgroundColor;
+			break;
+		case "weather":
+			// A weather background with no place picked would paint nothing at
+			// all, which reads as a broken setup rather than a deliberate one —
+			// so an unfinished sky falls back to the bundled image.
+			if (answers.skyValue) {
+				settings.backgroundKind = "weather";
+				settings.backgroundValue = answers.skyValue;
+			} else {
+				settings.backgroundKind = "default";
+				settings.backgroundValue = "";
+				const fallback = BACKGROUND_TUNING.default;
+				settings.backgroundOpacity = fallback.opacity;
+				settings.backgroundBlur = fallback.blur;
+			}
+			break;
+		case "none":
+			settings.backgroundKind = "none";
+			settings.backgroundValue = "";
+			break;
+	}
+}
+
+function applyBehaviour(settings: HomeSettings, answers: SetupAnswers): void {
+	settings.openOnStartup = answers.openOnStartup;
+	settings.replaceNewTabs = answers.replaceNewTabs;
+	settings.focusSearchOnOpen = answers.focusSearchOnOpen;
+	settings.openIn = answers.openIn;
+}
+
+/**
+ * Wire up the accepted integrations.
+ *
+ * Only ever *positive*: declining an offer leaves the corresponding setting
+ * exactly as it was rather than turning it off. The wizard can be re-run at any
+ * time, and a re-run that silently disabled things the user had since set up by
+ * hand would be a trap. The one exception is `customFileIcons`, whose default
+ * is already on — accepting simply keeps it there.
+ */
+function applyIntegrations(
+	settings: HomeSettings,
+	answers: SetupAnswers,
+	detection: SetupDetection,
+): void {
+	if (accepted(answers, "omnisearch")) settings.searchEngine = "omnisearch";
+	if (accepted(answers, "fileIcons")) settings.customFileIcons = true;
+
+	if (accepted(answers, "tasknotes") && detection.taskNotes) {
+		const imported = taskNotesImport(detection.taskNotes);
+		settings.taskNotesStatusField = imported.statusField;
+		settings.taskNotesDueField = imported.dueField;
+		settings.taskNotesPriorityField = imported.priorityField;
+		settings.taskNotesDoneValue = imported.doneValue;
+	}
+}
+
+/**
+ * How many grid rows a board may occupy and still be worth squeezing onto one
+ * screen.
+ *
+ * Fit-to-page is Hearth's default and is what makes a board read as a *home
+ * screen* rather than a page — but it works by scaling the whole layout down
+ * until it fits, so a board twice as tall as the viewport renders every card at
+ * half height. The starter board is thirteen rows and squeezes comfortably; a
+ * wizard board that picked every purpose can be twice that, and the honest
+ * answer for one of those is to let it scroll at its natural size.
+ */
+const FIT_TO_PAGE_ROW_LIMIT = 16;
+
+/** How many grid rows a set of cards occupies. */
+export function boardRows(cards: DashboardCard[]): number {
+	return cards.reduce((max, card) => Math.max(max, card.y + card.h), 0);
+}
+
+/**
+ * Put the cards somewhere: over the active board, or on a new one.
+ *
+ * "Replace" is offered because the very first run lands on the untouched
+ * starter board, where replacing is obviously right; "new dashboard" exists so
+ * a later re-run can't destroy a board somebody has spent an evening
+ * arranging. The wizard defaults between them on exactly that basis.
+ */
+function installBoard(
+	settings: HomeSettings,
+	answers: SetupAnswers,
+	cards: DashboardCard[],
+): SetupOutcome {
+	// A tall board scrolls rather than being scaled down to nothing. Stored as a
+	// per-dashboard override rather than by changing the global setting, so it
+	// only affects the board the wizard built.
+	const tall = boardRows(cards) > FIT_TO_PAGE_ROW_LIMIT;
+
+	if (answers.target === "replace") {
+		const active =
+			settings.dashboards.find((d) => d.id === settings.activeDashboardId) ??
+			settings.dashboards[0];
+		if (active) {
+			active.cards = cards;
+			if (answers.dashboardName.trim()) active.name = answers.dashboardName.trim();
+			// Only ever *relax* the fit: a board that comfortably fits keeps
+			// whatever the user (or the global default) already had.
+			if (tall) active.fitToPage = false;
+			settings.activeDashboardId = active.id;
+			return { dashboardId: active.id, cardCount: cards.length, replaced: true };
+		}
+		// No dashboards at all (a hand-emptied data.json); fall through and make
+		// one rather than dropping the board on the floor.
+	}
+
+	const dashboard: Dashboard = {
+		id: newDashboardId(),
+		name: answers.dashboardName.trim() || "Home",
+		cards,
+		...(tall ? { fitToPage: false } : {}),
+	};
+	settings.dashboards.push(dashboard);
+	settings.activeDashboardId = dashboard.id;
+	return { dashboardId: dashboard.id, cardCount: cards.length, replaced: false };
+}
+
+/**
+ * The ids of the cards a brand-new vault is seeded with (see `starterCards` in
+ * types.ts).
+ *
+ * Used to tell an untouched starter board from one the user has made their
+ * own, which is what decides whether the wizard offers to replace it or to add
+ * a dashboard beside it.
+ */
+const STARTER_CARD_IDS = ["card-clock", "card-daily", "card-calendar", "card-recent", "card-stats"];
+
+/**
+ * Whether the active board is still exactly the starter set — same cards, none
+ * added, none removed. Card *positions* are ignored: someone who dragged the
+ * starter cards around has still not invested anything the wizard would be
+ * destroying, and the wizard is about to lay out a new board anyway.
+ */
+export function isUntouchedStarterBoard(settings: HomeSettings): boolean {
+	const active =
+		settings.dashboards.find((d) => d.id === settings.activeDashboardId) ??
+		settings.dashboards[0];
+	if (!active) return true;
+	if (active.cards.length !== STARTER_CARD_IDS.length) return false;
+	return active.cards.every((card) => STARTER_CARD_IDS.includes(card.id));
+}

--- a/src/onboarding/wizard.ts
+++ b/src/onboarding/wizard.ts
@@ -633,7 +633,29 @@ export class SetupWizardModal extends Modal {
 					}),
 			);
 
-		body.createDiv({ cls: "hearth-setup-note", text: strings.reassurance });
+		this.renderOutro(body);
+	}
+
+	/**
+	 * The parting note, and the most important thing on the step.
+	 *
+	 * A wizard that builds a board for you invites exactly the wrong conclusion —
+	 * that the board it built is *the* board, and that Hearth is a plugin with a
+	 * few presets. It is the opposite: nearly everything here is adjustable, and
+	 * the generated board is a demonstration of that rather than a destination.
+	 * So the last thing the wizard says is to go and change it.
+	 */
+	private renderOutro(body: HTMLElement): void {
+		const strings = t().setup.finish;
+		const outro = body.createDiv("hearth-setup-outro");
+
+		const head = outro.createDiv("hearth-setup-outro-head");
+		setIcon(head.createSpan("hearth-setup-outro-icon"), "sliders-horizontal");
+		head.createSpan({ cls: "hearth-setup-outro-title", text: strings.outroTitle });
+
+		outro.createEl("p", { cls: "hearth-setup-outro-text", text: strings.outroLead });
+		outro.createEl("p", { cls: "hearth-setup-outro-text", text: strings.outroCustomize });
+		outro.createDiv({ cls: "hearth-setup-outro-hint", text: strings.outroHint });
 	}
 
 	/**

--- a/src/onboarding/wizard.ts
+++ b/src/onboarding/wizard.ts
@@ -592,6 +592,11 @@ export class SetupWizardModal extends Modal {
 		const a = this.answers;
 		const planned = planCards(a, this.detection, (i) => `preview-${i}`);
 
+		// First, above the preview: the step's body scrolls, and everything below
+		// is a list the reader is about to scroll through and then press a button.
+		// A note at the bottom of that is a note nobody reads.
+		this.renderCustomizeCallout(body);
+
 		if (planned.length === 0) {
 			body.createDiv({ cls: "hearth-setup-note", text: strings.empty });
 		} else {
@@ -632,30 +637,32 @@ export class SetupWizardModal extends Modal {
 						a.dashboardName = v;
 					}),
 			);
-
-		this.renderOutro(body);
 	}
 
 	/**
-	 * The parting note, and the most important thing on the step.
+	 * The most important thing on the step, and so the first thing on it.
 	 *
 	 * A wizard that builds a board for you invites exactly the wrong conclusion —
 	 * that the board it built is *the* board, and that Hearth is a plugin with a
 	 * few presets. It is the opposite: nearly everything here is adjustable, and
 	 * the generated board is a demonstration of that rather than a destination.
-	 * So the last thing the wizard says is to go and change it.
+	 *
+	 * Which is why it leads the step rather than closing it. Below this sit a
+	 * board preview, a card list and two controls — a reader working down that
+	 * and pressing "Build my dashboard" would never reach a footnote, and this is
+	 * the one thing on the step that must not be missed.
 	 */
-	private renderOutro(body: HTMLElement): void {
+	private renderCustomizeCallout(body: HTMLElement): void {
 		const strings = t().setup.finish;
-		const outro = body.createDiv("hearth-setup-outro");
+		const callout = body.createDiv("hearth-setup-callout");
 
-		const head = outro.createDiv("hearth-setup-outro-head");
-		setIcon(head.createSpan("hearth-setup-outro-icon"), "sliders-horizontal");
-		head.createSpan({ cls: "hearth-setup-outro-title", text: strings.outroTitle });
+		const head = callout.createDiv("hearth-setup-callout-head");
+		setIcon(head.createSpan("hearth-setup-callout-icon"), "sliders-horizontal");
+		head.createSpan({ cls: "hearth-setup-callout-title", text: strings.calloutTitle });
 
-		outro.createEl("p", { cls: "hearth-setup-outro-text", text: strings.outroLead });
-		outro.createEl("p", { cls: "hearth-setup-outro-text", text: strings.outroCustomize });
-		outro.createDiv({ cls: "hearth-setup-outro-hint", text: strings.outroHint });
+		callout.createEl("p", { cls: "hearth-setup-callout-text", text: strings.calloutLead });
+		callout.createEl("p", { cls: "hearth-setup-callout-text", text: strings.calloutBody });
+		callout.createDiv({ cls: "hearth-setup-callout-hint", text: strings.calloutHint });
 	}
 
 	/**

--- a/src/onboarding/wizard.ts
+++ b/src/onboarding/wizard.ts
@@ -1,0 +1,752 @@
+/**
+ * The first-run setup wizard.
+ *
+ * A new Hearth install used to drop the user straight onto a five-card starter
+ * board with a wallpaper they didn't choose and no indication that the plugin
+ * can read their tasks, their calendar or their git repository. Everything was
+ * configurable; nothing was offered. This asks instead — a handful of questions
+ * about how the vault is used and what it already has installed — and builds
+ * the board from the answers.
+ *
+ * This module is the *asking*. What the answers mean lives in `plan.ts`, and
+ * what the vault has lives in `detect.ts`, both of which are pure and tested;
+ * a step here does nothing but read and write one field of {@link SetupAnswers}
+ * and then redraw.
+ *
+ * ⚠️ #52 naming hazard: members here share a prototype chain with Obsidian's
+ * `Modal`, whose undocumented internals aren't in the typings, so a colliding
+ * method name compiles cleanly and silently replaces engine behaviour. Every
+ * member below is named unmistakably (`renderWizard`, not `render`).
+ */
+import { Modal, Notice, Setting, setIcon } from "obsidian";
+import { t } from "../i18n";
+import type HearthPlugin from "../main";
+import { configuredPlaces, renderSkySource } from "../placepicker";
+import { formatSkyValue, parseSkyValue } from "../sky";
+import { makeClickable } from "../ui";
+import type { OpenIn } from "../types";
+import { OPEN_IN_MODES } from "../types";
+import { detectSetup, type DetectedIntegration, type SetupDetection } from "./detect";
+import {
+	applySetup,
+	defaultAnswers,
+	isUntouchedStarterBoard,
+	planCards,
+	PURPOSE_ICONS,
+	SETUP_BACKGROUNDS,
+	SETUP_PURPOSES,
+	SETUP_SURFACES,
+	type PlannedCard,
+	type SetupAnswers,
+	type SetupBackground,
+	type SetupPurpose,
+	type SetupSurface,
+} from "./plan";
+
+/** The wizard's steps, in order. `integrations` is dropped when the vault has
+ * none to offer, so nobody is walked through an empty page. */
+type SetupStepId =
+	| "welcome"
+	| "vault"
+	| "look"
+	| "purpose"
+	| "integrations"
+	| "behaviour"
+	| "finish";
+
+/** The Lucide icon shown beside each step on the progress rail. */
+const STEP_ICONS: Record<SetupStepId, string> = {
+	welcome: "flame",
+	vault: "book-open",
+	look: "palette",
+	purpose: "compass",
+	integrations: "plug",
+	behaviour: "settings-2",
+	finish: "check",
+};
+
+/** Grid columns the finish step's board preview is drawn against — the same
+ * width `planCards` lays out to. */
+const PREVIEW_COLUMNS = 12;
+
+/** How a particular run of the wizard behaves. */
+export interface SetupWizardOptions {
+	/**
+	 * Force the built board onto a *new* dashboard, with no option to replace
+	 * an existing one.
+	 *
+	 * Set for every entry point except the first-run prompt. Re-running the
+	 * wizard from settings is something people do to explore — "what would it
+	 * build if I said I plan in here?" — and an exploration that can overwrite a
+	 * board somebody spent an evening arranging is a trap, however clearly the
+	 * dropdown is labelled. So the destructive option simply isn't offered:
+	 * every existing dashboard is left exactly as it is, and the result arrives
+	 * as one more board in the switcher.
+	 */
+	forceNewDashboard?: boolean;
+}
+
+export class SetupWizardModal extends Modal {
+	private readonly plugin: HearthPlugin;
+	private readonly detection: SetupDetection;
+	private readonly options: SetupWizardOptions;
+	private answers: SetupAnswers;
+	private stepIndex = 0;
+	/** True once the board has been built, so closing the modal afterwards
+	 * doesn't record the run as skipped. */
+	private finished = false;
+	/** Scratch space for the weather background's place picker, which keeps its
+	 * query and last results across the in-place redraws its own buttons
+	 * trigger. Dropped with the modal. */
+	private readonly placeSession: Record<string, unknown> = {};
+
+	constructor(plugin: HearthPlugin, options: SetupWizardOptions = {}) {
+		super(plugin.app);
+		this.plugin = plugin;
+		this.options = options;
+		this.detection = detectSetup(plugin.app);
+		this.answers = defaultAnswers(plugin.settings, this.detection);
+		// Replacing the board is right on a fresh install and wrong on a re-run
+		// over a board somebody has arranged; decide from what is actually there
+		// rather than making the user think about it. A forced run never replaces
+		// anything regardless.
+		this.answers.target =
+			!options.forceNewDashboard && isUntouchedStarterBoard(plugin.settings)
+				? "replace"
+				: "new";
+		// A second board wants a name that isn't already taken, so the switcher
+		// doesn't end up with two identically-labelled entries.
+		this.answers.dashboardName = this.freeDashboardName();
+	}
+
+	/** "Home", or "Home 2", "Home 3"… when the vault already has one. */
+	private freeDashboardName(): string {
+		const base = t().setup.finish.defaultName;
+		const taken = new Set(this.plugin.settings.dashboards.map((d) => d.name));
+		if (!taken.has(base)) return base;
+		for (let n = 2; n < 100; n++) {
+			const candidate = `${base} ${n}`;
+			if (!taken.has(candidate)) return candidate;
+		}
+		return base;
+	}
+
+	onOpen(): void {
+		this.modalEl.addClass("hearth-setup-modal");
+		this.renderWizard();
+	}
+
+	onClose(): void {
+		// Dismissing the wizard is an answer too: record it, or a fresh install
+		// would be greeted by it again on every single load.
+		if (!this.finished && this.plugin.settings.setupStatus === "pending") {
+			this.plugin.settings.setupStatus = "skipped";
+			void this.plugin.saveData(this.plugin.settings);
+		}
+		this.contentEl.empty();
+	}
+
+	// ---- Shell ---------------------------------------------------------
+
+	/** The steps this run actually has. */
+	private wizardSteps(): SetupStepId[] {
+		const steps: SetupStepId[] = ["welcome", "vault", "look", "purpose"];
+		if (this.detection.integrations.length > 0) steps.push("integrations");
+		steps.push("behaviour", "finish");
+		return steps;
+	}
+
+	private currentStep(): SetupStepId {
+		const steps = this.wizardSteps();
+		return steps[Math.min(this.stepIndex, steps.length - 1)];
+	}
+
+	/** Build (or rebuild) the whole modal. Called on every answer that changes
+	 * what the rest of the step shows, and on every navigation. */
+	private renderWizard(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass("hearth-setup");
+
+		const steps = this.wizardSteps();
+		const step = this.currentStep();
+		const strings = t().setup;
+
+		this.renderRail(contentEl, steps, step);
+
+		const head = contentEl.createDiv("hearth-setup-head");
+		head.createDiv({ cls: "hearth-setup-title", text: strings.stepTitles[step] });
+		head.createDiv({ cls: "hearth-setup-subtitle", text: strings.stepDescs[step] });
+
+		const body = contentEl.createDiv("hearth-setup-body");
+		// Per-step backstop, the #52 lesson: a throw while building one step
+		// shows an inline message instead of a blank modal, and the footer below
+		// still lets the user move on or leave.
+		try {
+			this.renderStepBody(body, step);
+		} catch (err) {
+			console.error(`Hearth: the "${step}" setup step failed to render`, err);
+			body.empty();
+			const box = body.createDiv("hearth-settings-error");
+			setIcon(box.createSpan("hearth-settings-error-icon"), "alert-triangle");
+			const text = box.createDiv("hearth-settings-error-text");
+			text.createDiv({
+				cls: "hearth-settings-error-title",
+				text: t().settings.sectionError(strings.stepTitles[step]),
+			});
+			text.createDiv({
+				cls: "hearth-settings-error-hint",
+				text: t().settings.sectionErrorHint,
+			});
+		}
+
+		this.renderFooter(contentEl.createDiv("hearth-setup-foot"), steps);
+	}
+
+	/** The progress rail: one pill per step, showing where the user is and how
+	 * much is left. Completed steps are clickable so going back is one press
+	 * rather than several. */
+	private renderRail(
+		parent: HTMLElement,
+		steps: SetupStepId[],
+		active: SetupStepId,
+	): void {
+		const strings = t().setup;
+		const rail = parent.createDiv("hearth-setup-rail");
+		const activeIndex = steps.indexOf(active);
+		steps.forEach((step, index) => {
+			const pill = rail.createDiv("hearth-setup-rail-step");
+			pill.toggleClass("is-active", index === activeIndex);
+			pill.toggleClass("is-done", index < activeIndex);
+			setIcon(
+				pill.createSpan("hearth-setup-rail-icon"),
+				index < activeIndex ? "check" : STEP_ICONS[step],
+			);
+			pill.createSpan({ cls: "hearth-setup-rail-label", text: strings.stepNames[step] });
+			if (index < activeIndex) {
+				const go = () => {
+					this.stepIndex = index;
+					this.renderWizard();
+				};
+				makeClickable(pill, go, strings.stepNames[step]);
+				pill.addEventListener("click", go);
+			}
+		});
+	}
+
+	/** Back / Next / Finish, plus the escape hatch on the first step. */
+	private renderFooter(footer: HTMLElement, steps: SetupStepId[]): void {
+		const strings = t().setup;
+		const last = this.stepIndex >= steps.length - 1;
+
+		const left = footer.createDiv("hearth-setup-foot-left");
+		if (this.stepIndex === 0) {
+			const skip = left.createEl("button", {
+				cls: "hearth-setup-skip",
+				text: strings.nav.skip,
+			});
+			skip.addEventListener("click", () => this.close());
+		}
+
+		const right = footer.createDiv("hearth-setup-foot-right");
+		if (this.stepIndex > 0) {
+			const back = right.createEl("button", { text: strings.nav.back });
+			back.addEventListener("click", () => {
+				this.stepIndex = Math.max(0, this.stepIndex - 1);
+				this.renderWizard();
+			});
+		}
+		const next = right.createEl("button", {
+			cls: "mod-cta",
+			text: last ? strings.nav.finish : strings.nav.next,
+		});
+		next.addEventListener("click", () => {
+			if (last) {
+				void this.finishSetup();
+				return;
+			}
+			this.stepIndex = Math.min(steps.length - 1, this.stepIndex + 1);
+			this.renderWizard();
+		});
+	}
+
+	// ---- Steps ---------------------------------------------------------
+
+	private renderStepBody(body: HTMLElement, step: SetupStepId): void {
+		switch (step) {
+			case "welcome":
+				this.renderWelcomeStep(body);
+				break;
+			case "vault":
+				this.renderVaultStep(body);
+				break;
+			case "look":
+				this.renderLookStep(body);
+				break;
+			case "purpose":
+				this.renderPurposeStep(body);
+				break;
+			case "integrations":
+				this.renderIntegrationsStep(body);
+				break;
+			case "behaviour":
+				this.renderBehaviourStep(body);
+				break;
+			case "finish":
+				this.renderFinishStep(body);
+				break;
+		}
+	}
+
+	private renderWelcomeStep(body: HTMLElement): void {
+		const strings = t().setup.welcome;
+		body.createEl("p", { cls: "hearth-setup-lead", text: strings.lead });
+
+		const list = body.createDiv("hearth-setup-bullets");
+		for (const bullet of strings.bullets) {
+			const row = list.createDiv("hearth-setup-bullet");
+			setIcon(row.createSpan("hearth-setup-bullet-icon"), bullet.icon);
+			const text = row.createDiv("hearth-setup-bullet-text");
+			text.createDiv({ cls: "hearth-setup-bullet-title", text: bullet.title });
+			text.createDiv({ cls: "hearth-setup-bullet-desc", text: bullet.desc });
+		}
+
+		const found = this.detection.integrations;
+		body.createDiv({
+			cls: "hearth-setup-note",
+			text: found.length
+				? strings.detected(found.map((i) => i.name).join(", "))
+				: strings.detectedNone,
+		});
+	}
+
+	private renderVaultStep(body: HTMLElement): void {
+		const strings = t().setup.vault;
+		const a = this.answers;
+
+		new Setting(body)
+			.setName(strings.title)
+			.setDesc(strings.titleDesc)
+			.addText((text) =>
+				text
+					.setPlaceholder(this.detection.vaultName || "Obsidian")
+					.setValue(a.title)
+					.onChange((v) => {
+						a.title = v;
+					}),
+			);
+
+		new Setting(body)
+			.setName(strings.showTitle)
+			.setDesc(strings.showTitleDesc)
+			.addToggle((tg) =>
+				tg.setValue(a.showTitle).onChange((v) => {
+					a.showTitle = v;
+				}),
+			);
+
+		new Setting(body)
+			.setName(strings.logo)
+			.setDesc(strings.logoDesc)
+			.addText((text) =>
+				text
+					.setPlaceholder("🔥")
+					.setValue(a.logo)
+					.onChange((v) => {
+						a.logo = v;
+					}),
+			);
+
+		new Setting(body)
+			.setName(strings.themeColor)
+			.setDesc(strings.themeColorDesc)
+			.addDropdown((d) => {
+				const labels = t().setup.vault.themeColorOptions;
+				d.addOption("none", labels.none);
+				d.addOption("icon", labels.icon);
+				d.addOption("title", labels.title);
+				d.addOption("both", labels.both);
+				d.setValue(a.themeColorTarget).onChange((v) => {
+					a.themeColorTarget = v as SetupAnswers["themeColorTarget"];
+				});
+			});
+
+		new Setting(body)
+			.setName(strings.showSearch)
+			.setDesc(strings.showSearchDesc)
+			.addToggle((tg) =>
+				tg.setValue(a.showSearch).onChange((v) => {
+					a.showSearch = v;
+				}),
+			);
+	}
+
+	private renderLookStep(body: HTMLElement): void {
+		const strings = t().setup.look;
+		const a = this.answers;
+
+		body.createDiv({ cls: "hearth-setup-grouplabel", text: strings.surfaceHeading });
+		this.optionGrid(
+			body,
+			SETUP_SURFACES,
+			(surface: SetupSurface) => ({
+				icon: t().setup.surfaces[surface].icon,
+				name: t().setup.surfaces[surface].name,
+				desc: t().setup.surfaces[surface].desc,
+				selected: a.surface === surface,
+			}),
+			(surface) => {
+				a.surface = surface;
+				this.renderWizard();
+			},
+		);
+
+		body.createDiv({ cls: "hearth-setup-grouplabel", text: strings.backgroundHeading });
+		this.optionGrid(
+			body,
+			SETUP_BACKGROUNDS,
+			(background: SetupBackground) => ({
+				icon: t().setup.backgrounds[background].icon,
+				name: t().setup.backgrounds[background].name,
+				desc: t().setup.backgrounds[background].desc,
+				selected: a.background === background,
+			}),
+			(background) => {
+				a.background = background;
+				this.renderWizard();
+			},
+		);
+
+		if (a.background === "color") {
+			new Setting(body).setName(strings.color).setDesc(strings.colorDesc).addColorPicker((c) =>
+				c.setValue(a.backgroundColor).onChange((v) => {
+					a.backgroundColor = v;
+				}),
+			);
+		}
+
+		if (a.background === "weather") {
+			const sky = parseSkyValue(a.skyValue);
+			body.createDiv({ cls: "hearth-setup-note", text: strings.weatherDesc });
+			renderSkySource(body, {
+				current: sky,
+				onChange: (next) => {
+					a.skyValue = next ? formatSkyValue(next) : "";
+				},
+				rerender: () => this.renderWizard(),
+				disabled: this.plugin.settings.disableExternalCalls,
+				session: this.placeSession,
+				suggestions: configuredPlaces(this.plugin.settings),
+			});
+		}
+
+		if (a.background !== "none") {
+			new Setting(body)
+				.setName(strings.layout)
+				.setDesc(strings.layoutDesc)
+				.addDropdown((d) => {
+					d.addOption("full", strings.layoutFull);
+					d.addOption("banner", strings.layoutBanner);
+					d.setValue(a.backgroundLayout).onChange((v) => {
+						a.backgroundLayout = v as SetupAnswers["backgroundLayout"];
+					});
+				});
+		}
+
+		new Setting(body)
+			.setName(strings.compact)
+			.setDesc(strings.compactDesc)
+			.addToggle((tg) =>
+				tg.setValue(a.compact).onChange((v) => {
+					a.compact = v;
+				}),
+			);
+	}
+
+	private renderPurposeStep(body: HTMLElement): void {
+		const a = this.answers;
+		this.optionGrid(
+			body,
+			SETUP_PURPOSES,
+			(purpose: SetupPurpose) => ({
+				icon: PURPOSE_ICONS[purpose],
+				name: t().setup.purposes[purpose].name,
+				desc: t().setup.purposes[purpose].desc,
+				selected: a.purposes.includes(purpose),
+			}),
+			(purpose) => {
+				a.purposes = a.purposes.includes(purpose)
+					? a.purposes.filter((p) => p !== purpose)
+					: [...a.purposes, purpose];
+				this.renderWizard();
+			},
+			"is-multi",
+		);
+
+		const count = planCards(a, this.detection, (i) => `preview-${i}`).length;
+		body.createDiv({ cls: "hearth-setup-note", text: t().setup.purpose.count(count) });
+	}
+
+	private renderIntegrationsStep(body: HTMLElement): void {
+		const strings = t().setup.integrations;
+		const a = this.answers;
+
+		body.createDiv({ cls: "hearth-setup-note", text: strings.lead });
+
+		for (const found of this.detection.integrations) {
+			const setting = new Setting(body)
+				.setName(found.name)
+				.setDesc(this.integrationEffect(found))
+				.addToggle((tg) =>
+					tg.setValue(a.integrations.includes(found.id)).onChange((v) => {
+						a.integrations = v
+							? [...a.integrations, found.id]
+							: a.integrations.filter((id) => id !== found.id);
+						// The Tasks card's configuration and the plan's card count
+						// both hinge on this, so redraw rather than let the summary
+						// go stale.
+						this.renderWizard();
+					}),
+				);
+			setting.settingEl.addClass("hearth-setup-integration");
+			if (found.recommended) {
+				setting.nameEl.createSpan({
+					cls: "hearth-setup-badge",
+					text: strings.recommended,
+				});
+			}
+		}
+
+		// The one detection worth spelling out: a TaskNotes vault that renamed
+		// its fields is exactly the vault where a Tasks card would otherwise come
+		// up empty, so say what was read rather than merely that something was.
+		const taskNotes = this.detection.taskNotes;
+		if (taskNotes && a.integrations.includes("tasknotes")) {
+			const box = body.createDiv("hearth-setup-detected");
+			box.createDiv({ cls: "hearth-setup-detected-title", text: strings.taskNotesTitle });
+			const fields = box.createDiv("hearth-setup-detected-list");
+			const row = (label: string, value: string): void => {
+				const line = fields.createDiv("hearth-setup-detected-row");
+				line.createSpan({ cls: "hearth-setup-detected-key", text: label });
+				line.createSpan({ cls: "hearth-setup-detected-value", text: value });
+			};
+			row(strings.taskNotesStatus, taskNotes.fields.status);
+			row(strings.taskNotesDue, taskNotes.fields.due);
+			row(strings.taskNotesPriority, taskNotes.fields.priority);
+			const done = taskNotes.statuses.filter((s) => s.isCompleted).map((s) => s.label);
+			row(strings.taskNotesDone, done.length ? done.join(", ") : strings.taskNotesDoneNone);
+		}
+	}
+
+	/** What accepting an integration will actually do, in one line. */
+	private integrationEffect(found: DetectedIntegration): string {
+		const effects = t().setup.integrations.effects;
+		return effects[found.id];
+	}
+
+	private renderBehaviourStep(body: HTMLElement): void {
+		const strings = t().setup.behaviour;
+		const a = this.answers;
+
+		new Setting(body)
+			.setName(strings.openOnStartup)
+			.setDesc(strings.openOnStartupDesc)
+			.addToggle((tg) =>
+				tg.setValue(a.openOnStartup).onChange((v) => {
+					a.openOnStartup = v;
+				}),
+			);
+
+		new Setting(body)
+			.setName(strings.replaceNewTabs)
+			.setDesc(strings.replaceNewTabsDesc)
+			.addToggle((tg) =>
+				tg.setValue(a.replaceNewTabs).onChange((v) => {
+					a.replaceNewTabs = v;
+				}),
+			);
+
+		new Setting(body)
+			.setName(strings.focusSearch)
+			.setDesc(strings.focusSearchDesc)
+			.addToggle((tg) =>
+				tg.setValue(a.focusSearchOnOpen).onChange((v) => {
+					a.focusSearchOnOpen = v;
+				}),
+			);
+
+		new Setting(body)
+			.setName(strings.openIn)
+			.setDesc(strings.openInDesc)
+			.addDropdown((d) => {
+				const labels = t().settings.behaviour.openInModes;
+				for (const mode of OPEN_IN_MODES) d.addOption(mode, labels[mode]);
+				d.setValue(a.openIn).onChange((v) => {
+					a.openIn = v as OpenIn;
+				});
+			});
+	}
+
+	private renderFinishStep(body: HTMLElement): void {
+		const strings = t().setup.finish;
+		const a = this.answers;
+		const planned = planCards(a, this.detection, (i) => `preview-${i}`);
+
+		if (planned.length === 0) {
+			body.createDiv({ cls: "hearth-setup-note", text: strings.empty });
+		} else {
+			this.renderBoardPreview(body, planned);
+			const list = body.createDiv("hearth-setup-plan");
+			for (const entry of planned) {
+				const row = list.createDiv("hearth-setup-plan-row");
+				row.createSpan({ cls: "hearth-setup-plan-name", text: plannedName(entry) });
+				row.createSpan({ cls: "hearth-setup-plan-why", text: plannedReason(entry) });
+			}
+		}
+
+		if (this.options.forceNewDashboard) {
+			// No dropdown at all: an option that is never selectable is noise, and
+			// stating the guarantee outright is the reassurance this run needs.
+			body.createDiv({ cls: "hearth-setup-note is-safe", text: strings.targetForcedNew });
+		} else {
+			new Setting(body)
+				.setName(strings.target)
+				.setDesc(strings.targetDesc)
+				.addDropdown((d) => {
+					d.addOption("replace", strings.targetReplace);
+					d.addOption("new", strings.targetNew);
+					d.setValue(a.target).onChange((v) => {
+						a.target = v as SetupAnswers["target"];
+					});
+				});
+		}
+
+		new Setting(body)
+			.setName(strings.name)
+			.setDesc(strings.nameDesc)
+			.addText((text) =>
+				text
+					.setPlaceholder("Home")
+					.setValue(a.dashboardName)
+					.onChange((v) => {
+						a.dashboardName = v;
+					}),
+			);
+
+		body.createDiv({ cls: "hearth-setup-note", text: strings.reassurance });
+	}
+
+	/**
+	 * A scale drawing of the board about to be built: the planned cards in their
+	 * packed positions, labelled.
+	 *
+	 * Worth the few lines it costs. "Clock, Today, Tasks, Recent…" as a list says
+	 * nothing about whether the result will look like a home screen; the same
+	 * information as boxes says it immediately.
+	 */
+	private renderBoardPreview(body: HTMLElement, planned: PlannedCard[]): void {
+		const rows = planned.reduce((max, p) => Math.max(max, p.card.y + p.card.h), 0);
+		const preview = body.createDiv("hearth-setup-preview");
+		preview.style.gridTemplateColumns = `repeat(${PREVIEW_COLUMNS}, 1fr)`;
+		preview.style.gridTemplateRows = `repeat(${Math.max(1, rows)}, 1fr)`;
+		for (const entry of planned) {
+			const cell = preview.createDiv("hearth-setup-preview-card");
+			cell.style.gridColumn = `${entry.card.x + 1} / span ${entry.card.w}`;
+			cell.style.gridRow = `${entry.card.y + 1} / span ${entry.card.h}`;
+			cell.createSpan({ cls: "hearth-setup-preview-label", text: plannedName(entry) });
+		}
+	}
+
+	// ---- Option tiles --------------------------------------------------
+
+	/**
+	 * A grid of selectable tiles — the wizard's main input.
+	 *
+	 * Deliberately not a dropdown or a row of toggles: every choice the wizard
+	 * asks about is one where the *description* is the question. "Frosted" means
+	 * nothing on its own and everything next to "translucent cards over the
+	 * wallpaper", and a tile has room for both.
+	 */
+	private optionGrid<T extends string>(
+		parent: HTMLElement,
+		options: readonly T[],
+		describe: (option: T) => { icon: string; name: string; desc: string; selected: boolean },
+		onPick: (option: T) => void,
+		extraClass?: string,
+	): void {
+		const grid = parent.createDiv("hearth-setup-options");
+		if (extraClass) grid.addClass(extraClass);
+		for (const option of options) {
+			const info = describe(option);
+			const tile = grid.createDiv("hearth-setup-option");
+			tile.toggleClass("is-selected", info.selected);
+			setIcon(tile.createSpan("hearth-setup-option-icon"), info.icon);
+			const text = tile.createDiv("hearth-setup-option-text");
+			text.createDiv({ cls: "hearth-setup-option-name", text: info.name });
+			text.createDiv({ cls: "hearth-setup-option-desc", text: info.desc });
+			const pick = () => onPick(option);
+			makeClickable(tile, pick, info.name);
+			tile.setAttribute("aria-pressed", String(info.selected));
+			tile.addEventListener("click", pick);
+		}
+	}
+
+	// ---- Finishing -----------------------------------------------------
+
+	/** Apply everything, persist once, and hand the user their board. */
+	private async finishSetup(): Promise<void> {
+		// Belt and braces: the "replace" control is never drawn on a forced run,
+		// so this can only differ if the answers were reached some other way —
+		// and the one thing this run promises is that it touches nothing.
+		if (this.options.forceNewDashboard) this.answers.target = "new";
+		const outcome = applySetup(this.plugin.settings, this.answers, this.detection);
+		this.finished = true;
+		// Record the version too, so a first-run user isn't shown the changelog
+		// for a build they have just been set up on.
+		this.plugin.settings.lastSeenVersion = this.plugin.manifest.version;
+		await this.plugin.saveSettings();
+		this.plugin.refreshBrandIcons();
+		this.close();
+		new Notice(t().setup.notice.done(outcome.cardCount));
+		await this.plugin.activateView();
+	}
+}
+
+/** What a planned card is called in the review list: its own title, or the
+ * blueprint's name when it has none (the clock and the search bar carry no
+ * title by design). Keyed by a plain string, so the lookup is widened rather
+ * than each blueprint id having to exist in the union. */
+function plannedName(entry: PlannedCard): string {
+	const names = t().setup.plan.names as Record<string, string>;
+	return entry.card.title || names[entry.id] || entry.id;
+}
+
+/** Why a planned card is on the board, in one phrase. */
+function plannedReason(entry: PlannedCard): string {
+	const reasons = t().setup.plan.reasons as Record<string, string>;
+	return reasons[entry.reason] ?? "";
+}
+
+/**
+ * Open the wizard.
+ *
+ * The single entry point: the command, the settings button and the first-run
+ * prompt all come through here, so there is one place that decides what
+ * "running setup" means.
+ */
+export function openSetupWizard(plugin: HearthPlugin, options: SetupWizardOptions = {}): void {
+	new SetupWizardModal(plugin, options).open();
+}
+
+/**
+ * Offer the wizard on a genuinely fresh install, once.
+ *
+ * `setupStatus` is `pending` only for a vault with no persisted Hearth settings
+ * at all (see `migrateSettings`), and the modal itself moves it off `pending`
+ * whether it is completed or dismissed — so this can never nag.
+ */
+export function maybeRunSetup(plugin: HearthPlugin): boolean {
+	if (plugin.settings.setupStatus !== "pending") return false;
+	openSetupWizard(plugin);
+	return true;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,7 @@ import {
 	type SettingsTabId,
 } from "./integrations";
 import { CHANGELOG, WhatsNewModal } from "./whatsnew";
+import { openSetupWizard } from "./onboarding";
 import { t } from "./i18n";
 
 /** Keys of HomeSettings whose default lives in DEFAULT_SETTINGS as a number —
@@ -1792,6 +1793,24 @@ export class HomeSettingTab extends PluginSettingTab {
 		// Grouped like every other page, rather than as bare rows: the section
 		// heading replaces what used to be a `setHeading()` row of its own.
 		this.section(containerEl, about.heading, about.headingDesc, (body) => {
+			// First in the list: the row a user who skipped the first-run wizard —
+			// or who simply wants another board — comes here looking for.
+			//
+			// Always `forceNewDashboard`: from settings the wizard is a board
+			// *generator*, not a reset. Every dashboard that already exists is
+			// left untouched and the result arrives as a new one in the switcher,
+			// so this row can be pressed to see what it would make without any
+			// risk to work already done.
+			const skipped = this.plugin.settings.setupStatus !== "done";
+			new Setting(body)
+				.setName(skipped ? about.setup : about.setupAgain)
+				.setDesc(skipped ? about.setupDesc : about.setupAgainDesc)
+				.addButton((b) =>
+					this.aboutButton(b, "wand-2", about.setupButton, () =>
+						openSetupWizard(this.plugin, { forceNewDashboard: true }),
+					),
+				);
+
 			new Setting(body)
 				.setName(about.whatsNew)
 				.setDesc(about.whatsNewDesc)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1691,7 +1691,23 @@ export interface HomeSettings {
 	 * when to pop the "What's new" dialog after an update. Empty on a fresh
 	 * install (which is seeded silently, without showing the dialog). */
 	lastSeenVersion: string;
+	/** How far the first-run setup wizard has got. See {@link SetupStatus}. */
+	setupStatus: SetupStatus;
 }
+
+/**
+ * Whether the first-run setup wizard still has something to do.
+ *
+ * - `pending` — a fresh install that hasn't been offered the wizard yet. The
+ *   only value that pops it automatically.
+ * - `done` — the wizard was completed, *or* this is a vault that predates it
+ *   (see `migrateSettings`): an existing dashboard must never be interrupted by
+ *   a wizard offering to rebuild it.
+ * - `skipped` — the wizard was offered and dismissed. Behaves like `done`, but
+ *   is kept distinct so "Set up Hearth" in settings can still read as an
+ *   invitation rather than a redo.
+ */
+export type SetupStatus = "pending" | "done" | "skipped";
 
 export const DEFAULT_SETTINGS: HomeSettings = {
 	title: "Obsidian",
@@ -1782,6 +1798,10 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	maxWidth: 1600,
 
 	lastSeenVersion: "",
+	// Fresh installs start out owing the wizard a run; `migrateSettings` marks
+	// every *existing* vault as done, so nobody is offered a rebuild of a
+	// dashboard they already have.
+	setupStatus: "pending",
 };
 
 /** The cards a brand-new vault starts with. Coordinates and sizes are taken
@@ -2276,6 +2296,18 @@ export function migrateSettings(s: HomeSettings, raw: Record<string, unknown>): 
 				migratedCommandId = true;
 			}
 		}
+	}
+	// The first-run wizard is for first runs. A vault that has any persisted
+	// settings at all already has a dashboard — possibly one it has been using
+	// for a year — so it is marked done rather than being offered a rebuild.
+	// Mirrors how `lastSeenVersion` tells a fresh install from an upgrade: no
+	// persisted keys whatsoever is the only signal that means "brand new".
+	if (typeof raw.setupStatus !== "string") {
+		s.setupStatus = Object.keys(raw).length === 0 ? "pending" : "done";
+	} else if (s.setupStatus !== "pending" && s.setupStatus !== "done" && s.setupStatus !== "skipped") {
+		// A hand-edited or partially-synced data.json; anything unrecognised is
+		// treated as done, which is the outcome that never surprises anyone.
+		s.setupStatus = "done";
 	}
 	// The short-lived "split" pill mode was replaced by a plain single button
 	// whose action is chosen here; fall back to the original New-note behaviour.

--- a/styles.css
+++ b/styles.css
@@ -9344,3 +9344,419 @@ body.hearth-dv-resizing {
 		grid-column: 1 / -1;
 	}
 }
+
+/* ======================================================================
+   Setup wizard (first run)
+   ----------------------------------------------------------------------
+   A stepped dialog rather than a settings page: a progress rail, one step
+   at a time, and a fixed footer. The frame's height is pinned (not maxed)
+   for the same reason the card picker's is — steps differ wildly in
+   length, and a dialog that resizes under the pointer moves the Next
+   button out from under the click that was heading for it.
+   ====================================================================== */
+
+.hearth-setup-modal {
+	max-width: 720px;
+	width: min(720px, 94vw);
+}
+
+.hearth-setup-modal .modal-content {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+
+.hearth-setup {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	height: min(70vh, 660px);
+}
+
+/* ---- Progress rail ---- */
+.hearth-setup-rail {
+	flex: none;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	overflow-x: auto;
+	scrollbar-width: none;
+	padding-bottom: 12px;
+	margin-bottom: 4px;
+	border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.hearth-setup-rail::-webkit-scrollbar {
+	display: none;
+}
+
+.hearth-setup-rail-step {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex: none;
+	padding: 4px 10px;
+	border-radius: 999px;
+	color: var(--text-faint);
+	font-size: 0.82em;
+	white-space: nowrap;
+}
+
+.hearth-setup-rail-step.is-done {
+	color: var(--text-muted);
+	cursor: pointer;
+}
+
+.hearth-setup-rail-step.is-done:hover {
+	background: var(--background-modifier-hover);
+}
+
+.hearth-setup-rail-step.is-active {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+	font-weight: 600;
+}
+
+.hearth-setup-rail-icon {
+	display: inline-flex;
+}
+
+.hearth-setup-rail-icon .svg-icon {
+	width: 14px;
+	height: 14px;
+}
+
+/* ---- Step heading ---- */
+.hearth-setup-head {
+	flex: none;
+	padding: 16px 0 12px;
+}
+
+.hearth-setup-title {
+	font-size: 1.35em;
+	font-weight: 650;
+	line-height: 1.25;
+}
+
+.hearth-setup-subtitle {
+	margin-top: 4px;
+	color: var(--text-muted);
+	font-size: 0.9em;
+}
+
+/* ---- Step body: the only part that scrolls ---- */
+.hearth-setup-body {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	/* Room for the scrollbar so option tiles don't run under it. */
+	padding-right: 8px;
+}
+
+/* Settings rows inside the wizard are denser than in the settings pane:
+   there are a lot of them and the dialog is short. */
+.hearth-setup-body .setting-item {
+	padding: 10px 0;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.hearth-setup-body .setting-item:first-child {
+	border-top: none;
+}
+
+.hearth-setup-lead {
+	margin: 0 0 16px;
+	color: var(--text-muted);
+	line-height: 1.55;
+}
+
+.hearth-setup-grouplabel {
+	margin: 18px 0 8px;
+	font-size: 0.78em;
+	font-weight: 650;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--text-faint);
+}
+
+.hearth-setup-grouplabel:first-child {
+	margin-top: 0;
+}
+
+.hearth-setup-note {
+	margin-top: 14px;
+	padding: 10px 12px;
+	border-radius: 8px;
+	background: var(--background-secondary);
+	color: var(--text-muted);
+	font-size: 0.85em;
+	line-height: 1.5;
+}
+
+/* The one note that is a promise rather than an aside — "nothing you have
+   is touched" — so it reads as reassurance, not small print. */
+.hearth-setup-note.is-safe {
+	background: var(--background-modifier-success, var(--background-secondary));
+	border: 1px solid var(--background-modifier-border);
+	color: var(--text-normal);
+}
+
+/* ---- Welcome bullets ---- */
+.hearth-setup-bullets {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+.hearth-setup-bullet {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+}
+
+.hearth-setup-bullet-icon {
+	display: inline-flex;
+	flex: none;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	border-radius: 8px;
+	background: var(--background-modifier-hover);
+	color: var(--text-accent);
+}
+
+.hearth-setup-bullet-title {
+	font-weight: 600;
+}
+
+.hearth-setup-bullet-desc {
+	margin-top: 2px;
+	color: var(--text-muted);
+	font-size: 0.88em;
+	line-height: 1.45;
+}
+
+/* ---- Option tiles ---- */
+.hearth-setup-options {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+	gap: 10px;
+}
+
+.hearth-setup-option {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 12px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 10px;
+	background: var(--background-primary);
+	cursor: pointer;
+	transition: border-color 120ms ease, background 120ms ease;
+}
+
+.hearth-setup-option:hover {
+	background: var(--background-modifier-hover);
+}
+
+.hearth-setup-option.is-selected {
+	border-color: var(--interactive-accent);
+	background: var(--background-modifier-hover);
+}
+
+.hearth-setup-option-icon {
+	display: inline-flex;
+	flex: none;
+	color: var(--text-muted);
+}
+
+.hearth-setup-option.is-selected .hearth-setup-option-icon {
+	color: var(--text-accent);
+}
+
+.hearth-setup-option-name {
+	font-weight: 600;
+	font-size: 0.92em;
+}
+
+.hearth-setup-option-desc {
+	margin-top: 3px;
+	color: var(--text-muted);
+	font-size: 0.82em;
+	line-height: 1.4;
+}
+
+/* A multi-select grid gets a checkmark on its chosen tiles: with several
+   selected at once, a border tint alone reads as "these are highlighted"
+   rather than "these are picked". */
+.hearth-setup-options.is-multi .hearth-setup-option.is-selected::after {
+	content: "✓";
+	margin-left: auto;
+	align-self: center;
+	color: var(--text-accent);
+	font-weight: 700;
+}
+
+/* ---- Integrations ---- */
+.hearth-setup-badge {
+	margin-left: 8px;
+	padding: 1px 7px;
+	border-radius: 999px;
+	background: var(--background-modifier-hover);
+	color: var(--text-accent);
+	font-size: 0.72em;
+	font-weight: 650;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	vertical-align: middle;
+}
+
+.hearth-setup-detected {
+	margin-top: 14px;
+	padding: 12px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 10px;
+	background: var(--background-secondary);
+}
+
+.hearth-setup-detected-title {
+	font-weight: 600;
+	font-size: 0.88em;
+	margin-bottom: 8px;
+}
+
+.hearth-setup-detected-list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.hearth-setup-detected-row {
+	display: flex;
+	justify-content: space-between;
+	gap: 12px;
+	font-size: 0.85em;
+}
+
+.hearth-setup-detected-key {
+	color: var(--text-muted);
+}
+
+.hearth-setup-detected-value {
+	font-family: var(--font-monospace);
+	color: var(--text-normal);
+	text-align: right;
+}
+
+/* ---- The board preview ---- */
+.hearth-setup-preview {
+	display: grid;
+	gap: 4px;
+	height: 190px;
+	padding: 8px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 10px;
+	background: var(--background-secondary);
+}
+
+.hearth-setup-preview-card {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 0;
+	padding: 2px 4px;
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 5px;
+	background: var(--background-primary);
+	overflow: hidden;
+}
+
+.hearth-setup-preview-label {
+	font-size: 0.68em;
+	color: var(--text-muted);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+/* ---- The plan list ---- */
+.hearth-setup-plan {
+	display: flex;
+	flex-direction: column;
+	margin-top: 12px;
+}
+
+.hearth-setup-plan-row {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 6px 0;
+	border-bottom: 1px solid var(--background-modifier-border);
+	font-size: 0.88em;
+}
+
+.hearth-setup-plan-row:last-child {
+	border-bottom: none;
+}
+
+.hearth-setup-plan-name {
+	font-weight: 550;
+}
+
+.hearth-setup-plan-why {
+	color: var(--text-faint);
+	font-size: 0.9em;
+	text-align: right;
+}
+
+/* ---- Footer ---- */
+.hearth-setup-foot {
+	flex: none;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	padding-top: 14px;
+	margin-top: 4px;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.hearth-setup-foot-right {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-left: auto;
+}
+
+.hearth-setup-skip {
+	background: none;
+	box-shadow: none;
+	color: var(--text-muted);
+}
+
+.hearth-setup-skip:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+@media (max-width: 620px) {
+	.hearth-setup {
+		height: min(78vh, 660px);
+	}
+
+	.hearth-setup-options {
+		grid-template-columns: 1fr;
+	}
+
+	/* The rail's labels are the first thing to go on a phone: the icons plus
+	   the step heading below already say where you are. */
+	.hearth-setup-rail-label {
+		display: none;
+	}
+
+	.hearth-setup-preview {
+		height: 140px;
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -9741,53 +9741,55 @@ body.hearth-dv-resizing {
 	color: var(--text-normal);
 }
 
-/* ---- The parting note ----
-   Set apart from the notes above it: this is the one paragraph on the step
-   that isn't about the board being built, and the point it makes — that the
-   board is a starting point and everything is yours to change — is the one
-   worth reading twice. An accent edge rather than a box, so it reads as the
-   wizard's closing word rather than another aside. */
-.hearth-setup-outro {
-	margin-top: 20px;
+/* ---- The customize callout ----
+   Leads the final step, above the board preview. Everything below it is a
+   picture, a list and two controls that end at a "Build my dashboard"
+   button, so a note placed after them is a note nobody reads — and the point
+   this one makes, that the board is a starting point and all of it is yours
+   to change, is the one that must land. Given the accent edge and a tinted
+   surface so it reads as the step's opening statement rather than an aside
+   that can be skimmed past. */
+.hearth-setup-callout {
+	margin: 0 0 18px;
 	padding: 14px 16px;
 	border-left: 3px solid var(--interactive-accent);
 	border-radius: 4px 10px 10px 4px;
 	background: var(--background-secondary);
 }
 
-.hearth-setup-outro-head {
+.hearth-setup-callout-head {
 	display: flex;
 	align-items: center;
 	gap: 8px;
 	margin-bottom: 8px;
 }
 
-.hearth-setup-outro-icon {
+.hearth-setup-callout-icon {
 	display: inline-flex;
 	color: var(--text-accent);
 }
 
-.hearth-setup-outro-icon .svg-icon {
+.hearth-setup-callout-icon .svg-icon {
 	width: 16px;
 	height: 16px;
 }
 
-.hearth-setup-outro-title {
+.hearth-setup-callout-title {
 	font-weight: 650;
 }
 
-.hearth-setup-outro-text {
+.hearth-setup-callout-text {
 	margin: 0 0 8px;
 	color: var(--text-muted);
 	font-size: 0.88em;
 	line-height: 1.55;
 }
 
-.hearth-setup-outro-text:last-of-type {
+.hearth-setup-callout-text:last-of-type {
 	margin-bottom: 0;
 }
 
-.hearth-setup-outro-hint {
+.hearth-setup-callout-hint {
 	margin-top: 10px;
 	padding-top: 10px;
 	border-top: 1px solid var(--background-modifier-border);

--- a/styles.css
+++ b/styles.css
@@ -9741,6 +9741,61 @@ body.hearth-dv-resizing {
 	color: var(--text-normal);
 }
 
+/* ---- The parting note ----
+   Set apart from the notes above it: this is the one paragraph on the step
+   that isn't about the board being built, and the point it makes — that the
+   board is a starting point and everything is yours to change — is the one
+   worth reading twice. An accent edge rather than a box, so it reads as the
+   wizard's closing word rather than another aside. */
+.hearth-setup-outro {
+	margin-top: 20px;
+	padding: 14px 16px;
+	border-left: 3px solid var(--interactive-accent);
+	border-radius: 4px 10px 10px 4px;
+	background: var(--background-secondary);
+}
+
+.hearth-setup-outro-head {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 8px;
+}
+
+.hearth-setup-outro-icon {
+	display: inline-flex;
+	color: var(--text-accent);
+}
+
+.hearth-setup-outro-icon .svg-icon {
+	width: 16px;
+	height: 16px;
+}
+
+.hearth-setup-outro-title {
+	font-weight: 650;
+}
+
+.hearth-setup-outro-text {
+	margin: 0 0 8px;
+	color: var(--text-muted);
+	font-size: 0.88em;
+	line-height: 1.55;
+}
+
+.hearth-setup-outro-text:last-of-type {
+	margin-bottom: 0;
+}
+
+.hearth-setup-outro-hint {
+	margin-top: 10px;
+	padding-top: 10px;
+	border-top: 1px solid var(--background-modifier-border);
+	color: var(--text-faint);
+	font-size: 0.82em;
+	line-height: 1.5;
+}
+
 @media (max-width: 620px) {
 	.hearth-setup {
 		height: min(78vh, 660px);

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -1,0 +1,615 @@
+import { describe, expect, it } from "vitest";
+import type { App } from "obsidian";
+import { detectSetup, taskNotesImport } from "../src/onboarding/detect";
+import {
+	applySetup,
+	defaultAnswers,
+	isUntouchedStarterBoard,
+	planCards,
+	SURFACE_PRESETS,
+	type SetupAnswers,
+} from "../src/onboarding/plan";
+import type { SetupDetection } from "../src/onboarding/detect";
+import { DEFAULT_SETTINGS, migrateSettings, type HomeSettings } from "../src/types";
+import { parseTaskNotesSettings } from "../src/tasknotes";
+
+/**
+ * The first-run setup wizard.
+ *
+ * The modal itself is Obsidian UI and stays untested (per the no-mocks rule),
+ * but everything it decides is pure: what the vault has, which cards that
+ * implies, where they land, and what changes in settings. That is what's
+ * covered here — including the two things a first impression actually hinges
+ * on, that the planned board never overlaps itself and that a TaskNotes vault
+ * gets a Tasks card configured with TaskNotes' *own* field names.
+ */
+
+// ---- Fixtures --------------------------------------------------------
+
+/** A settings object in the state a fresh install reaches `applySetup` in:
+ * defaults, plus the one starter dashboard `migrateSettings` builds. */
+function freshSettings(): HomeSettings {
+	const settings = structuredClone(DEFAULT_SETTINGS);
+	migrateSettings(settings, {});
+	return settings;
+}
+
+/** A detection snapshot with nothing found, unless overridden. */
+function emptyDetection(over: Partial<SetupDetection> = {}): SetupDetection {
+	return {
+		vaultName: "Notes",
+		integrations: [],
+		taskNotes: null,
+		basePath: null,
+		kanbanPath: null,
+		...over,
+	};
+}
+
+/** Answers with nothing selected, so each test opts in to exactly what it is
+ * about rather than inheriting the recommended defaults. */
+function blankAnswers(over: Partial<SetupAnswers> = {}): SetupAnswers {
+	return {
+		...defaultAnswers(freshSettings(), emptyDetection()),
+		purposes: [],
+		integrations: [],
+		...over,
+	};
+}
+
+/**
+ * A stand-in `App` exposing only what the detection pass reads. Same approach
+ * as the integrations catalogue's test: no Obsidian behaviour is simulated,
+ * just the shape of the registries the probes look at.
+ */
+function fakeApp(opts: {
+	enabled?: string[];
+	installed?: Record<string, string>;
+	core?: Record<string, boolean>;
+	files?: { path: string; extension: string; frontmatter?: Record<string, unknown> }[];
+	pluginSettings?: Record<string, unknown>;
+	vaultName?: string;
+}): App {
+	const files = opts.files ?? [];
+	return {
+		plugins: {
+			enabledPlugins: new Set(opts.enabled ?? []),
+			manifests: Object.fromEntries(
+				Object.entries(opts.installed ?? {}).map(([id, name]) => [id, { name }]),
+			),
+			plugins: opts.pluginSettings ?? {},
+		},
+		internalPlugins: {
+			getPluginById: (id: string) =>
+				id in (opts.core ?? {}) ? { instance: {}, enabled: opts.core![id] } : null,
+		},
+		vault: {
+			getName: () => opts.vaultName ?? "Notes",
+			getFiles: () => files,
+		},
+		metadataCache: {
+			getFileCache: (file: { path: string; frontmatter?: Record<string, unknown> }) =>
+				files.find((f) => f.path === file.path)?.frontmatter
+					? { frontmatter: files.find((f) => f.path === file.path)!.frontmatter }
+					: null,
+		},
+	} as unknown as App;
+}
+
+// ---- Reading TaskNotes' configuration --------------------------------
+
+describe("taskNotesImport", () => {
+	it("mirrors TaskNotes' remapped field names", () => {
+		const setup = parseTaskNotesSettings({
+			fieldMapping: { status: "state", due: "deadline", priority: "urgency" },
+		});
+
+		expect(taskNotesImport(setup)).toMatchObject({
+			statusField: "state",
+			dueField: "deadline",
+			priorityField: "urgency",
+		});
+	});
+
+	it("collects every status TaskNotes counts as complete", () => {
+		const setup = parseTaskNotesSettings({
+			customStatuses: [
+				{ value: "open", label: "Open", order: 0 },
+				{ value: "done", label: "Done", isCompleted: true, order: 2 },
+				{ value: "cancelled", label: "Cancelled", isCompleted: true, order: 3 },
+			],
+		});
+
+		const imported = taskNotesImport(setup);
+		expect(imported.doneStatuses).toEqual(["done", "cancelled"]);
+		// The single global done-value takes the first, in TaskNotes' own order.
+		expect(imported.doneValue).toBe("done");
+	});
+
+	it("falls back to a usable done-value when no status is marked complete", () => {
+		const imported = taskNotesImport(parseTaskNotesSettings({ customStatuses: [] }));
+
+		expect(imported.doneValue).toBe("done");
+		expect(imported.doneStatuses).toEqual([]);
+	});
+});
+
+// ---- Detection -------------------------------------------------------
+
+describe("detectSetup", () => {
+	it("offers only plugins that are installed and enabled", () => {
+		const detection = detectSetup(
+			fakeApp({
+				enabled: ["dataview"],
+				installed: { dataview: "Dataview", "obsidian-git": "Git" },
+			}),
+		);
+
+		expect(detection.integrations.map((i) => i.id)).toEqual(["dataview"]);
+	});
+
+	it("names an integration after its own manifest", () => {
+		const detection = detectSetup(
+			fakeApp({ enabled: ["tasknotes"], installed: { tasknotes: "TaskNotes (fork)" } }),
+		);
+
+		expect(detection.integrations[0].name).toBe("TaskNotes (fork)");
+	});
+
+	it("reads TaskNotes' settings off the running plugin", () => {
+		const detection = detectSetup(
+			fakeApp({
+				enabled: ["tasknotes"],
+				pluginSettings: {
+					tasknotes: {
+						settings: {
+							fieldMapping: { due: "deadline" },
+							customStatuses: [{ value: "shipped", isCompleted: true }],
+						},
+					},
+				},
+			}),
+		);
+
+		expect(detection.taskNotes?.fields.due).toBe("deadline");
+		expect(taskNotesImport(detection.taskNotes!).doneValue).toBe("shipped");
+	});
+
+	it("finds a Kanban board by its frontmatter, plugin or no plugin", () => {
+		const detection = detectSetup(
+			fakeApp({
+				files: [
+					{ path: "Notes/Plain.md", extension: "md" },
+					{ path: "Boards/Work.md", extension: "md", frontmatter: { "kanban-plugin": "board" } },
+				],
+			}),
+		);
+
+		expect(detection.kanbanPath).toBe("Boards/Work.md");
+		expect(detection.integrations.map((i) => i.id)).toContain("kanban");
+	});
+
+	it("does not offer Kanban alongside TaskNotes — one card has one source", () => {
+		const detection = detectSetup(
+			fakeApp({
+				enabled: ["tasknotes"],
+				files: [
+					{ path: "Boards/Work.md", extension: "md", frontmatter: { "kanban-plugin": "board" } },
+				],
+			}),
+		);
+
+		expect(detection.integrations.map((i) => i.id)).toContain("tasknotes");
+		expect(detection.integrations.map((i) => i.id)).not.toContain("kanban");
+	});
+
+	it("only offers a base when Bases is on and the vault has one", () => {
+		const files = [{ path: "Tables/Books.base", extension: "base" }];
+
+		expect(detectSetup(fakeApp({ files })).basePath).toBeNull();
+		expect(detectSetup(fakeApp({ files, core: { bases: true } })).basePath).toBe(
+			"Tables/Books.base",
+		);
+	});
+
+	it("survives an app whose internals are missing entirely", () => {
+		expect(() => detectSetup({} as App)).not.toThrow();
+		expect(detectSetup({} as App).integrations).toEqual([]);
+	});
+});
+
+// ---- Default answers -------------------------------------------------
+
+describe("defaultAnswers", () => {
+	it("seeds the title from the vault name", () => {
+		const answers = defaultAnswers(freshSettings(), emptyDetection({ vaultName: "Second Brain" }));
+
+		expect(answers.title).toBe("Second Brain");
+	});
+
+	it("pre-accepts only the recommended integrations", () => {
+		const answers = defaultAnswers(
+			freshSettings(),
+			emptyDetection({
+				integrations: [
+					{ id: "omnisearch", name: "Omnisearch", recommended: true },
+					{ id: "git", name: "Git", recommended: false },
+				],
+			}),
+		);
+
+		expect(answers.integrations).toEqual(["omnisearch"]);
+	});
+
+	it("assumes someone running a task plugin wants tasks on their board", () => {
+		const answers = defaultAnswers(
+			freshSettings(),
+			emptyDetection({
+				integrations: [{ id: "tasknotes", name: "TaskNotes", recommended: true }],
+			}),
+		);
+
+		expect(answers.purposes).toContain("tasks");
+	});
+});
+
+// ---- Planning the board ----------------------------------------------
+
+describe("planCards", () => {
+	const ids = (answers: SetupAnswers, detection = emptyDetection()): string[] =>
+		planCards(answers, detection, (i) => `c${i}`).map((p) => p.id);
+
+	it("always starts with a full-width clock", () => {
+		const [first] = planCards(blankAnswers(), emptyDetection(), (i) => `c${i}`);
+
+		expect(first.id).toBe("clock");
+		expect(first.card).toMatchObject({ kind: "clock", x: 0, y: 0, w: 12 });
+	});
+
+	it("adds a card group per chosen purpose", () => {
+		expect(ids(blankAnswers({ purposes: ["browsing"] }))).toEqual([
+			"clock",
+			"recent",
+			"favorites",
+		]);
+		expect(ids(blankAnswers({ purposes: ["insights"] }))).toEqual(["clock", "stats", "heatmap"]);
+	});
+
+	it("gives a planning board the full calendar and a journaling board the mini one", () => {
+		expect(ids(blankAnswers({ purposes: ["planning"] }))).toContain("schedule");
+		expect(ids(blankAnswers({ purposes: ["daily"] }))).toContain("calendar");
+		// Both chosen: the full calendar supersedes the mini one rather than
+		// stacking two calendars on one board.
+		const both = ids(blankAnswers({ purposes: ["daily", "planning"] }));
+		expect(both).toContain("schedule");
+		expect(both).not.toContain("calendar");
+	});
+
+	it("adds the Tasks card exactly once when a purpose and an integration both ask", () => {
+		const planned = ids(
+			blankAnswers({ purposes: ["tasks"], integrations: ["tasknotes"] }),
+			emptyDetection({ taskNotes: parseTaskNotesSettings({}) }),
+		);
+
+		expect(planned.filter((id) => id === "tasks")).toHaveLength(1);
+	});
+
+	it("configures the Tasks card for TaskNotes, completed statuses included", () => {
+		const detection = emptyDetection({
+			taskNotes: parseTaskNotesSettings({
+				customStatuses: [
+					{ value: "todo", order: 0 },
+					{ value: "done", isCompleted: true, order: 1 },
+					{ value: "cancelled", isCompleted: true, order: 2 },
+				],
+			}),
+		});
+
+		const tasks = planCards(
+			blankAnswers({ integrations: ["tasknotes"] }),
+			detection,
+			(i) => `c${i}`,
+		).find((p) => p.id === "tasks");
+
+		expect(tasks?.card.tasks).toEqual({
+			source: "tasknotes",
+			taskNotesDoneStatuses: ["done", "cancelled"],
+		});
+		expect(tasks?.reason).toBe("tasknotes");
+	});
+
+	it("points the Tasks card at the detected Kanban board", () => {
+		const tasks = planCards(
+			blankAnswers({ integrations: ["kanban"] }),
+			emptyDetection({ kanbanPath: "Boards/Work.md" }),
+			(i) => `c${i}`,
+		).find((p) => p.id === "tasks");
+
+		expect(tasks?.card.tasks).toEqual({
+			source: "kanban",
+			kanbanFile: "Boards/Work.md",
+			layout: "kanban",
+		});
+	});
+
+	it("embeds the detected base under its own name", () => {
+		const base = planCards(
+			blankAnswers({ integrations: ["bases"] }),
+			emptyDetection({ basePath: "Tables/Reading list.base" }),
+			(i) => `c${i}`,
+		).find((p) => p.id === "base");
+
+		expect(base?.card).toMatchObject({
+			kind: "embed",
+			target: "Tables/Reading list.base",
+			title: "Reading list",
+		});
+	});
+
+	it("lays every card out without overlapping, inside the grid", () => {
+		const planned = planCards(
+			blankAnswers({
+				purposes: ["daily", "tasks", "planning", "browsing", "capture", "insights", "reading", "ambience"],
+				integrations: ["dataview", "git", "bookmarks"],
+			}),
+			emptyDetection(),
+			(i) => `c${i}`,
+		);
+
+		expect(planned.length).toBeGreaterThan(10);
+		for (const { card } of planned) {
+			expect(card.x).toBeGreaterThanOrEqual(0);
+			expect(card.x + card.w).toBeLessThanOrEqual(12);
+		}
+		for (const a of planned) {
+			for (const b of planned) {
+				if (a === b) continue;
+				const overlaps =
+					a.card.x < b.card.x + b.card.w &&
+					a.card.x + a.card.w > b.card.x &&
+					a.card.y < b.card.y + b.card.h &&
+					a.card.y + a.card.h > b.card.y;
+				expect(overlaps, `${a.id} overlaps ${b.id}`).toBe(false);
+			}
+		}
+	});
+
+	it("gives every card a distinct id", () => {
+		const planned = planCards(
+			blankAnswers({ purposes: ["daily", "browsing", "insights"] }),
+			emptyDetection(),
+		);
+		const seen = new Set(planned.map((p) => p.card.id));
+
+		expect(seen.size).toBe(planned.length);
+	});
+});
+
+// ---- Applying the answers --------------------------------------------
+
+describe("applySetup", () => {
+	it("writes the chosen surface preset", () => {
+		const settings = freshSettings();
+		applySetup(settings, blankAnswers({ surface: "minimal" }), emptyDetection());
+
+		expect(settings).toMatchObject(SURFACE_PRESETS.minimal);
+	});
+
+	it("paints a flat colour at full strength rather than fading it", () => {
+		const settings = freshSettings();
+		applySetup(
+			settings,
+			blankAnswers({ background: "color", backgroundColor: "#102030" }),
+			emptyDetection(),
+		);
+
+		expect(settings.backgroundKind).toBe("color");
+		expect(settings.backgroundValue).toBe("#102030");
+		expect(settings.backgroundOpacity).toBe(1);
+		expect(settings.backgroundBlur).toBe(0);
+	});
+
+	it("falls back to the bundled wallpaper when a live sky has no place yet", () => {
+		const settings = freshSettings();
+		applySetup(settings, blankAnswers({ background: "weather", skyValue: "" }), emptyDetection());
+
+		expect(settings.backgroundKind).toBe("default");
+		expect(settings.backgroundOpacity).toBe(0.35);
+	});
+
+	it("keeps a weather background once a sky is picked", () => {
+		const settings = freshSettings();
+		applySetup(
+			settings,
+			blankAnswers({ background: "weather", skyValue: "fixed:clear:auto" }),
+			emptyDetection(),
+		);
+
+		expect(settings.backgroundKind).toBe("weather");
+		expect(settings.backgroundValue).toBe("fixed:clear:auto");
+	});
+
+	it("syncs the TaskNotes field mapping into settings", () => {
+		const settings = freshSettings();
+		const detection = emptyDetection({
+			taskNotes: parseTaskNotesSettings({
+				fieldMapping: { status: "state", due: "deadline", priority: "urgency" },
+				customStatuses: [{ value: "shipped", isCompleted: true }],
+			}),
+		});
+
+		applySetup(settings, blankAnswers({ integrations: ["tasknotes"] }), detection);
+
+		expect(settings).toMatchObject({
+			taskNotesStatusField: "state",
+			taskNotesDueField: "deadline",
+			taskNotesPriorityField: "urgency",
+			taskNotesDoneValue: "shipped",
+		});
+	});
+
+	it("switches the search engine only when Omnisearch is accepted", () => {
+		const declined = freshSettings();
+		applySetup(declined, blankAnswers(), emptyDetection());
+		expect(declined.searchEngine).toBe("builtin");
+
+		const accepted = freshSettings();
+		applySetup(accepted, blankAnswers({ integrations: ["omnisearch"] }), emptyDetection());
+		expect(accepted.searchEngine).toBe("omnisearch");
+	});
+
+	it("never turns an integration off — declining leaves settings alone", () => {
+		const settings = freshSettings();
+		settings.searchEngine = "omnisearch";
+		settings.customFileIcons = true;
+
+		applySetup(settings, blankAnswers({ integrations: [] }), emptyDetection());
+
+		expect(settings.searchEngine).toBe("omnisearch");
+		expect(settings.customFileIcons).toBe(true);
+	});
+
+	it("replaces the active board's cards when asked to replace", () => {
+		const settings = freshSettings();
+		const before = settings.dashboards[0].id;
+
+		const outcome = applySetup(
+			settings,
+			blankAnswers({ target: "replace", dashboardName: "Home", purposes: ["browsing"] }),
+			emptyDetection(),
+		);
+
+		expect(settings.dashboards).toHaveLength(1);
+		expect(settings.dashboards[0].id).toBe(before);
+		expect(settings.dashboards[0].name).toBe("Home");
+		expect(settings.dashboards[0].cards).toHaveLength(outcome.cardCount);
+		expect(outcome.replaced).toBe(true);
+	});
+
+	it("adds a board beside the existing one when asked for a new dashboard", () => {
+		const settings = freshSettings();
+		const original = settings.dashboards[0];
+		const originalCards = original.cards.length;
+
+		const outcome = applySetup(
+			settings,
+			blankAnswers({ target: "new", dashboardName: "Planning" }),
+			emptyDetection(),
+		);
+
+		expect(settings.dashboards).toHaveLength(2);
+		expect(original.cards).toHaveLength(originalCards);
+		expect(settings.activeDashboardId).toBe(outcome.dashboardId);
+		expect(settings.dashboards[1].name).toBe("Planning");
+	});
+
+	it("still builds a board when settings hold no dashboards at all", () => {
+		const settings = freshSettings();
+		settings.dashboards = [];
+
+		const outcome = applySetup(settings, blankAnswers({ target: "replace" }), emptyDetection());
+
+		expect(settings.dashboards).toHaveLength(1);
+		expect(outcome.replaced).toBe(false);
+		expect(settings.activeDashboardId).toBe(outcome.dashboardId);
+	});
+
+	it("lets a tall board scroll instead of squeezing it onto one screen", () => {
+		const settings = freshSettings();
+		applySetup(
+			settings,
+			blankAnswers({
+				target: "new",
+				purposes: [
+					"daily",
+					"tasks",
+					"planning",
+					"browsing",
+					"capture",
+					"insights",
+					"reading",
+					"ambience",
+				],
+			}),
+			emptyDetection(),
+		);
+
+		expect(settings.dashboards[1].fitToPage).toBe(false);
+		// The global default is untouched — only this board opts out.
+		expect(settings.fitToPage).toBe(true);
+	});
+
+	it("leaves a board that comfortably fits on fit-to-page", () => {
+		const settings = freshSettings();
+		applySetup(settings, blankAnswers({ target: "new", purposes: ["browsing"] }), emptyDetection());
+
+		expect(settings.dashboards[1].fitToPage).toBeUndefined();
+	});
+
+	it("records the run as done", () => {
+		const settings = freshSettings();
+		applySetup(settings, blankAnswers(), emptyDetection());
+
+		expect(settings.setupStatus).toBe("done");
+	});
+});
+
+// ---- Which board the wizard offers to replace ------------------------
+
+describe("isUntouchedStarterBoard", () => {
+	it("recognises the freshly seeded starter board", () => {
+		expect(isUntouchedStarterBoard(freshSettings())).toBe(true);
+	});
+
+	it("notices a card added or removed", () => {
+		const added = freshSettings();
+		added.dashboards[0].cards.push({ id: "card-mine", kind: "text", x: 0, y: 0, w: 2, h: 2 });
+		expect(isUntouchedStarterBoard(added)).toBe(false);
+
+		const removed = freshSettings();
+		removed.dashboards[0].cards.pop();
+		expect(isUntouchedStarterBoard(removed)).toBe(false);
+	});
+
+	it("does not count rearranging as making the board your own", () => {
+		const moved = freshSettings();
+		moved.dashboards[0].cards[0].x = 4;
+		moved.dashboards[0].cards[0].y = 9;
+
+		expect(isUntouchedStarterBoard(moved)).toBe(true);
+	});
+});
+
+// ---- Who gets offered the wizard -------------------------------------
+
+describe("setupStatus migration", () => {
+	it("offers the wizard to a vault with no persisted settings", () => {
+		const settings = structuredClone(DEFAULT_SETTINGS);
+		migrateSettings(settings, {});
+
+		expect(settings.setupStatus).toBe("pending");
+	});
+
+	it("never interrupts an existing vault that predates the wizard", () => {
+		const settings = structuredClone(DEFAULT_SETTINGS);
+		migrateSettings(settings, { title: "My vault", gridColumns: 12 });
+
+		expect(settings.setupStatus).toBe("done");
+	});
+
+	it("keeps a recorded status", () => {
+		const skipped = structuredClone(DEFAULT_SETTINGS);
+		skipped.setupStatus = "skipped";
+		migrateSettings(skipped, { setupStatus: "skipped" });
+
+		expect(skipped.setupStatus).toBe("skipped");
+	});
+
+	it("treats an unrecognised status as done rather than re-prompting", () => {
+		const settings = structuredClone(DEFAULT_SETTINGS);
+		settings.setupStatus = "nonsense" as HomeSettings["setupStatus"];
+		migrateSettings(settings, { setupStatus: "nonsense" });
+
+		expect(settings.setupStatus).toBe("done");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

A new install landed on a generic five-card starter board with a wallpaper nobody chose, and no indication that Hearth can read the user's tasks, calendar or repository. Everything was configurable; nothing was offered.

This adds a setup wizard that asks instead — a title and logo, a card style and background, what the vault is actually used for, how Hearth should behave on startup — and lays out a board from the answers.

**It looks before it asks.** Every supported plugin installed *and* enabled in that vault is offered on its own step, each with the single concrete thing accepting it will do. Nothing is installed, and nothing is changed inside the other plugin:

| Found | What accepting it does |
| --- | --- |
| **TaskNotes** | Tasks card on the TaskNotes source, using TaskNotes' own field names and completed statuses |
| **Kanban** | Tasks card showing the board as draggable columns (found by frontmatter, so it works whether or not the plugin is on) |
| **Dataview** / **Datacore** | A card, seeded with an editable query |
| **Git** | Git card with status, commit and sync |
| **Omnisearch** | Becomes the engine behind Hearth's search bar |
| **Iconic** / **Iconize** | Turns on the file icons already set |
| **Bases** | Embeds a `.base` from the vault |
| **Daily notes** / **Bookmarks** | Adds the matching card |

**TaskNotes is read properly, not merely noticed.** Its field names are remappable and its statuses user-defined, so the running plugin's own configuration is read — the status/due/priority properties and every status it counts as complete — and copied into both the card and Hearth's global mapping. The step shows what it found. A vault that renamed `due` to `deadline`, or treats "cancelled" as finished, gets a Tasks card that is right on its first render instead of one that silently shows nothing.

**Nothing is written until the last step**, which draws the board to scale and lists every card beside the answer that put it there.

### Re-runs never touch an existing board

The **Settings → About → Build a dashboard** button and the **Set up Hearth** command both run with `forceNewDashboard`: the result always arrives as a *new* dashboard and every board that already exists is left exactly as it is. The "replace" control isn't drawn at all on those runs — an option that is never selectable is noise — and the finish step states the guarantee outright instead. Only the first-run prompt offers to replace the untouched starter board, and "untouched" is judged by card identity, so rearranging the starter cards doesn't count as making it yours.

### Structure

Three modules under `src/onboarding/`, split by what they need:

- `detect.ts` — probes the vault once. Every probe is guarded; several read Obsidian internals a given version may not expose.
- `plan.ts` — pure. Answers + detection → cards (packed via the existing `ensureLayout`) and a settings patch. All the decisions live here, so all of them are tested.
- `wizard.ts` — Obsidian UI only. Seven steps, a progress rail, a per-step render backstop and `hearth*`-safe member naming (the #52 lesson).

### Judgement calls worth a look

- **Declining an integration never turns a setting off** — it just doesn't turn it on. A re-run that silently disabled things configured by hand since would be a trap.
- **A board over 16 grid rows gets `fitToPage: false`** as a per-dashboard override, so it scrolls at natural size rather than being scaled down to nothing. The global setting is untouched.
- **Existing vaults are never interrupted.** `migrateSettings` marks any install with saved settings as `done`, mirroring how `lastSeenVersion` tells a fresh install from an upgrade. Dismissing the wizard records `skipped`, so it cannot nag.

## Related issue

None — raised directly.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault

`npm run typecheck`, `npm run lint` (no new warnings) and `npm run build` all pass; 713 tests pass, 42 of them new in `test/onboarding.test.ts` covering detection, planning, layout non-overlap, the TaskNotes import and the settings migration. **Not yet exercised in a real vault** — the wizard's own rendering is Obsidian UI and stays untested per the no-mocks rule, so the modal itself wants a manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGwM6tsHSyrEu4Lz4h9zJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGwM6tsHSyrEu4Lz4h9zJQ)_