### PR TITLE
Format an embedded picture, not just embed it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,25 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   digits (`-0xA`) rather than wrapping into two's complement at a bit width the
   card never asked you for.
 
+- **An embedded picture can be framed, not just embedded.** An image embed used
+  to render at whatever size the picture happened to be, in a box that scrolled
+  — a wide photo in a short card showed a sliver of itself. The embed card's
+  Content tab now offers the usual choices for any picture target, on the
+  primary view and the second view alike:
+
+  - **Fit the whole picture** — scaled down whole, letterboxed if it has to be.
+  - **Fill the card (crop)** — the whole card, edge to edge, cropping the
+    overflow.
+  - **Stretch to the card** — both edges pinned, aspect ratio be damned.
+  - **Fit the width (scroll)** — full width, its own height, scroll for the rest.
+  - **Original size** — what image embeds have always done, and still the
+    default, so no existing card changes.
+
+  **Picture position** anchors the picture to any of nine points, which is what
+  decides *which part* a crop keeps — a portrait cropped to a wide card can hold
+  onto the face instead of the middle. **Zoom** now works inside the frame too:
+  zooming a cropped picture crops in further rather than scrolling the box.
+
 - **A slideshow card.** **Notes & files → Slideshow** is the image embed with
   more than one picture: it shows them in turn, on a timer you set. Choose the
   pictures one by one — each can carry its own caption, and the list can be

--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ issue or email.
 
 - **Embed** — any note, image, canvas or `.base` file, rendered by Obsidian
   itself. Per-card zoom, optional in-place editing (raw or Live Preview), and a
-  second view you can flip to with a switcher.
+  second view you can flip to with a switcher. A picture can be framed as well
+  as embedded: fill the card and crop, fit the whole thing, stretch it, or fit
+  the width and scroll — with the crop anchored to any of nine points, and zoom
+  working inside the frame.
 - **Slideshow** — pictures from your vault, rotated on a timer. Pick them one by
   one (each with its own caption) or point the card at a folder, with or without
   its subfolders. Order by name, creation or modification date, your own list

--- a/src/cardbodies.ts
+++ b/src/cardbodies.ts
@@ -117,6 +117,8 @@ export function embedViews(card: DashboardCard): EmbedView[] {
 			target: card.target,
 			baseView: card.baseView,
 			scale: card.scale,
+			imageFit: card.imageFit,
+			imagePosition: card.imagePosition,
 			editable: card.editable,
 			livePreview: card.livePreview,
 		},

--- a/src/cards/embed.ts
+++ b/src/cards/embed.ts
@@ -14,11 +14,26 @@ import {
 	watchedCardPath,
 	wireMarkdownLinks,
 } from "../cardbodies";
-import { EXCALIDRAW_PLUGIN_ID, isExcalidraw } from "../filetypes";
+import {
+	EMBED_IMAGE_FITS,
+	EMBED_IMAGE_POSITIONS,
+	embedImageFit,
+	embedImagePosition,
+	embedImagePositionApplies,
+	embedImageScale,
+	embedImageStyle,
+	framesEmbedImage,
+} from "../embedimage";
+import { EXCALIDRAW_PLUGIN_ID, isExcalidraw, isImageFile, isImagePath } from "../filetypes";
 import { t } from "../i18n";
 import { openFile } from "../opener";
 import { FilePickerModal } from "../pickers";
-import { type DashboardCard, type EmbedView } from "../types";
+import {
+	type DashboardCard,
+	type EmbedImageFit,
+	type EmbedImagePosition,
+	type EmbedView,
+} from "../types";
 import { type HomeView } from "../view";
 import { type CardDefinition, type CardEditorContext } from "./definition";
 
