### PR TITLE
Customize Hearth's tab title and icon, and the title icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,23 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   leaves the *layout* alone: a bannered board keeps its banner, so toggling the
   mode no longer moves every card on it.
 
+- **Lucide icons for the tab and the title.** Hearth's crystal is no longer the
+  only mark it can wear. **Appearance → Home → Tab icon** picks any Lucide icon
+  for Hearth's tab header and ribbon button, and **Title icon** does the same for
+  the icon beside the big title on the board. Leave either empty and nothing
+  changes: the crystal, and the emoji/text logo, stay exactly as they were.
+
+  **Each dashboard can set its own title icon**, under **Header → Title icon** in
+  that board's settings — one board a flame, the next a rocket, or one board back
+  to the plain logo text while the vault-wide setting shows an icon.
+
+  **Every icon field is now a picker.** Type an id if you know it, or press the
+  magnifier and search the whole Lucide set with each icon drawn beside its name;
+  a preview beside the field shows what you'll get. That applies to the dashboard
+  switcher's icon too, which until now was an id typed from memory. An id that
+  names no icon falls back — to the crystal, the logo text, or the switcher's
+  number — rather than leaving a blank where the icon should be.
+
 - **A slideshow card.** **Notes & files → Slideshow** is the image embed with
   more than one picture: it shows them in turn, on a timer you set. Choose the
   pictures one by one — each can carry its own caption, and the list can be

--- a/README.md
+++ b/README.md
@@ -231,10 +231,10 @@ calls**.
 - **Edge-merging** — snap two cards together and their shared border drops out,
   so the pair reads as one continuous tile.
 - **Multiple dashboards** — a `[1] [2] [+]` switcher in the top-left. Name each
-  board, give it an emoji, reorder by dragging, and override the global width,
-  columns, row height and background per board. Open a board's settings either
-  from **Dashboard settings** in the **Arrange** toolbar or by right-clicking
-  its switcher button.
+  board, give it an emoji or a Lucide icon, reorder by dragging, and override
+  the global width, columns, row height, background and title icon per board.
+  Open a board's settings either from **Dashboard settings** in the **Arrange**
+  toolbar or by right-clicking its switcher button.
 - **Pinned cards** — pin a card to appear on every dashboard, sharing one
   definition and position.
 - **Fit to page** — lock the board to one screen or let it scroll.
@@ -262,6 +262,11 @@ calls**.
 - **Card corner radius** — from the default 14 px down to sharp 0 px.
 - **Per-card colors** — an accent and a background tint for any card.
 - **Title, logo and compact spacing** for the dashboard header.
+- **Lucide icons** — pick any icon from the Lucide set for Hearth's **tab and
+  ribbon** button and for the **title** beside the board's heading, searched
+  from a picker rather than typed from memory. Each dashboard can override the
+  title icon, so one board can show a flame and the next a rocket; leave a field
+  empty and the Hearth crystal (or your emoji logo) stays as it was.
 
 ## Mobile
 

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -22,6 +22,7 @@ import {
 	newDashboardId,
 } from "./types";
 import { cloneCard } from "./cards";
+import { addIconPicker, renderIcon } from "./lucide";
 import { configuredPlaces, renderSkySource } from "./placepicker";
 import { formatSkyValue, parseSkyValue } from "./sky";
 import { confirmAction } from "./ui";
@@ -58,11 +59,9 @@ export function renderDashboardSwitcher(
 		const btn = bar.createEl("button", {
 			cls: "hearth-dash-btn",
 		});
-		if (lucide) {
-			setIcon(btn, lucide);
-		} else {
-			btn.setText(icon || String(i + 1));
-		}
+		// An icon id that names nothing renderable falls through to the emoji or
+		// the number, so a mistyped id never leaves a blank switcher button.
+		if (!renderIcon(btn, lucide)) btn.setText(icon || String(i + 1));
 		const active = d.id === s.activeDashboardId;
 		btn.toggleClass("is-active", active);
 		if (active) btn.setAttribute("aria-current", "true");
@@ -315,18 +314,17 @@ class DashboardSettingsModal extends HearthTabbedModal {
 				}),
 			);
 
-		new Setting(containerEl)
-			.setName(t().dashboards.modal.switcherLucide)
-			.setDesc(t().dashboards.modal.switcherLucideDesc)
-			.addText((tx) =>
-				tx
-					.setPlaceholder(t().dashboards.modal.lucidePlaceholder)
-					.setValue(dash.iconLucide ?? "")
-					.onChange((v) => {
-						dash.iconLucide = v.trim() || undefined;
-						this.commit();
-					}),
-			);
+		addIconPicker(
+			new Setting(containerEl)
+				.setName(t().dashboards.modal.switcherLucide)
+				.setDesc(t().dashboards.modal.switcherLucideDesc),
+			this.view.app,
+			dash.iconLucide ?? "",
+			(v) => {
+				dash.iconLucide = v || undefined;
+				this.commit();
+			},
+		);
 
 		new Setting(containerEl)
 			.setName(t().dashboards.modal.mobileDefault)
@@ -479,6 +477,18 @@ class DashboardSettingsModal extends HearthTabbedModal {
 			},
 		);
 