@@ -104,15 +119,23 @@ export function renderEmbed(
 	// + filter/property controls) so only the results show. Scoped via a class on
 	// the host so it only affects this card's base embed.
 	if (ext === "base" && card.hideBaseHeader) host.addClass("hearth-embed-hide-base-header");
+	// A picture with a fit mode set is drawn by Hearth rather than transcluded,
+	// so it can be sized against the card (see renderFormattedImage). Zoom is
+	// part of that sizing there, which is why the host zoom below skips it.
+	const fit = isImageFile(file) ? embedImageFit(active) : "natural";
+	const framed = framesEmbedImage(fit);
+
 	// Optional zoom: scale the rendered content and widen it inversely so it
 	// still fills the card width before scaling (the body handles overflow).
-	const scale = active.scale && active.scale > 0 ? active.scale : 1;
-	if (scale !== 1) {
+	const scale = embedImageScale(active.scale);
+	if (scale !== 1 && !framed) {
 		host.addClass("is-scaled");
 		host.style.setProperty("--hearth-embed-scale", String(scale));
 	}
 
-	if (isMarkdown && !excalidraw) {
+	if (framed) {
+		renderFormattedImage(view, file, body, host, fit, embedImagePosition(active), scale);
+	} else if (isMarkdown && !excalidraw) {
 		// Render the note's actual content so all Markdown (headings, lists,
 		// callouts, links…) shows. A bare ![[embed]] only renders a placeholder
 		// outside a real Markdown view, which looks empty on the dashboard.
@@ -141,6 +164,48 @@ export function renderEmbed(
 			body.addClass("hearth-card-body-live");
 		}
 	}
+}
+
+
+/**
+ * Draw a picture that has been given a fit mode — "Fit the whole picture",
+ * "Fill the card", "Stretch to the card" or "Fit the width".
+ *
+ * These are the modes where the picture is sized against the card rather than
+ * against itself, and Obsidian's transclusion can't express them: it renders
+ * into wrappers of its own with their own margins, so there is no element to
+ * hang an `object-fit` on that reliably spans the card. Hearth therefore draws
+ * the `<img>` itself here — the picture gets the whole body, edge to edge, and
+ * the CSS does the rest from the custom properties set below.
+ *
+ * "natural" never reaches this function: it stays on the transclusion path it
+ * has always used, so an embed card nobody has formatted renders exactly as
+ * before.
+ */
+function renderFormattedImage(
+	view: HomeView,
+	file: TFile,
+	body: HTMLElement,
+	host: HTMLElement,
+	fit: EmbedImageFit,
+	position: EmbedImagePosition,
+	scale: number,
+): void {
+	// The body stops scrolling and drops its padding, exactly as it does for a
+	// canvas embed: the picture is the card's whole surface now, and a gutter
+	// around a "fill the card" picture would be a visible lie.
+	body.addClass("hearth-card-body-image");
+	host.addClass("hearth-embed-image", `is-fit-${fit}`);
+	for (const [prop, value] of Object.entries(embedImageStyle(fit, position, scale)))
+		host.style.setProperty(prop, value);
+
+	const img = host.createEl("img", { cls: "hearth-embed-img" });
+	img.src = view.app.vault.getResourcePath(file);
+	img.alt = file.basename;
+	// The picture is the card's surface here, not something to drag out of it —
+	// the native image drag would otherwise fight the card's own in arrange mode.
+	img.draggable = false;
+	img.decoding = "async";
 }
 
 
@@ -219,6 +284,91 @@ function renderEmbedOpenButton(view: HomeView, file: TFile, body: HTMLElement): 
 }
 
 
+/**
+ * The picture-formatting controls: how the picture fills the card, and — for
+ * the modes where that leaves it something to decide — where it sits.
+ *
+ * Shown only when the view's target names a picture, since every other file
+ * type ignores the fields. Shared by both embed views, so the second view
+ * formats its picture exactly like the primary one does.
+ */
+function imageFormatSettings(
+	ctx: CardEditorContext,
+	containerEl: HTMLElement,
+	target: string | undefined,
+	view: Pick<EmbedView, "imageFit" | "imagePosition">,
+): void {
+	if (!isImagePath(target)) return;
+	const strings = t().editors.embed;
+	const fit = embedImageFit(view);
+
+	new Setting(containerEl)
+		.setName(strings.imageFit)
+		.setDesc(strings.imageFitDesc)
+		.addDropdown((d) => {
+			for (const option of EMBED_IMAGE_FITS)
+				d.addOption(option, strings.imageFits[option]);
+			d.setValue(fit).onChange((v) => {
+				view.imageFit = v === "natural" ? undefined : (v as EmbedImageFit);
+				ctx.opts.save();
+				ctx.opts.rerender();
+				// The anchor control below only exists for some of the modes.
+				ctx.requestRender();
+			});
+		});
+
+	if (!embedImagePositionApplies(fit)) return;
+	new Setting(containerEl)
+		.setName(strings.imagePosition)
+		.setDesc(fit === "cover" ? strings.imagePositionCropDesc : strings.imagePositionDesc)
+		.addDropdown((d) => {
+			for (const option of EMBED_IMAGE_POSITIONS)
+				d.addOption(option, strings.imagePositions[option]);
+			d.setValue(embedImagePosition(view)).onChange((v) => {
+				view.imagePosition = v === "center" ? undefined : (v as EmbedImagePosition);
+				ctx.opts.save();
+				ctx.opts.rerender();
+			});
+		});
+}
+
+
+/** The zoom slider, shared by both embed views. Its description depends on what
+ * is being zoomed: a framed picture is scaled inside the frame it was fitted to
+ * (so zooming a cropped picture crops further), everything else is scaled as a
+ * whole with the card scrolling around it. */
+function zoomSetting(
+	ctx: CardEditorContext,
+	containerEl: HTMLElement,
+	target: string | undefined,
+	view: Pick<EmbedView, "imageFit" | "scale">,
+): void {
+	const framed = isImagePath(target) && framesEmbedImage(embedImageFit(view));
+	new Setting(containerEl)
+		.setName(t().editors.embed.zoom)
+		.setDesc(framed ? t().editors.embed.zoomImageDesc : t().editors.embed.zoomDesc)
+		.addSlider((s) => {
+			s.setLimits(50, 200, 10)
+				.setValue(Math.round((view.scale ?? 1) * 100))
+				.setDynamicTooltip()
+				.onChange((v) => {
+					view.scale = v === 100 ? undefined : v / 100;
+					ctx.opts.save();
+				});
+		})
+		.addExtraButton((b) =>
+			b
+				.setIcon("rotate-ccw")
+				.setTooltip(t().settings.resetSlider)
+				.onClick(() => {
+					view.scale = undefined;
+					ctx.opts.save();
+					ctx.requestRender();
+				}),
+		);
+}
+
+
 export function embedEditor(ctx: CardEditorContext, containerEl: HTMLElement): void {
 	const card = ctx.card;
 	const setting = new Setting(containerEl)
@@ -252,28 +402,8 @@ export function embedEditor(ctx: CardEditorContext, containerEl: HTMLElement): v
 			ctx.opts.save();
 		},
 	);
-	new Setting(containerEl)
-		.setName(t().editors.embed.zoom)
-		.setDesc(t().editors.embed.zoomDesc)
-		.addSlider((s) => {
-			s.setLimits(50, 200, 10)
-				.setValue(Math.round((card.scale ?? 1) * 100))
-				.setDynamicTooltip()
-				.onChange((v) => {
-					card.scale = v === 100 ? undefined : v / 100;
-					ctx.opts.save();
-				});
-		})
-		.addExtraButton((b) =>
-			b
-				.setIcon("rotate-ccw")
-				.setTooltip(t().settings.resetSlider)
-				.onClick(() => {
-					card.scale = undefined;
-					ctx.opts.save();
-					ctx.requestRender();
-				}),
-		);
+	imageFormatSettings(ctx, containerEl, card.target, card);
+	zoomSetting(ctx, containerEl, card.target, card);
 	new Setting(containerEl)
 		.setName(t().editors.embed.editable)
 		.setDesc(t().editors.embed.editableDesc)
@@ -323,7 +453,10 @@ export function setPrimaryEmbedTarget(ctx: CardEditorContext, value: string, rer
 	ctx.card.target = value;
 	if (!isBase || targetChanged) ctx.card.baseView = undefined;
 	ctx.opts.save();
-	if (rerender || wasBase !== isBase || (isBase && targetChanged))
+	// A picture brings the formatting controls with it, and loses them again
+	// when the target stops being one.
+	const imageChanged = isImagePath(previousTarget) !== isImagePath(nextTarget);
+	if (rerender || wasBase !== isBase || imageChanged || (isBase && targetChanged))
 		ctx.requestRender();
 }
 
@@ -442,28 +575,8 @@ export function embedSecondView(ctx: CardEditorContext, containerEl: HTMLElement
 				ctx.opts.save();
 			},
 		);
-		new Setting(containerEl)
-			.setName(t().editors.embed.zoom)
-			.setDesc(t().editors.embed.zoomDesc)
-			.addSlider((s) => {
-				s.setLimits(50, 200, 10)
-					.setValue(Math.round((view.scale ?? 1) * 100))
-					.setDynamicTooltip()
-					.onChange((v) => {
-						view.scale = v === 100 ? undefined : v / 100;
-						ctx.opts.save();
-					});
-			})
-			.addExtraButton((b) =>
-				b
-					.setIcon("rotate-ccw")
-					.setTooltip(t().settings.resetSlider)
-					.onClick(() => {
-						view.scale = undefined;
-						ctx.opts.save();
-						ctx.requestRender();
-					}),
-			);
+		imageFormatSettings(ctx, containerEl, view.target, view);
+		zoomSetting(ctx, containerEl, view.target, view);
 		new Setting(containerEl)
 			.setName(t().editors.embed.editable)
 			.setDesc(t().editors.embed.editableDesc)
@@ -496,7 +609,8 @@ export function setSecondViewTarget(ctx: CardEditorContext, value: string, reren
 		ctx.card.secondView = next;
 	}
 	ctx.opts.save();
-	if (rerender || wasBase !== isBase || (isBase && targetChanged))
+	const imageChanged = isImagePath(previousTarget) !== isImagePath(target);
+	if (rerender || wasBase !== isBase || imageChanged || (isBase && targetChanged))
 		ctx.requestRender();
 }
 