+		this.overrideHeaderIcon(
+			containerEl,
+			t().dashboards.modal.logoIcon,
+			t().dashboards.modal.logoIconDesc,
+			header?.logoIcon,
+			s.logoIcon,
+			(v) => {
+				this.setHeaderOverride("logoIcon", v);
+				this.commit();
+			},
+		);
+
 		new Setting(containerEl)
 			.setName(t().dashboards.modal.titleAlign)
 			.setDesc(t().dashboards.modal.titleAlignDesc)
@@ -583,6 +593,42 @@ class DashboardSettingsModal extends HearthTabbedModal {
 					set(v);
 				}),
 			);
+		}
+	}
+
+	/**
+	 * The icon counterpart of {@link overrideHeaderText}: a toggle that takes the
+	 * board off the global icon, and — once it has — a full Lucide picker.
+	 *
+	 * Turning the toggle on seeds the override with whatever the global icon is,
+	 * so the board starts from the look it already had; clearing the picker
+	 * leaves an empty override, which is a board that deliberately shows no
+	 * Lucide icon while the global setting has one.
+	 */
+	private overrideHeaderIcon(
+		containerEl: HTMLElement,
+		name: string,
+		desc: string,
+		current: string | undefined,
+		fallback: string,
+		set: (value: string | undefined) => void,
+	): void {
+		const overriding = current !== undefined;
+		const row = new Setting(containerEl)
+			.setName(name)
+			.setDesc(
+				overriding
+					? desc
+					: t().dashboards.modal.usingDefaultText(fallback || "∅"),
+			)
+			.addToggle((tg) =>
+				tg.setValue(overriding).onChange((v) => {
+					set(v ? fallback : undefined);
+					this.render();
+				}),
+			);
+		if (overriding) {
+			addIconPicker(row, this.view.app, current, (v) => set(v));
 		}
 	}
 

--- a/src/fileicons.ts
+++ b/src/fileicons.ts
@@ -1,5 +1,6 @@
-import { getIconIds, setIcon, TFile, type App, type TAbstractFile } from "obsidian";
+import { setIcon, TFile, type App, type TAbstractFile } from "obsidian";
 import { iconForFile } from "./filetypes";