--- a/src/embedimage.ts
+++ b/src/embedimage.ts
@@ -1,0 +1,151 @@
+import type { EmbedImageFit, EmbedImagePosition, EmbedView } from "./types";
+
+/**
+ * The embed card's picture-formatting half: how an embedded image fills its
+ * card, where it sits, and what CSS that comes out as. Data in, data out — no
+ * vault, no DOM, no Obsidian imports — so all of it is unit-tested in
+ * test/embedimage.test.ts.
+ *
+ * It lives here rather than in `src/cards/embed.ts` for the same reason
+ * `slideshow.ts` does: the card module imports the settings-modal helpers,
+ * which import the card registry, which imports the card module — a cycle a
+ * test importing the card module directly walks straight into.
+ */
+
+/** The fit modes offered in the editor, in dropdown order. */
+export const EMBED_IMAGE_FITS: EmbedImageFit[] = [
+	"natural",
+	"contain",
+	"cover",
+	"stretch",
+	"width",
+];
+
+/** The nine anchor points, in dropdown order (reading order of a 3×3 grid). */
+export const EMBED_IMAGE_POSITIONS: EmbedImagePosition[] = [
+	"top-left",
+	"top",
+	"top-right",
+	"left",
+	"center",
+	"right",
+	"bottom-left",
+	"bottom",
+	"bottom-right",
+];
+
+/** The `object-position` / `transform-origin` value for each anchor point. */
+const POSITION_CSS: Record<EmbedImagePosition, string> = {
+	"top-left": "left top",
+	top: "center top",
+	"top-right": "right top",
+	left: "left center",
+	center: "center center",
+	right: "right center",
+	"bottom-left": "left bottom",
+	bottom: "center bottom",
+	"bottom-right": "right bottom",
+};
+
+/** Horizontal flex alignment per anchor point. `safe` so a picture wider than
+ * the card still starts at its left edge instead of overflowing both ways out
+ * of a centred flex line, which would put the start of it out of scroll reach. */
+const POSITION_JUSTIFY: Record<EmbedImagePosition, string> = {
+	"top-left": "flex-start",
+	top: "safe center",
+	"top-right": "safe flex-end",
+	left: "flex-start",
+	center: "safe center",
+	right: "safe flex-end",
+	"bottom-left": "flex-start",
+	bottom: "safe center",
+	"bottom-right": "safe flex-end",
+};
+
+/** Vertical flex alignment per anchor point (see POSITION_JUSTIFY on `safe`). */
+const POSITION_ALIGN: Record<EmbedImagePosition, string> = {
+	"top-left": "flex-start",
+	top: "flex-start",
+	"top-right": "flex-start",
+	left: "safe center",
+	center: "safe center",
+	right: "safe center",
+	"bottom-left": "safe flex-end",
+	bottom: "safe flex-end",
+	"bottom-right": "safe flex-end",
+};
+
+/** The fit mode a view is set to, falling back to "natural" for anything a
+ * hand-edited `data.json` (or an older Hearth) left behind. */
+export function embedImageFit(view: Pick<EmbedView, "imageFit">): EmbedImageFit {
+	const fit = view.imageFit;
+	return fit && EMBED_IMAGE_FITS.includes(fit) ? fit : "natural";
+}
+
+/** The anchor point a view is set to, falling back to the centre. */
+export function embedImagePosition(
+	view: Pick<EmbedView, "imagePosition">,
+): EmbedImagePosition {
+	const position = view.imagePosition;
+	return position && EMBED_IMAGE_POSITIONS.includes(position) ? position : "center";
+}
+
+/**
+ * Whether this fit mode frames the picture itself — i.e. whether Hearth draws
+ * the `<img>` and sizes it, rather than handing the file to Obsidian's own
+ * transclusion. False only for "natural", which is left exactly as it was
+ * before the formatting options existed.
+ */
+export function framesEmbedImage(fit: EmbedImageFit): boolean {
+	return fit !== "natural";
+}
+
+/**
+ * Whether the anchor point means anything for this fit mode. "stretch" pins
+ * all four edges to the card, so there is nothing left to position; "natural"
+ * isn't framed by Hearth at all.
+ */
+export function embedImagePositionApplies(fit: EmbedImageFit): boolean {
+	return fit === "contain" || fit === "cover" || fit === "width";
+}
+
+/**
+ * How a framed picture takes its zoom. The card's own `zoom` on the host is no
+ * use once the picture is sized against the card: zooming the host zooms the
+ * box the picture is being fitted *to*, which changes nothing at 100% height
+ * except overflow. So:
+ *
+ * - "scale" — the fitted picture is transformed about its anchor point, which
+ *   is what zooming into a cropped or letterboxed picture should do.
+ * - "width" — the picture is simply drawn wider than the card and the host
+ *   scrolls, because a transform wouldn't reflow the height that mode derives
+ *   from the width, leaving a gap under a shrunk picture.
+ * - "none" — "natural", which keeps the host zoom it always had.
+ */
+export function embedImageZoomMode(fit: EmbedImageFit): "none" | "scale" | "width" {
+	if (fit === "width") return "width";
+	return framesEmbedImage(fit) ? "scale" : "none";
+}
+
+/** The CSS custom properties a framed picture is drawn with. Returned as plain
+ * data so the mapping is testable without a DOM. */
+export function embedImageStyle(
+	fit: EmbedImageFit,
+	position: EmbedImagePosition,
+	scale: number,
+): Record<string, string> {
+	const anchor = embedImagePositionApplies(fit) ? position : "center";
+	const zoom = embedImageZoomMode(fit) === "none" ? 1 : embedImageScale(scale);
+	return {
+		"--hearth-embed-img-pos": POSITION_CSS[anchor],
+		"--hearth-embed-img-justify": POSITION_JUSTIFY[anchor],
+		"--hearth-embed-img-align": POSITION_ALIGN[anchor],
+		"--hearth-embed-img-scale": String(zoom),
+	};
+}
+
+/** A card's zoom factor, guarded against a missing, zero or nonsense value the
+ * slider can't produce but a hand-edited `data.json` can. */
+export function embedImageScale(scale: number | undefined): number {
+	return typeof scale === "number" && Number.isFinite(scale) && scale > 0 ? scale : 1;
+}

--- a/src/filetypes.ts
+++ b/src/filetypes.ts
@@ -65,6 +65,14 @@ export function isImageFile(file: TAbstractFile): file is TFile {
 	return file instanceof TFile && IMAGE_EXTENSIONS.has(file.extension.toLowerCase());
 }
 
+/** Whether this vault path names a picture. The path-based twin of
+ * `isImageFile`, for the card editors: a target is typed there as text and may
+ * not resolve to a file in the vault (yet) when the controls are drawn. */
+export function isImagePath(path: string | undefined): boolean {
+	const ext = /\.([^./\\]+)$/.exec((path ?? "").trim())?.[1];
+	return !!ext && IMAGE_EXTENSIONS.has(ext.toLowerCase());
+}
+
 /**
  * Excalidraw drawings are stored either as `*.excalidraw` files or, more
  * commonly with the Excalidraw plugin, as `*.excalidraw.md` notes. The latter

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -10,6 +10,8 @@ import {
 	type DashboardCard,
 	type DatacoreConfig,
 	type DataviewConfig,
+	type EmbedImageFit,
+	type EmbedImagePosition,
 	type GitConfig,
 	type HeatmapConfig,
 	type HomeSettings,
@@ -44,6 +46,7 @@ import {
 } from "./types";
 import { CARD_KINDS } from "./cards";
 import { isEmbeddableBaseViewName } from "./bases";
+import { EMBED_IMAGE_FITS, EMBED_IMAGE_POSITIONS } from "./embedimage";
 import {
 	SLIDESHOW_MAX_INTERVAL_SEC,
 	SLIDESHOW_MAX_TRANSITION_MS,
@@ -232,6 +235,21 @@ function sanitizeBaseViewName(raw: unknown): string | undefined {
 	return isEmbeddableBaseViewName(name) ? name : undefined;
 }
 
+/** An embed's picture-fit mode, or undefined when the import names one Hearth
+ * doesn't have (a newer file, or a hand-edited one). */
+function sanitizeImageFit(raw: unknown): EmbedImageFit | undefined {
+	return EMBED_IMAGE_FITS.includes(raw as EmbedImageFit)
+		? (raw as EmbedImageFit)
+		: undefined;
+}
+
+/** An embed's picture anchor point, or undefined when it isn't one of the nine. */
+function sanitizeImagePosition(raw: unknown): EmbedImagePosition | undefined {
+	return EMBED_IMAGE_POSITIONS.includes(raw as EmbedImagePosition)
+		? (raw as EmbedImagePosition)
+		: undefined;
+}
+
 function sanitizeEmbedView(
 	raw: unknown,
 ): DashboardCard["secondView"] | undefined {
@@ -243,6 +261,10 @@ function sanitizeEmbedView(
 	const baseView = sanitizeBaseViewName(r.baseView);
 	if (baseView !== undefined) view.baseView = baseView;
 	if (typeof r.scale === "number") view.scale = r.scale;
+	const imageFit = sanitizeImageFit(r.imageFit);
+	if (imageFit !== undefined) view.imageFit = imageFit;
+	const imagePosition = sanitizeImagePosition(r.imagePosition);
+	if (imagePosition !== undefined) view.imagePosition = imagePosition;
 	if (typeof r.editable === "boolean") view.editable = r.editable;
 	if (typeof r.livePreview === "boolean") view.livePreview = r.livePreview;
 	return view;
@@ -321,6 +343,10 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 	if (background !== undefined) card.background = background;
 	if (typeof r.count === "number") card.count = r.count;
 	if (typeof r.scale === "number") card.scale = r.scale;
+	const cardImageFit = sanitizeImageFit(r.imageFit);
+	if (cardImageFit !== undefined) card.imageFit = cardImageFit;
+	const cardImagePosition = sanitizeImagePosition(r.imagePosition);
+	if (cardImagePosition !== undefined) card.imagePosition = cardImagePosition;
 	if (typeof r.refreshSec === "number") card.refreshSec = r.refreshSec;
 	if (typeof r.editable === "boolean") card.editable = r.editable;
 	if (typeof r.livePreview === "boolean") card.livePreview = r.livePreview;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1276,6 +1276,34 @@ export const en = {
 			zoom: "Zoom",
 			zoomDesc:
 				"Scale the embedded content. Applies when you close this dialog.",
+			zoomImageDesc:
+				"Scale the picture inside the frame it was fitted to — zooming a " +
+				"cropped picture crops in further. Applies when you close this dialog.",
+			imageFit: "Picture fit",
+			imageFitDesc:
+				"How the picture fills the card. Every mode but the first hands it " +
+				"the whole card, edge to edge.",
+			imageFits: {
+				natural: "Original size",
+				contain: "Fit the whole picture",
+				cover: "Fill the card (crop)",
+				stretch: "Stretch to the card",
+				width: "Fit the width (scroll)",
+			},
+			imagePosition: "Picture position",
+			imagePositionDesc: "Where the picture sits in the card.",
+			imagePositionCropDesc: "Which part of the picture the crop keeps.",
+			imagePositions: {
+				"top-left": "Top left",
+				top: "Top",
+				"top-right": "Top right",
+				left: "Left",
+				center: "Center",
+				right: "Right",
+				"bottom-left": "Bottom left",
+				bottom: "Bottom",
+				"bottom-right": "Bottom right",
+			},
 			editable: "Editable",
 			editableDesc:
 				"Edit the embedded note's text in place (Markdown notes only).",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1008,6 +1008,30 @@ export interface MobileActionButton {
 	commandId?: string;
 }
 
+/**
+ * How an embedded picture fills its card.
+ *
+ * "natural" is the original behaviour and stays the default: Obsidian's own
+ * transclusion, the picture at its natural size in a scrolling box. The rest
+ * hand the picture the whole card body and differ in what gives — the crop
+ * ("cover"), the empty space ("contain"), the aspect ratio ("stretch") or the
+ * height ("width", which fills the width and scrolls).
+ */
+export type EmbedImageFit = "natural" | "contain" | "cover" | "stretch" | "width";
+
+/** Where a formatted picture sits in its card — and, when it is cropped, which
+ * part of it survives the crop. The nine points of a 3×3 grid. */
+export type EmbedImagePosition =
+	| "top-left"
+	| "top"
+	| "top-right"
+	| "left"
+	| "center"
+	| "right"
+	| "bottom-left"
+	| "bottom"
+	| "bottom-right";
+
 /** A secondary embed a card can switch to. Only `target` is required; `scale`
  * and `editable` mirror the primary embed's fields and default to that view's
  * behaviour when omitted. A card with a valid second view shows a switcher —
@@ -1020,6 +1044,12 @@ export interface EmbedView {
 	baseView?: string;
 	/** Zoom factor for the embedded content (1 = 100%); omitted means no scaling. */
 	scale?: number;
+	/** How an embedded picture fills the card; omitted means "natural" (the
+	 * picture at its own size). Ignored by every other file type. */
+	imageFit?: EmbedImageFit;
+	/** Where a formatted picture sits, and which part of it a crop keeps;
+	 * omitted means "center". Only read when `imageFit` frames the picture. */
+	imagePosition?: EmbedImagePosition;
 	/** Edit the embedded note's text in place instead of read-only (Markdown only). */
 	editable?: boolean;
 	/** Edit through Obsidian's own Live Preview editor rather than Hearth's plain
@@ -1211,6 +1241,16 @@ export interface DashboardCard {
 	 * Live Preview editor (hosted in the card) instead of Hearth's plain
 	 * raw-Markdown box. Only meaningful together with `editable`. */
 	livePreview?: boolean;
+
+	/** kind === "embed": how an embedded picture fills the card. Omitted means
+	 * "natural" — the picture at its own size, as Obsidian renders it. Ignored
+	 * for every other file type. */
+	imageFit?: EmbedImageFit;
+
+	/** kind === "embed": where a formatted picture sits in the card, and which
+	 * part of it survives a crop. Omitted means "center". Only read when
+	 * `imageFit` frames the picture. */
+	imagePosition?: EmbedImagePosition;
 
 	/** kind === "embed": an optional second view the card can switch to. When it
 	 * carries a target, a switcher toggles the body between the primary embed

--- a/styles.css
+++ b/styles.css
@@ -923,9 +923,9 @@
 	padding-inline: 0;
 }
 
-/* Read-only embed and jot hosts. `.hearth-embed-live` (canvas/Excalidraw) is
- * excluded — it's deliberately edge-to-edge and its body already zeroes all
- * padding.
+/* Read-only embed and jot hosts. `.hearth-embed-live` (canvas/Excalidraw) and
+ * `.hearth-embed-image` (a picture given a fit mode) are excluded — both are
+ * deliberately edge-to-edge and their bodies already zero all padding.
  *
  * The start gutter is sized from the hang itself rather than being a flat
  * number, because the hang has no upper bound. Obsidian computes
@@ -940,7 +940,8 @@
  * hang only widens it once it would otherwise eat in. The gutter is added on
  * top of the hang, not compared against it, so the checkbox keeps a full
  * gutter's clearance instead of landing flush against the clip edge. */
-.hearth-card-body.is-embed-host > .hearth-embed:not(.hearth-embed-live),
+.hearth-card-body.is-embed-host
+	> .hearth-embed:not(.hearth-embed-live):not(.hearth-embed-image),
 .hearth-card-body.is-jot-host .hearth-jot-preview {
 	padding-inline-start: max(
 		var(--hearth-card-pad-x),
@@ -1014,6 +1015,73 @@
  * desktop runtime) and modern WebKit (mobile) both support `zoom`. */
 .hearth-embed.is-scaled {
 	zoom: var(--hearth-embed-scale, 1);
+}
+
+/* ---- Formatted picture embeds --------------------------------------- */
+
+/* An image embed given a fit mode is drawn by Hearth as a bare <img> (see
+ * renderFormattedImage) and takes the whole card body, so the body drops its
+ * padding and its scrollbar the way a canvas embed's does — a gutter around a
+ * picture that says "fill the card" would be a visible lie, and the picture's
+ * own corners are clipped by the card's radius. */
+.hearth-card > .hearth-card-body.hearth-card-body-image {
+	overflow: hidden;
+	padding: 0;
+}
+
+/* The custom properties come from `embedImageStyle`: the anchor point, once as
+ * an `object-position` (which doubles as the zoom's transform origin) and once
+ * as flex alignment, plus the zoom factor. The flex alignment only bites in
+ * "fit the width", the one mode where the picture doesn't span both axes. */
+.hearth-embed.hearth-embed-image {
+	display: flex;
+	justify-content: var(--hearth-embed-img-justify, center);
+	align-items: var(--hearth-embed-img-align, center);
+	overflow: hidden;
+	padding: 0;
+}
+
+.hearth-embed-image .hearth-embed-img {
+	display: block;
+	width: 100%;
+	height: 100%;
+	max-width: none;
+	/* The card's own radius clips the picture; a second radius on a picture that
+	 * reaches the card's edge just cuts a notch out of the corner. */
+	border-radius: 0;
+	object-position: var(--hearth-embed-img-pos, center center);
+	/* Zoom scales the fitted picture about its anchor point, so zooming into a
+	 * cropped picture keeps looking at the same part of it. The host clips. */
+	transform: scale(var(--hearth-embed-img-scale, 1));
+	transform-origin: var(--hearth-embed-img-pos, center center);
+}
+
+.hearth-embed-image.is-fit-contain .hearth-embed-img {
+	object-fit: contain;
+}
+
+.hearth-embed-image.is-fit-cover .hearth-embed-img {
+	object-fit: cover;
+}
+
+.hearth-embed-image.is-fit-stretch .hearth-embed-img {
+	object-fit: fill;
+}
+
+/* "Fit the width": the picture spans the card and keeps its ratio, so its
+ * height is whatever that comes to and the card scrolls. Zoom widens the
+ * picture instead of transforming it — a transform wouldn't reflow the height
+ * derived from the width, leaving a gap under a shrunk picture. */
+.hearth-embed-image.is-fit-width {
+	overflow: auto;
+}
+
+.hearth-embed-image.is-fit-width .hearth-embed-img {
+	width: calc(100% * var(--hearth-embed-img-scale, 1));
+	height: auto;
+	flex: none;
+	object-fit: contain;
+	transform: none;
 }
 
 /* Editable embed: a plain textarea bound to the note's file. Uses a monospace

--- a/test/embedimage.test.ts
+++ b/test/embedimage.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import {
+	EMBED_IMAGE_FITS,
+	EMBED_IMAGE_POSITIONS,
+	embedImageFit,
+	embedImagePosition,
+	embedImagePositionApplies,
+	embedImageScale,
+	embedImageStyle,
+	embedImageZoomMode,
+	framesEmbedImage,
+} from "../src/embedimage";
+import { isImagePath } from "../src/filetypes";
+import type { EmbedImageFit, EmbedImagePosition, EmbedView } from "../src/types";
+
+/**
+ * The embed card's picture formatting: which fit mode and anchor point a view
+ * resolves to, and the CSS that comes out of the pair. Data in, data out — the
+ * `<img>` those properties end up on is deliberately untested, per the "no
+ * Obsidian API mocks" rule.
+ */
+
+function view(extra: Partial<EmbedView> = {}): EmbedView {
+	return { target: "Attachments/photo.png", ...extra };
+}
+
+describe("embedImageFit", () => {
+	it("defaults to the untouched natural mode", () => {
+		expect(embedImageFit(view())).toBe("natural");
+	});
+
+	it("returns the mode a view is set to", () => {
+		for (const fit of EMBED_IMAGE_FITS) {
+			expect(embedImageFit(view({ imageFit: fit }))).toBe(fit);
+		}
+	});
+
+	it("falls back to natural for a mode Hearth doesn't have", () => {
+		// A hand-edited data.json, or a board exported by a newer Hearth.
+		const rogue = { imageFit: "parallax" as unknown as EmbedImageFit };
+		expect(embedImageFit(rogue)).toBe("natural");
+	});
+});
+
+describe("embedImagePosition", () => {
+	it("defaults to the centre", () => {
+		expect(embedImagePosition(view())).toBe("center");
+	});
+
+	it("returns each of the nine anchor points", () => {
+		for (const position of EMBED_IMAGE_POSITIONS) {
+			expect(embedImagePosition(view({ imagePosition: position }))).toBe(position);
+		}
+	});
+
+	it("falls back to the centre for an anchor point that isn't one of the nine", () => {
+		const rogue = { imagePosition: "middle" as unknown as EmbedImagePosition };
+		expect(embedImagePosition(rogue)).toBe("center");
+	});
+});
+
+describe("framesEmbedImage", () => {
+	it("leaves natural on Obsidian's own transclusion", () => {
+		expect(framesEmbedImage("natural")).toBe(false);
+	});
+
+	it("frames every mode that sizes the picture against the card", () => {
+		for (const fit of EMBED_IMAGE_FITS.filter((f) => f !== "natural")) {
+			expect(framesEmbedImage(fit)).toBe(true);
+		}
+	});
+});
+
+describe("embedImagePositionApplies", () => {
+	it("applies where the picture has room to move", () => {
+		expect(embedImagePositionApplies("contain")).toBe(true);
+		expect(embedImagePositionApplies("cover")).toBe(true);
+		expect(embedImagePositionApplies("width")).toBe(true);
+	});
+
+	it("does not apply where there is nothing to position", () => {
+		// Stretch pins all four edges; natural isn't framed by Hearth at all.
+		expect(embedImagePositionApplies("stretch")).toBe(false);
+		expect(embedImagePositionApplies("natural")).toBe(false);
+	});
+});
+
+describe("embedImageZoomMode", () => {
+	it("keeps the host zoom for natural", () => {
+		expect(embedImageZoomMode("natural")).toBe("none");
+	});
+
+	it("transforms the fitted picture for the framed modes", () => {
+		expect(embedImageZoomMode("contain")).toBe("scale");
+		expect(embedImageZoomMode("cover")).toBe("scale");
+		expect(embedImageZoomMode("stretch")).toBe("scale");
+	});
+
+	it("widens the picture in fit-the-width, so its height reflows", () => {
+		expect(embedImageZoomMode("width")).toBe("width");
+	});
+});
+
+describe("embedImageScale", () => {
+	it("defaults to 1 when unset", () => {
+		expect(embedImageScale(undefined)).toBe(1);
+	});
+
+	it("passes a real factor through", () => {
+		expect(embedImageScale(1.5)).toBe(1.5);
+		expect(embedImageScale(0.5)).toBe(0.5);
+	});
+
+	it("rejects factors that would make the picture vanish or break layout", () => {
+		expect(embedImageScale(0)).toBe(1);
+		expect(embedImageScale(-2)).toBe(1);
+		expect(embedImageScale(Number.NaN)).toBe(1);
+		expect(embedImageScale(Number.POSITIVE_INFINITY)).toBe(1);
+	});
+});
+
+describe("embedImageStyle", () => {
+	it("turns an anchor point into an object-position and a transform origin", () => {
+		const style = embedImageStyle("cover", "top-left", 1);
+		expect(style["--hearth-embed-img-pos"]).toBe("left top");
+		expect(style["--hearth-embed-img-justify"]).toBe("flex-start");
+		expect(style["--hearth-embed-img-align"]).toBe("flex-start");
+	});
+
+	it("centres every mode that has nothing to position", () => {
+		for (const fit of ["stretch", "natural"] as EmbedImageFit[]) {
+			const style = embedImageStyle(fit, "bottom-right", 1);
+			expect(style["--hearth-embed-img-pos"]).toBe("center center");
+		}
+	});
+
+	it("carries the zoom factor for a framed picture", () => {
+		expect(embedImageStyle("cover", "center", 1.5)["--hearth-embed-img-scale"]).toBe("1.5");
+		expect(embedImageStyle("width", "center", 0.75)["--hearth-embed-img-scale"]).toBe("0.75");
+	});
+
+	it("never zooms an unframed picture through these properties", () => {
+		// Natural keeps the host's own `zoom`, so the image scale stays neutral.
+		expect(embedImageStyle("natural", "center", 1.5)["--hearth-embed-img-scale"]).toBe("1");
+	});
+
+	it("neutralises a nonsense zoom factor", () => {
+		expect(embedImageStyle("cover", "center", 0)["--hearth-embed-img-scale"]).toBe("1");
+	});
+
+	it("emits every anchor point as a usable CSS pair", () => {
+		for (const position of EMBED_IMAGE_POSITIONS) {
+			const style = embedImageStyle("contain", position, 1);
+			expect(style["--hearth-embed-img-pos"]).toMatch(
+				/^(left|center|right) (top|center|bottom)$/,
+			);
+			expect(style["--hearth-embed-img-justify"]).toMatch(
+				/^(flex-start|safe center|safe flex-end)$/,
+			);
+			expect(style["--hearth-embed-img-align"]).toMatch(
+				/^(flex-start|safe center|safe flex-end)$/,
+			);
+		}
+	});
+});
+
+describe("isImagePath", () => {
+	it("recognises the picture formats Hearth draws", () => {
+		expect(isImagePath("Attachments/photo.png")).toBe(true);
+		expect(isImagePath("cover.JPG")).toBe(true);
+		expect(isImagePath("a/b/diagram.svg")).toBe(true);
+		expect(isImagePath("  spaced.webp  ")).toBe(true);
+	});
+
+	it("rejects everything the formatting options don't apply to", () => {
+		expect(isImagePath("Notes/note.md")).toBe(false);
+		expect(isImagePath("Boards/tasks.base")).toBe(false);
+		expect(isImagePath("Drawing.excalidraw.md")).toBe(false);
+		expect(isImagePath("clip.mp4")).toBe(false);
+	});
+
+	it("handles a path with no usable extension", () => {
+		expect(isImagePath("")).toBe(false);
+		expect(isImagePath(undefined)).toBe(false);
+		expect(isImagePath("README")).toBe(false);
+		// A dot in a folder name is not the file's extension.
+		expect(isImagePath("my.png.folder/file")).toBe(false);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

An image embed rendered at whatever size the picture happened to be, in a box that scrolled — a wide photo in a short card showed a sliver of itself, and the only lever was a zoom that scaled the same sliver.

The embed card's **Content** tab now offers the usual fit modes for any picture target, on the primary view and the second view alike:

| Mode | Behaviour |
| --- | --- |
| **Original size** | unchanged default — Obsidian's transclusion, picture at its own size |
| **Fit the whole picture** | `contain`, letterboxed |
| **Fill the card (crop)** | `cover`, edge to edge |
| **Stretch to the card** | `fill`, aspect ratio ignored |
| **Fit the width (scroll)** | full width, natural height, card scrolls |

**Picture position** anchors the picture to any of nine points, which decides *which part* a crop keeps — a portrait cropped into a wide card can hold onto the face instead of the middle. It's hidden for stretch and original size, where it means nothing.

**Zoom** now works inside the frame too: on cover/contain/stretch it scales about the anchor point (zooming a crop crops in further), and on fit-the-width it widens the picture so the height reflows instead of leaving a gap under it.

### How it's built

- `src/embedimage.ts` — the fit/anchor → CSS mapping as pure data (no DOM, no Obsidian imports), unit-tested in `test/embedimage.test.ts`.
- `src/cards/embed.ts` — anything but "original size" is drawn as a bare `<img>` given the whole card body, edge to edge. Obsidian's transclusion can't express these modes: it renders into wrappers of its own with their own margins, so there's no element to hang an `object-fit` on that reliably spans the card. "Original size" stays on that transclusion path untouched, so **no existing card renders differently than it did**.
- `styles.css` — one block of fit rules driven by four custom properties; the embed gutter rule now excludes the image host the same way it already excludes canvas/Excalidraw embeds.
- `src/layout.ts` — an imported layout naming a mode or anchor Hearth doesn't have falls back to the default instead of being trusted.

Note: an **SVG** target keeps its own `preserveAspectRatio`, so "stretch" won't visibly distort an SVG the way it does a raster image. Left alone deliberately rather than overriding the SVG's own aspect handling.

## Related issue

None — raised directly as a request for the usual image formatting options on the embed card.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault

On the last box: no vault was available in this environment. Instead every fit mode, anchor point and zoom flavour was rendered in headless Chromium against the real `styles.css` with the card DOM reproduced, and the computed geometry checked (crop anchoring, distortion under stretch, both zoom paths). `npm run lint` reports 0 errors and one fewer warning than the base branch; the full suite is 762 passing (25 new).


---
_Generated by [Claude Code](https://claude.ai/code/session_016XJ6mv9wQC7LS9xkEL6pdN)_