+import { knownIconIds } from "./lucide";
 import { type HomeSettings } from "./types";
 
 /**
@@ -159,27 +160,6 @@ export function iconicIconForPath(fileIcons: unknown, path: string): string | nu
 
 // ---- Reading the plugins ------------------------------------------------
 
-/**
- * The set of icon ids Obsidian has registered, memoized by list length.
- *
- * `getIconIds()` allocates a fresh array of ~1,700 entries, which is too much
- * to redo for every file in a card. Length is a good enough cache key: the list
- * only grows, and only when a plugin calls `addIcon`.
- */
-let knownIconIds: { size: number; ids: Set<string> } | null = null;
-
-function knownIcons(): Set<string> {
-	try {
-		const ids = getIconIds();
-		if (!knownIconIds || knownIconIds.size !== ids.length) {
-			knownIconIds = { size: ids.length, ids: new Set(ids) };
-		}
-		return knownIconIds.ids;
-	} catch {
-		return new Set();
-	}
-}
-
 /** Iconic's plugin instance keeps its settings — including the path→icon map —
  * on the instance itself. */
 function iconicIcon(app: App, path: string): string | null {
@@ -261,7 +241,7 @@ export function resolveFileIcon(
 			iconizeIcon(app, path) ??
 			frontmatterIcon(app, file, opts.frontmatterProperty);
 		if (!raw) return fallback;
-		const ids = knownIcons();
+		const ids = knownIconIds();
 		return normalizeStoredIcon(raw, (id) => ids.has(id)) ?? fallback;
 	} catch {
 		// Both plugins' internals are private; a shape change must cost the user

--- a/src/header.ts
+++ b/src/header.ts
@@ -2,6 +2,7 @@ import { type Component, Platform, setIcon } from "obsidian";
 import type { HomeView } from "./view";
 import { SearchSection } from "./search";
 import { hearthIconIdFor } from "./icon";
+import { resolveIconId } from "./lucide";
 import {
 	effectiveHeaderAlign,
 	effectiveHeaderLogoScale,
@@ -9,6 +10,7 @@ import {
 	effectiveHeaderSpacingBelow,
 	effectiveHeaderTitleScale,
 	effectiveLogo,
+	effectiveLogoIcon,
 	effectiveShowSearch,
 	effectiveShowTitle,
 	effectiveTitle,
@@ -52,10 +54,16 @@ export function renderHeader(view: HomeView, container: HTMLElement, component: 
 			titleRow.style.setProperty("--hearth-title-margin-top", `${marginTop}px`);
 		}
 
+		// Three ways to mark the title, in order: a Lucide icon (global, or this
+		// board's override), a custom emoji/text logo shown verbatim, or the
+		// Hearth crystal as the fallback brand mark. An unknown Lucide id draws
+		// nothing, so it falls through rather than leaving an empty slot.
 		const logo = effectiveLogo(s).trim();
-		// A custom emoji/text logo is shown verbatim; otherwise fall back to the
-		// Hearth crystal icon as the brand mark.
-		if (logo === "") {
+		const lucideId = resolveIconId(effectiveLogoIcon(s));
+		if (lucideId) {
+			const logoEl = titleRow.createSpan({ cls: "hearth-logo hearth-logo-icon" });
+			setIcon(logoEl, lucideId);
+		} else if (logo === "") {
 			const logoEl = titleRow.createSpan({ cls: "hearth-logo hearth-logo-icon" });
 			setIcon(logoEl, hearthIconIdFor(target));
 		} else {

--- a/src/icon.ts
+++ b/src/icon.ts
@@ -13,6 +13,8 @@
  *
  * The content is sized to Obsidian's 0 0 100 100 icon viewBox.
  */
+import { resolveIconId } from "./lucide";
+
 export const HEARTH_ICON_ID = "hearth-crystal";
 export const HEARTH_ICON_THEMED_ID = "hearth-crystal-themed";
 
@@ -32,4 +34,20 @@ export const HEARTH_ICON_THEMED_SVG = `<path fill="currentColor" d="${FACETS_INS
  * icon follows the theme, the brand-purple mark otherwise. */
 export function hearthIconIdFor(target: "none" | "icon" | "title" | "both"): string {
 	return target === "icon" || target === "both" ? HEARTH_ICON_THEMED_ID : HEARTH_ICON_ID;
+}
+
+/**
+ * The icon for Hearth's tab header and ribbon button: the user's chosen Lucide
+ * icon, or the crystal when they haven't chosen one.
+ *
+ * The chosen id is resolved against the icons Obsidian actually has, so a typo
+ * in the setting shows the crystal rather than a blank tab — a tab with no icon
+ * at all is much harder to notice, and much harder to undo, than one that
+ * simply didn't change.
+ */
+export function tabIconIdFor(
+	target: "none" | "icon" | "title" | "both",
+	custom: string | undefined,
+): string {
+	return resolveIconId(custom) ?? hearthIconIdFor(target);
 }

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -144,6 +144,8 @@ export function exportSettings(s: HomeSettings): string {
 		title: s.title,
 		showTitle: s.showTitle,
 		logo: s.logo,
+		logoIcon: s.logoIcon,
+		tabIcon: s.tabIcon,
 		showSearch: s.showSearch,
 		searchPlaceholder: s.searchPlaceholder,
 		showNewNoteButton: s.showNewNoteButton,
@@ -1012,6 +1014,10 @@ function sanitizeDashboard(
 		if (title !== undefined) header.title = title;
 		const logo = str(h.logo);
 		if (logo !== undefined) header.logo = logo;
+		// Kept even when empty: an empty override is a board that deliberately
+		// shows no Lucide title icon, which is not the same as no override.
+		const logoIcon = str(h.logoIcon);
+		if (logoIcon !== undefined) header.logoIcon = logoIcon.trim();
 		if (h.align === "left" || h.align === "center" || h.align === "right") {
 			header.align = h.align;
 		}
@@ -1273,6 +1279,10 @@ function applySettings(s: HomeSettings, data: Record<string, unknown>): void {
 	if (typeof data.showTitle === "boolean") s.showTitle = data.showTitle;
 	const logo = str(data.logo);
 	if (logo !== undefined) s.logo = logo;
+	const logoIcon = str(data.logoIcon);
+	if (logoIcon !== undefined) s.logoIcon = logoIcon.trim();
+	const tabIcon = str(data.tabIcon);
+	if (tabIcon !== undefined) s.tabIcon = tabIcon.trim();
 	if (typeof data.showSearch === "boolean") s.showSearch = data.showSearch;
 	const searchPlaceholder = str(data.searchPlaceholder);
 	if (searchPlaceholder !== undefined) s.searchPlaceholder = searchPlaceholder;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -406,6 +406,10 @@ export const en = {
 		noteToFavorite: "Pick a note to favorite…",
 		folder: "Pick a folder…",
 		image: "Pick an image…",
+		icon: "Search Lucide icons…",
+		iconPlaceholder: "Lucide icon id",
+		iconBrowse: "Browse Lucide icons",
+		iconClear: "Clear icon",
 	},
 
 	// ---- Dashboard toolbar & card controls -----------------------------
@@ -460,8 +464,7 @@ export const en = {
 				"An emoji or short text shown on the switcher button. Empty = number.",
 			switcherLucide: "Switcher Lucide icon",
 			switcherLucideDesc:
-				"A Lucide icon id (e.g. “home”, “star”, “layout-dashboard”). Takes precedence over the emoji above.",
-			lucidePlaceholder: "home",
+				"A Lucide icon (e.g. “home”, “star”, “layout-dashboard”) — browse the set, or type an id. Takes precedence over the emoji above.",
 			linkedWorkspace: "Linked workspace",
 			linkedWorkspaceDesc:
 				"Auto-switch to this dashboard when this workspace loads. Requires the core Workspaces plugin.",
@@ -488,6 +491,9 @@ export const en = {
 			logoText: "Logo text",
 			logoTextDesc:
 				"Override the global logo for this dashboard. Empty uses the Hearth crystal icon.",
+			logoIcon: "Title icon",
+			logoIconDesc:
+				"A Lucide icon drawn beside this dashboard's title instead of the logo text. Clear it to show the logo text (or the Hearth crystal) on this board alone.",
 			titleAlign: "Title alignment",
 			titleAlignDesc:
 				"Align only the title/logo block. The search bar keeps its own layout.",
@@ -603,7 +609,8 @@ export const en = {
 			lowPowerDesc:
 				"Trade the visual effects for battery life and smoothness on slower hardware.",
 			home: "Home",
-			homeDesc: "Title, logo, search visibility and overall content width.",
+			homeDesc:
+				"Title, logo, title and tab icons, search visibility and overall content width.",
 			searchBar: "Search bar",
 			searchBarDesc: "How the search field looks and what it does.",
 			grid: "Grid & spacing",
@@ -667,6 +674,15 @@ export const en = {
 			logo: "Logo",
 			logoDesc:
 				"An emoji or short text shown next to the title. Leave empty for the Hearth crystal icon.",
+			logoIcon: "Title icon",
+			logoIconDesc:
+				"A Lucide icon drawn next to the title instead of the logo text. " +
+				"Browse the set or type an id; leave empty to keep the logo text. " +
+				"Each dashboard can override it in its own settings.",
+			tabIcon: "Tab icon",
+			tabIconDesc:
+				"A Lucide icon for Hearth's tab header and ribbon button, in place of " +
+				"the Hearth crystal. Browse the set or type an id; leave empty for the crystal.",
 			themeColorTarget: "Follow theme icon color",
 			themeColorTargetDesc:
 				"Draw the crystal icon and/or the title text in your theme's icon " +

--- a/src/lucide.ts
+++ b/src/lucide.ts
@@ -1,0 +1,202 @@
+import {
+	FuzzySuggestModal,
+	Setting,
+	getIconIds,
+	setIcon,
+	type App,
+	type FuzzyMatch,
+	type TextComponent,
+} from "obsidian";
+import { t } from "./i18n";
+
+/**
+ * Lucide icons as a first-class, user-pickable value.
+ *
+ * Obsidian ships the whole Lucide set and registers it with `addIcon`, so any
+ * icon is one `setIcon` call away — the hard part is letting a user *choose*
+ * one. Typing an id from memory only works if you already know the set, so
+ * everything here exists to make an icon field a browsable picker with a live
+ * preview: the dashboard switcher icon, the tab icon, and the title icons.
+ *
+ * Three shapes of icon id are in circulation and all of them have to work:
+ * Obsidian's registered form (`lucide-home`), the bare Lucide name (`home`,
+ * which is what plugins normally write and what Hearth stores), and whatever a
+ * user typed by hand — which may not name an icon at all. {@link resolveIconId}
+ * is the single place that reconciles them, so an unknown id degrades to "no
+ * icon" instead of an invisible, blank icon slot.
+ */
+
+/** Obsidian's prefix on the icon ids it registers the Lucide set under. */
+const LUCIDE_PREFIX = "lucide-";
+
+/**
+ * Every icon id Obsidian has registered, memoized by list length.
+ *
+ * `getIconIds()` allocates a fresh array of ~1,700 entries, which is too much
+ * to redo per file in a card or per keystroke in a picker. Length is a good
+ * enough cache key: the list only grows, and only when a plugin calls `addIcon`.
+ */
+let cache: { size: number; ids: Set<string> } | null = null;
+
+export function knownIconIds(): Set<string> {
+	try {
+		const ids = getIconIds();
+		if (!cache || cache.size !== ids.length) {
+			cache = { size: ids.length, ids: new Set(ids) };
+		}
+		return cache.ids;
+	} catch {
+		return new Set();
+	}
+}
+
+/**
+ * Pick the id `setIcon` should be handed for a stored icon value, or null when
+ * the value names nothing renderable.
+ *
+ * `isKnown` is injected so this stays pure and testable, and so the icon list is
+ * looked up once per render rather than once per lookup. An empty registry means
+ * the icon list is unavailable rather than that every icon is missing (tests,
+ * a future API change), so the raw value is trusted through instead of every
+ * icon silently disappearing — hence the `hasRegistry` flag.
+ */
+export function pickIconId(
+	raw: string | undefined,
+	isKnown: (id: string) => boolean,
+	hasRegistry = true,
+): string | null {
+	const value = raw?.trim();
+	if (!value) return null;
+	if (!hasRegistry) return value;
+	for (const candidate of [value, `${LUCIDE_PREFIX}${value}`]) {
+		if (isKnown(candidate)) return candidate;
+	}
+	return null;
+}
+
+/** Strip Obsidian's registration prefix, leaving the bare Lucide name that
+ * Hearth stores and that users recognise from lucide.dev. */
+export function bareIconName(id: string): string {
+	return id.startsWith(LUCIDE_PREFIX) ? id.slice(LUCIDE_PREFIX.length) : id;
+}
+
+/** {@link pickIconId} against the icons Obsidian actually has registered. */
+export function resolveIconId(raw: string | undefined): string | null {
+	const known = knownIconIds();
+	return pickIconId(raw, (id) => known.has(id), known.size > 0);
+}
+
+/** Draw a stored icon value into `el`, or leave it empty when the value names
+ * no icon Obsidian knows. Returns whether anything was drawn. */
+export function renderIcon(el: HTMLElement, raw: string | undefined): boolean {
+	const id = resolveIconId(raw);
+	if (!id) return false;
+	setIcon(el, id);
+	return true;
+}
+
+/**
+ * The names offered by the picker: the Lucide set, bare and sorted.
+ *
+ * Icons registered by plugins (Hearth's own crystal among them) are left out —
+ * they are not Lucide, they come and go with whatever plugins are enabled, and
+ * a board that referenced one would lose its icon the moment that plugin was
+ * disabled. Should Obsidian ever stop prefixing the set, every id is offered
+ * rather than an empty list.
+ */
+export function lucideIconNames(): string[] {
+	const ids = [...knownIconIds()];
+	const lucide = ids.filter((id) => id.startsWith(LUCIDE_PREFIX));
+	return (lucide.length > 0 ? lucide.map(bareIconName) : ids).sort((a, b) =>
+		a.localeCompare(b),
+	);
+}
+
+/** A fuzzy picker over the Lucide set, each row drawn as the icon beside its
+ * name so icons can be recognised rather than recalled. */
+export class LucideIconPickerModal extends FuzzySuggestModal<string> {
+	private onChoose: (name: string) => void;
+
+	constructor(app: App, onChoose: (name: string) => void) {
+		super(app);
+		this.onChoose = onChoose;
+		this.setPlaceholder(t().pickers.icon);
+	}
+
+	getItems(): string[] {
+		return lucideIconNames();
+	}
+
+	getItemText(name: string): string {
+		return name;
+	}
+
+	renderSuggestion(match: FuzzyMatch<string>, el: HTMLElement): void {
+		el.addClass("hearth-icon-suggestion");
+		renderIcon(el.createSpan("hearth-icon-suggestion-icon"), match.item);
+		el.createSpan({ cls: "hearth-icon-suggestion-name", text: match.item });
+	}
+
+	onChooseItem(name: string): void {
+		this.onChoose(name);
+	}
+}
+
+/**
+ * Turn a Setting row into a Lucide icon field: a live preview, a text input for
+ * anyone who knows the id they want, a Browse button opening
+ * {@link LucideIconPickerModal}, and a Clear button.
+ *
+ * The preview is created before the text input so it sits at the left of the
+ * control row, and it doubles as validation feedback — type an id that isn't an
+ * icon and the preview goes blank rather than the change silently doing nothing
+ * visible until the board is redrawn.
+ */
+export function addIconPicker(
+	setting: Setting,
+	app: App,
+	value: string,
+	onChange: (value: string) => void,
+): Setting {
+	const preview = setting.controlEl.createSpan({ cls: "hearth-icon-preview" });
+	let text: TextComponent | undefined;
+
+	const apply = (next: string) => {
+		const trimmed = next.trim();
+		preview.empty();
+		preview.toggleClass("is-empty", !renderIcon(preview, trimmed));
+		onChange(trimmed);
+	};
+
+	setting.addText((tx) => {
+		text = tx;
+		tx.setPlaceholder(t().pickers.iconPlaceholder)
+			.setValue(value)
+			.onChange((v) => apply(v));
+	});
+
+	setting.addExtraButton((b) =>
+		b
+			.setIcon("search")
+			.setTooltip(t().pickers.iconBrowse)
+			.onClick(() => {
+				new LucideIconPickerModal(app, (name) => {
+					text?.setValue(name);
+					apply(name);
+				}).open();
+			}),
+	);
+
+	setting.addExtraButton((b) =>
+		b
+			.setIcon("x")
+			.setTooltip(t().pickers.iconClear)
+			.onClick(() => {
+				text?.setValue("");
+				apply("");
+			}),
+	);
+
+	preview.toggleClass("is-empty", !renderIcon(preview, value));
+	return setting;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import {
 	HEARTH_ICON_SVG,
 	HEARTH_ICON_THEMED_ID,
 	HEARTH_ICON_THEMED_SVG,
-	hearthIconIdFor,
+	tabIconIdFor,
 } from "./icon";
 import type { WorkspacesInstance } from "./obsidian-ext";
 import { openFile } from "./opener";
@@ -73,7 +73,7 @@ export default class HearthPlugin extends Plugin {
 		this.registerView(VIEW_TYPE_HOME, (leaf) => new HomeView(leaf, this));
 
 		this.ribbonEl = this.addRibbonIcon(
-			hearthIconIdFor(this.settings.themeColorTarget),
+			this.brandIconId(),
 			t().ribbon.openHome,
 			() => this.activateView(),
 		);
@@ -372,10 +372,16 @@ export default class HearthPlugin extends Plugin {
 		this.refreshViews();
 	}
 
-	/** Re-apply the brand/themed crystal to the ribbon and open tab headers
-	 * after the themeColorTarget setting changes. */
+	/** The mark Hearth wears in the ribbon and on its tab: the user's Lucide tab
+	 * icon, or the brand/themed crystal. */
+	private brandIconId(): string {
+		return tabIconIdFor(this.settings.themeColorTarget, this.settings.tabIcon);
+	}
+
+	/** Re-apply the tab icon to the ribbon and open tab headers after the tab
+	 * icon or themeColorTarget setting changes. */
 	refreshBrandIcons() {
-		if (this.ribbonEl) setIcon(this.ribbonEl, hearthIconIdFor(this.settings.themeColorTarget));
+		if (this.ribbonEl) setIcon(this.ribbonEl, this.brandIconId());
 		this.app.workspace.getLeavesOfType(VIEW_TYPE_HOME).forEach((leaf) => {
 			// updateHeader is undocumented; when absent the tab icon simply
 			// refreshes the next time the leaf re-renders.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import type HearthPlugin from "./main";
 import { TaskFieldsModal } from "./cards/tasks";
 import { hasFileIconPlugin } from "./fileicons";
 import { FILE_TYPE_GROUPS, fileTypeLabel } from "./filetypes";
+import { addIconPicker } from "./lucide";
 import { CommandPickerModal } from "./pickers";
 import { configuredPlaces, renderSkySource } from "./placepicker";
 import { BANNER_HEIGHT_MAX, BANNER_HEIGHT_MIN, type BackgroundKind, type BackgroundLayout, CARD_BORDER_WIDTH_MAX, clampBannerHeight, DEFAULT_SETTINGS, defaultMobileActionButtons, type HomeSettings, LOW_POWER_BACKGROUND, type MobileActionButton, OPEN_IN_MODES, OPEN_SOURCES, type OpenIn, type OpenInRule, type OpenOutsideRule } from "./types";
@@ -612,6 +613,30 @@ export class HomeSettingTab extends PluginSettingTab {
 			});
 			this.addTextReset(logo, txt, "logo");
 		});
+
+		addIconPicker(
+			new Setting(containerEl)
+				.setName(t().settings.appearance.logoIcon)
+				.setDesc(t().settings.appearance.logoIconDesc),
+			this.app,
+			s.logoIcon,
+			(v) => {
+				s.logoIcon = v;
+				void this.save();
+			},
+		);
+
+		addIconPicker(
+			new Setting(containerEl)
+				.setName(t().settings.appearance.tabIcon)
+				.setDesc(t().settings.appearance.tabIconDesc),
+			this.app,
+			s.tabIcon,
+			(v) => {
+				s.tabIcon = v;
+				void this.save().then(() => this.plugin.refreshBrandIcons());
+			},
+		);
 
 		new Setting(containerEl)
 			.setName(t().settings.appearance.themeColorTarget)
@@ -1778,6 +1803,10 @@ export class HomeSettingTab extends PluginSettingTab {
 					return;
 				}
 				void this.save();
+				// An import can carry a different tab icon (or theme-color
+				// target), and neither the ribbon button nor an open tab header
+				// is redrawn by a settings save on its own.
+				this.plugin.refreshBrandIcons();
 				this.rerender();
 				new Notice(opts.imported);
 			},

--- a/src/types.ts
+++ b/src/types.ts
@@ -1390,6 +1390,11 @@ export interface DashboardHeaderConfig {
 	title?: string;
 	/** Override the global logo text/icon for this dashboard. Empty = Hearth icon. */
 	logo?: string;
+	/** Override the global title Lucide icon for this dashboard. A bare Lucide id
+	 * (`"flame"`), drawn instead of the logo text. An empty string is a real
+	 * override meaning "no icon on this board" — it falls back to the logo text,
+	 * not to the global icon; undefined follows the global setting. */
+	logoIcon?: string;
 	/** Align only the title/logo block; the search section below has its own
 	 * layout. */
 	align?: HeaderAlign;
@@ -1509,6 +1514,14 @@ export interface HomeSettings {
 	showTitle: boolean;
 	/** Emoji or short text shown as a logo next to the title. */
 	logo: string;
+	/** A Lucide icon id drawn as the title icon instead of the emoji/text logo
+	 * (`"flame"`, `"layout-dashboard"`). Empty = fall back to {@link logo}, and
+	 * to the Hearth crystal when that is empty too. Each dashboard can override
+	 * it — see {@link DashboardHeaderConfig.logoIcon}. */
+	logoIcon: string;
+	/** A Lucide icon id used for Hearth's tab header and ribbon button instead of
+	 * the Hearth crystal. Empty = the crystal. */
+	tabIcon: string;
 	/** What follows the theme's icon color: nothing (brand-purple crystal and
 	 * normal title text, the historical look), the crystal icon, the title
 	 * text, or both. */
@@ -1714,6 +1727,10 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	showTitle: true,
 	// Empty => the Hearth crystal icon is shown as the brand mark.
 	logo: "",
+	// Empty => no Lucide title icon; the logo text (or the crystal) is drawn.
+	logoIcon: "",
+	// Empty => the Hearth crystal is the tab and ribbon icon.
+	tabIcon: "",
 	themeColorTarget: "none",
 	showSearch: true,
 	searchPlaceholder: "Search or command",
@@ -1957,6 +1974,13 @@ export function effectiveTitle(s: HomeSettings): string {
 /** Logo text for the active board's title/logo block. Empty = Hearth icon. */
 export function effectiveLogo(s: HomeSettings): string {
 	return activeDashboard(s).header?.logo ?? s.logo;
+}
+
+/** Lucide title icon for the active board. Empty = none, so the logo text (or
+ * the Hearth crystal) is drawn instead. A board's own empty string wins over a
+ * global icon: that is how a single board opts back out of it. */
+export function effectiveLogoIcon(s: HomeSettings): string {
+	return activeDashboard(s).header?.logoIcon ?? s.logoIcon;
 }
 
 /** Alignment for the active board's title/logo block; search layout is separate. */

--- a/src/view.ts
+++ b/src/view.ts
@@ -15,7 +15,7 @@ import {
 	lowPowerActive,
 	renderCards,
 } from "./types";
-import { hearthIconIdFor } from "./icon";
+import { tabIconIdFor } from "./icon";
 import { hearthLeafIsNavigable } from "./opener";
 import { t } from "./i18n";
 
@@ -63,7 +63,8 @@ export class HomeView extends ItemView {
 	}
 
 	getIcon(): string {
-		return hearthIconIdFor(this.plugin.settings.themeColorTarget);
+		const s = this.plugin.settings;
+		return tabIconIdFor(s.themeColorTarget, s.tabIcon);
 	}
 
 	async onOpen(): Promise<void> {

--- a/styles.css
+++ b/styles.css
@@ -2431,6 +2431,53 @@
 	display: none;
 }
 
+/* ---- Lucide icon fields --------------------------------------------- */
+
+/* The live preview beside a Lucide icon field (settings, dashboard settings).
+   It keeps its box when empty so the row doesn't jump as icons come and go —
+   an unrecognised id simply leaves a dim, empty slot. */
+.hearth-icon-preview {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	flex: none;
+	border-radius: var(--radius-s, 4px);
+	color: var(--text-normal);
+	background: var(--background-modifier-form-field);
+}
+
+.hearth-icon-preview.is-empty {
+	background: transparent;
+	box-shadow: inset 0 0 0 1px var(--background-modifier-border);
+}
+
+.hearth-icon-preview svg {
+	width: 18px;
+	height: 18px;
+}
+
+/* A row in the Lucide icon picker: the icon itself, then its id. */
+.hearth-icon-suggestion {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.hearth-icon-suggestion-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text-muted);
+	flex: none;
+}
+
+.hearth-icon-suggestion-icon svg {
+	width: 18px;
+	height: 18px;
+}
+
 /* The small "?" help badge beside an icon field in the card editors (#119). */
 .hearth-icon-help {
 	display: inline-flex;

--- a/test/lucideicons.test.ts
+++ b/test/lucideicons.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { bareIconName, pickIconId } from "../src/lucide";
+import { HEARTH_ICON_ID, HEARTH_ICON_THEMED_ID, tabIconIdFor } from "../src/icon";
+import {
+	DEFAULT_SETTINGS,
+	effectiveLogo,
+	effectiveLogoIcon,
+	type HomeSettings,
+} from "../src/types";
+
+/**
+ * Lucide icons reach Hearth from three directions — a picker, a hand-typed id
+ * and an imported settings file — so what counts as "an icon" has to be decided
+ * in one place. These tests pin that decision: which id `setIcon` is handed,
+ * and what happens when the value names nothing.
+ */
+
+/** The registered ids Obsidian would report: the Lucide set is prefixed. */
+const REGISTERED = new Set(["lucide-flame", "lucide-star", "hearth-crystal"]);
+const isKnown = (id: string) => REGISTERED.has(id);
+
+describe("pickIconId", () => {
+	it("accepts a bare Lucide name and returns the registered id", () => {
+		expect(pickIconId("flame", isKnown)).toBe("lucide-flame");
+	});
+
+	it("accepts an already-prefixed id unchanged", () => {
+		expect(pickIconId("lucide-star", isKnown)).toBe("lucide-star");
+	});
+
+	it("accepts a plugin-registered id that carries no Lucide prefix", () => {
+		expect(pickIconId("hearth-crystal", isKnown)).toBe("hearth-crystal");
+	});
+
+	it("trims what the user typed", () => {
+		expect(pickIconId("  flame  ", isKnown)).toBe("lucide-flame");
+	});
+
+	it("rejects an empty value and one that names no icon", () => {
+		expect(pickIconId("", isKnown)).toBeNull();
+		expect(pickIconId(undefined, isKnown)).toBeNull();
+		expect(pickIconId("   ", isKnown)).toBeNull();
+		expect(pickIconId("not-an-icon", isKnown)).toBeNull();
+	});
+
+	it("trusts the value when the icon registry is unavailable", () => {
+		// An unreadable registry must not make every icon vanish — that would be
+		// indistinguishable from the user clearing them.
+		expect(pickIconId("flame", () => false, false)).toBe("flame");
+		expect(pickIconId("", () => false, false)).toBeNull();
+	});
+});
+
+describe("bareIconName", () => {
+	it("strips Obsidian's registration prefix and leaves anything else alone", () => {
+		expect(bareIconName("lucide-flame")).toBe("flame");
+		expect(bareIconName("hearth-crystal")).toBe("hearth-crystal");
+	});
+});
+
+describe("tabIconIdFor", () => {
+	it("falls back to the crystal — brand or themed — with no custom icon", () => {
+		expect(tabIconIdFor("none", "")).toBe(HEARTH_ICON_ID);
+		expect(tabIconIdFor("title", undefined)).toBe(HEARTH_ICON_ID);
+		expect(tabIconIdFor("icon", "")).toBe(HEARTH_ICON_THEMED_ID);
+		expect(tabIconIdFor("both", "   ")).toBe(HEARTH_ICON_THEMED_ID);
+	});
+
+	it("uses the custom icon when one is set", () => {
+		// The icon registry is unavailable under vitest, so a set value is trusted
+		// through — which is exactly the behaviour a user with a valid id sees.
+		expect(tabIconIdFor("none", "flame")).toBe("flame");
+		expect(tabIconIdFor("icon", " layout-dashboard ")).toBe("layout-dashboard");
+	});
+});
+
+function settings(): HomeSettings {
+	const s: HomeSettings = structuredClone(DEFAULT_SETTINGS);
+	s.dashboards = [
+		{ id: "d1", name: "Dashboard 1", cards: [] },
+		{ id: "d2", name: "Dashboard 2", cards: [] },
+	];
+	s.activeDashboardId = "d1";
+	return s;
+}
+
+describe("effectiveLogoIcon", () => {
+	it("is empty by default, so the logo text keeps its place", () => {
+		const s = settings();
+		expect(effectiveLogoIcon(s)).toBe("");
+		expect(effectiveLogo(s)).toBe(DEFAULT_SETTINGS.logo);
+	});
+
+	it("follows the global icon on a board with no override", () => {
+		const s = settings();
+		s.logoIcon = "flame";
+		expect(effectiveLogoIcon(s)).toBe("flame");
+	});
+
+	it("lets a board pick its own icon without touching the others", () => {
+		const s = settings();
+		s.logoIcon = "flame";
+		s.dashboards[0].header = { logoIcon: "rocket" };
+		expect(effectiveLogoIcon(s)).toBe("rocket");
+		s.activeDashboardId = "d2";
+		expect(effectiveLogoIcon(s)).toBe("flame");
+	});
+
+	it("treats an empty override as 'no icon on this board'", () => {
+		// Distinct from having no override at all: the board opts out of the
+		// global icon and shows the logo text (or the crystal) instead.
+		const s = settings();
+		s.logoIcon = "flame";
+		s.dashboards[0].header = { logoIcon: "" };
+		expect(effectiveLogoIcon(s)).toBe("");
+		s.activeDashboardId = "d2";
+		expect(effectiveLogoIcon(s)).toBe("flame");
+	});
+});

--- a/test/support/obsidian-shim.ts
+++ b/test/support/obsidian-shim.ts
@@ -72,9 +72,10 @@ export class TextComponent {}
 
 export function setIcon(): void {}
 export function addIcon(): void {}
-// fileicons.ts imports this for its icon-registry lookup. The pure helpers
-// under test take the "is this icon registered?" check as a parameter, so the
-// real registry is never consulted.
+// lucide.ts imports this for its icon-registry lookup (fileicons.ts and the
+// icon pickers go through it). The pure helpers under test take the "is this
+// icon registered?" check as a parameter, so the real registry is never
+// consulted; the throw is caught and read as "no registry available".
 export function getIconIds(): string[] {
 	throw new Error("getIconIds is not implemented in tests (Obsidian API)");
 }


### PR DESCRIPTION
## What does this PR do?

Hearth's tab was always called "Home" with a purple crystal beside it, and the one place a Lucide id was already accepted — the dashboard switcher — asked you to type it from memory. This makes all of that yours to set.

**Global — tab title.** `Appearance → Home → Tab title` names Hearth's tab whatever you like, in the tab header and anywhere else Obsidian lists an open view. Empty means the translated default — and so does whitespace, so the tab can't end up nameless. The field's placeholder shows the default, so the empty state reads as a choice.

**Global — tab icon.** `Appearance → Home → Tab icon` replaces the crystal on the tab header and the ribbon button (the two have always shared a mark and are refreshed together).

**Global — title icon.** `Appearance → Home → Title icon` draws a Lucide icon beside the big title instead of the emoji/text logo.

**Per dashboard — title icon.** The board's settings modal, `Header → Title icon`, following the existing override pattern: a toggle takes the board off the global (seeded with the global value, so it starts from the look it had), then a picker. An *empty* override is a real one — that board shows its logo text (or the crystal) while the vault-wide setting still shows an icon.

All three default to empty, so nothing changes for an existing vault until something is picked.

**The picker** (new `src/lucide.ts`): a live preview, a text input, a browse button that fuzzy-searches the whole Lucide set with each icon drawn beside its name, and a clear button. The dashboard switcher's `iconLucide` field now uses it too. Ids are resolved against the icons Obsidian actually has registered — bare (`flame`), prefixed (`lucide-flame`) or plugin-registered — so an id that names nothing falls back to the crystal, the logo text, or the switcher's number rather than leaving a blank slot. The memoized icon-id registry moved out of `fileicons.ts` so both paths share one cache.

Every setting travels through layout export/import (with the per-board `logoIcon`), and a settings import now refreshes the ribbon and open tab headers — which it previously didn't do even for `themeColorTarget`. `refreshBrandIcons` is renamed `refreshTabHeader`: it always redrew the whole tab header, and now the title depends on it too.

## Related issue

None — raised directly.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [x] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

`npm test` passes (729 tests; 17 new in `test/lucideicons.test.ts` covering id resolution, the tab-icon fallback, the tab-title default and the per-board override semantics) and `npm run lint` reports 0 errors — the 41 warnings are the pre-existing `setDynamicTooltip`/deprecation set, unchanged. Not yet exercised in a real vault; the picker, the previews and the live tab-header refresh are the parts worth a look there.
