### PR TITLE
Add a Templater card: launchpad tiles that create notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,37 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Added
 
+- **A launchpad that makes notes: the Templater card.** Hearth's third tile card
+  sits beside Links and Commands, but each of its buttons creates a note. A tile
+  carries three things — one of your
+  [Templater](https://github.com/SilentVoid13/Templater) templates, the folder
+  the note goes in, and what it is called — and one click makes it.
+
+  **The destination is the point.** Templater's own per-template commands drop
+  the note wherever Obsidian's "Default location for new notes" says, so the
+  same template can only ever land in one place. A tile carries its own folder,
+  so *Meeting* → `Work/Meetings`, *Book note* → `Library`, and *Idea* → `Inbox`
+  are three buttons over one or three templates, whichever you have.
+
+  **Filenames are patterns.** `{{date}}`, `{{date:YYYY-MM}}`, `{{time}}` and
+  `{{time:HH-mm}}` are substituted when the tile is clicked, and `{{prompt}}`
+  asks you for the rest of the name first — so `Meeting {{date}} — {{prompt}}`
+  is one click and one line typed. Leave the field empty and Templater names the
+  note, as it does from its own command.
+
+  **Templater does the templating.** Hearth calls
+  `create_new_note_from_template` on the running plugin and nothing else: your
+  user scripts, `tp.system.prompt()` dialogs, folder templates and
+  `tp.file.cursor()` placement all behave exactly as they do everywhere else.
+  What Hearth adds is where the note *opens* — through its own "Open notes in"
+  setting, so a click from the dashboard no longer replaces the dashboard.
+
+  Tiles drag, resize and overlap like every other launchpad tile, take a Lucide
+  icon or a vault image, and can be told to file the note away silently instead
+  of opening it. The template picker lists Templater's own template folder. And
+  the setup wizard offers the card on a fresh install, seeded with a button per
+  template you already have.
+
 - **A setup wizard that builds your first dashboard.** A new install no longer
   lands on a generic starter grid and a wallpaper nobody chose. Hearth asks
   instead — a title and logo, a card style and a background, what you actually

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ installed and enabled is offered with the one thing accepting it will do:
 | **TaskNotes** | Adds a Tasks card on the TaskNotes source, using TaskNotes' *own* field names and completed statuses |
 | **Kanban** | Adds a Tasks card showing your board as draggable columns |
 | **Dataview** / **Datacore** | Adds a card, seeded with an editable query |
+| **Templater** | Adds a launchpad with a button per template you already have |
 | **Git** | Adds a Git card with status, commit and sync |
 | **Omnisearch** | Makes it the engine behind Hearth's search bar |
 | **Iconic** / **Iconize** | Shows the file icons you already set |
@@ -107,7 +108,7 @@ Add cards from the **Arrange** toolbar; configure each one from the card itself
 **Add card** opens a searchable picker: type to match a card's name or its
 description, or browse by category (Notes & files, Planning, Vault insight,
 Tools, Integrations, Fun). Cards backed by a community plugin are always listed
-— they're marked *Needs Dataview* (or Datacore, or Git) when the plugin isn't
+— they're marked *Needs Dataview* (or Datacore, or Templater, or Git) when the plugin isn't
 there, with a one-click jump to install it. And if the card you want doesn't
 exist, **Request a card** at the bottom of the rail opens a pre-filled GitHub
 issue or email.
@@ -205,6 +206,17 @@ issue or email.
 - **Links / launchpad** — a grid of tiles opening notes, URLs or commands, each
   with its own column and row span, droppable anywhere on the card.
 - **Commands** — tiles that run any command-palette command.
+- **New note from template** *(requires
+  [Templater](https://github.com/SilentVoid13/Templater))* — the same launchpad,
+  but each tile makes a note: pick one of your Templater templates, the folder
+  the note goes in, and a filename pattern (`Meeting {{date}}`, `{{prompt}}` to
+  be asked for the rest of the name), and one click creates it. The same
+  template can feed three different folders from three different buttons —
+  something Templater's own per-template commands can't do, since they all obey
+  one default location. Templater does the templating: your user scripts,
+  `tp.system.prompt()` dialogs and `tp.file.cursor()` placement behave exactly
+  as they do from its own command. Tiles that only file something away can skip
+  opening the note.
 - **Bookmarks** — Obsidian's core bookmarks, with site favicons.
 - **Favorites** and **Recent files** — curated and recent note grids.
 - **Web page** — any `http(s)` URL in a sandboxed iframe, with optional

--- a/src/cards/index.ts
+++ b/src/cards/index.ts
@@ -18,6 +18,7 @@ import { textCard } from "./text";
 import { recentCard } from "./recent";
 import { linksCard } from "./links";
 import { commandsCard } from "./commands";
+import { templaterCard } from "./templater";
 import { clockCard } from "./clock";
 import { tasksCard } from "./tasks";
 import { calendarCard } from "./calendar";
@@ -63,6 +64,7 @@ export const CARD_DEFINITIONS: { [K in CardKind]: CardDefinition<K> } = {
 	recent: recentCard,
 	links: linksCard,
 	commands: commandsCard,
+	templater: templaterCard,
 	clock: clockCard,
 	tasks: tasksCard,
 	calendar: calendarCard,
@@ -124,7 +126,7 @@ export const TEMPLATE_MENU_GROUPS: { category: CardCategory; templates: string[]
 	{ category: "planning", templates: ["tasks", "schedule", "calendar", "clock"] },
 	{ category: "vault", templates: ["search", "searchbar", "stats", "heatmap"] },
 	{ category: "tools", templates: ["links", "commands", "text", "calculator", "web"] },
-	{ category: "integrations", templates: ["dataview", "datacore", "git", "jira", "rss", "weather", "leaf"] },
+	{ category: "integrations", templates: ["templater", "dataview", "datacore", "git", "jira", "rss", "weather", "leaf"] },
 	{ category: "fun", templates: ["pet"] },
 ];
 

--- a/src/cards/templater.ts
+++ b/src/cards/templater.ts
@@ -1,0 +1,437 @@
+import { Notice, setTooltip, Setting, TFile } from "obsidian";
+import {
+	applyTileSize,
+	emptyState,
+	makeTileDraggable,
+	makeTileResizable,
+	markOverlappingTiles,
+} from "../cardbodies";
+import { moveItem } from "../editors";
+import { t } from "../i18n";
+import { openFile } from "../opener";
+import { FilePickerModal, FolderPickerModal } from "../pickers";
+import {
+	TEMPLATER_PLUGIN_ID,
+	createNoteFromTemplate,
+	destinationSummary,
+	expandTemplaterFilename,
+	filenameNeedsPrompt,
+	isTemplaterAvailable,
+	isTemplaterTemplate,
+	jumpToTemplaterCursor,
+	normalizeFolderPath,
+	resolveTemplateFile,
+	templateDisplayName,
+	templaterTemplatesFolder,
+} from "../templater";
+import { type DashboardCard, type TemplaterItem } from "../types";
+import { makeClickable, promptForText } from "../ui";
+import { type HomeView } from "../view";
+import { addIconHelp, applyTileVisual } from "../widgeticon";
+import { type CardDefinition, type CardEditorContext } from "./definition";
+
+
+// ---- Templater / new note from template ---------------------------------
+
+/**
+ * A launchpad whose tiles create notes: each one names a Templater template, a
+ * destination folder and a filename pattern, and one click makes the note.
+ *
+ * It is the Links and Commands cards' third sibling — same tiles, same
+ * arrange-mode drag and resize — and deliberately so. "New meeting note", "New
+ * book note", "Capture an idea" are launcher actions in every sense except that
+ * Obsidian has no command to bind them to: Templater registers commands only for
+ * templates the user hand-picks in its own hotkey list, and those commands drop
+ * the note wherever the vault's default-location setting says. A tile carries
+ * its own destination, so the same template can feed three different folders
+ * from three different buttons.
+ *
+ * Everything past "which template, where" is Templater's: `src/templater.ts`
+ * calls its `create_new_note_from_template`, so user scripts,
+ * `tp.system.prompt()` dialogs, cursor placement and folder templates all
+ * behave exactly as they do from Templater's own command.
+ */
+export function renderTemplater(view: HomeView, card: DashboardCard, body: HTMLElement): void {
+	if (!isTemplaterAvailable(view.app)) {
+		emptyState(body, "file-plus-2", t().cards.empty.templaterEnable);
+		return;
+	}
+
+	const items = card.templater?.items ?? [];
+	if (items.length === 0) {
+		emptyState(body, "file-plus-2", t().cards.empty.templaterEmpty);
+		return;
+	}
+
+	const grid = body.createDiv("hearth-links hearth-tiles-sized");
+	const baseTile = card.tileSize && card.tileSize > 0 ? card.tileSize : 90;
+	grid.style.setProperty("--hearth-tile", `${baseTile}px`);
+	// Flag the card body so CSS can disable the card drag overlay over tiles in
+	// arrange mode (tiles are self-contained widgets with their own resize).
+	if (view.arrangeMode) body.addClass("hearth-tiles-arrange");
+
+	for (const item of items) {
+		const tile = grid.createDiv("hearth-link-tile");
+		applyTileSize(tile, item.sizeW, item.sizeH, item.size, baseTile, item.col, item.row);
+		applyTileVisual(view, tile, item.icon, "file-plus-2");
+		const label = tileLabel(item);
+		tile.createDiv({ cls: "hearth-link-label", text: label });
+		setTooltip(tile, tileTooltip(item));
+
+		// One note per click. Creating one is asynchronous (Templater may open a
+		// prompt of its own), and an impatient second click would otherwise make
+		// a second note — so the tile marks itself busy for the duration.
+		let busy = false;
+		const run = (): void => {
+			if (busy) return;
+			busy = true;
+			tile.addClass("is-busy");
+			void runTemplaterItem(view, item).finally(() => {
+				busy = false;
+				tile.removeClass("is-busy");
+			});
+		};
+
+		// In arrange mode, clicking a tile must NOT trigger its action — the
+		// click is almost always the tail end of a resize/drag gesture.
+		if (!view.arrangeMode) {
+			tile.addEventListener("click", run);
+			makeClickable(tile, run, label);
+		}
+
+		if (view.arrangeMode) {
+			makeTileResizable(view, tile, baseTile, () => item.sizeW, (v) => {
+				item.sizeW = v;
+			}, () => item.sizeH, (v) => {
+				item.sizeH = v;
+			}, () => item.size, (v) => {
+				item.size = v;
+			});
+			makeTileDraggable(view, grid, tile, items, item, card.tileAutoFlow === true);
+		}
+	}
+
+	// Flag tiles obscured behind a sibling so the overlap is visible (always,
+	// not just in arrange mode — a hidden tile is a problem either way).
+	markOverlappingTiles(grid);
+}
+
+
+/** The text on a tile: the user's label, or the template's own name so a tile
+ * added and never renamed still reads correctly. */
+function tileLabel(item: TemplaterItem): string {
+	return item.label.trim() || templateDisplayName(item.template) || t().cards.templater.untitledTile;
+}
+
+
+/** The tile's hover text: where the note will go, so a board of six tiles is
+ * self-documenting without opening settings. */
+function tileTooltip(item: TemplaterItem): string {
+	const strings = t().cards.templater;
+	return strings.createsIn(
+		destinationSummary(
+			item.folder ?? "",
+			item.filename ?? "",
+			strings.vaultRoot,
+			strings.untitledNote,
+		),
+	);
+}
+
+
+/**
+ * One tile's click: resolve the template, ask for the `{{prompt}}` value if the
+ * pattern wants one, hand the job to Templater, then open the result the way
+ * Hearth opens notes.
+ *
+ * Every failure is reported as a Notice rather than swallowed — a launcher
+ * button that silently does nothing is worse than one that says why.
+ */
+async function runTemplaterItem(view: HomeView, item: TemplaterItem): Promise<void> {
+	const strings = t().notices;
+	const app = view.app;
+
+	const template = resolveTemplateFile(app, item.template);
+	if (!template) {
+		new Notice(strings.templaterNoTemplate(item.template || tileLabel(item)));
+		return;
+	}
+
+	const pattern = item.filename ?? "";
+	let promptValue = "";
+	if (filenameNeedsPrompt(pattern)) {
+		const answer = await promptForText(app, {
+			title: t().cards.templater.promptTitle,
+			label: tileLabel(item),
+			placeholder: t().cards.templater.promptPlaceholder,
+		});
+		// Cancelled — not an error, and nothing to report.
+		if (answer === null) return;
+		promptValue = answer.trim();
+	}
+
+	const file = await createNoteFromTemplate(app, {
+		template,
+		folder: normalizeFolderPath(item.folder ?? ""),
+		filename: expandTemplaterFilename(pattern, new Date(), promptValue),
+	});
+	if (!file) {
+		// Templater shows its own error notice for a parse failure or a prompt
+		// the user dismissed, so this is the catch-all for everything else.
+		new Notice(strings.templaterFailed(templateDisplayName(item.template)));
+		return;
+	}
+
+	if (item.open === false) {
+		new Notice(strings.templaterCreated(file.path));
+		return;
+	}
+	await openFile(view, file, "newNote");
+	// Templater does this itself when it opens the note; Hearth opened it
+	// instead (see src/templater.ts), so the cursor jump has to be asked for.
+	await jumpToTemplaterCursor(app, file);
+}
+
+
+export function templaterEditor(ctx: CardEditorContext, containerEl: HTMLElement): void {
+	const strings = t().editors.templater;
+	const card = ctx.card;
+	const cfg = (card.templater ??= {});
+	const items = (cfg.items ??= []);
+
+	// Same courtesy the Git editor extends: say the card needs the plugin here,
+	// rather than leaving the user to wonder why their tiles do nothing.
+	if (!isTemplaterAvailable(ctx.app)) {
+		new Setting(containerEl).setName(strings.missing).setDesc(strings.missingDesc);
+	}
+
+	new Setting(containerEl)
+		.setName(strings.autoShift)
+		.setDesc(strings.autoShiftDesc)
+		.addToggle((tg) =>
+			tg.setValue(card.tileAutoFlow ?? false).onChange((v) => {
+				card.tileAutoFlow = v;
+				ctx.opts.save();
+			}),
+		);
+
+	const buttonSize = new Setting(containerEl)
+		.setName(strings.buttonSize)
+		.setDesc(strings.buttonSizeDesc);
+	buttonSize.addSlider((s) => {
+		s.setLimits(60, 180, 10)
+			.setValue(card.tileSize ?? 90)
+			.setDynamicTooltip()
+			.onChange((v) => {
+				card.tileSize = v === 90 ? undefined : v;
+				ctx.opts.save();
+				ctx.opts.rerender();
+			});
+	});
+	buttonSize.addExtraButton((b) =>
+		b
+			.setIcon("rotate-ccw")
+			.setTooltip(t().settings.resetSlider)
+			.onClick(() => {
+				card.tileSize = undefined;
+				ctx.opts.save();
+				ctx.opts.rerender();
+				ctx.requestRender();
+			}),
+	);
+
+	new Setting(containerEl).setName(strings.heading).setHeading();
+
+	items.forEach((item, index) => {
+		const row = new Setting(containerEl)
+			.setClass("hearth-link-setting")
+			.setName(tileLabel(item))
+			// The destination is the whole point of a tile and the one thing a
+			// row of narrow controls can't show, so it is spelled out in full.
+			.setDesc(
+				destinationSummary(
+					item.folder ?? "",
+					item.filename ?? "",
+					t().cards.templater.vaultRoot,
+					t().cards.templater.untitledNote,
+				),
+			);
+
+		row.addText((txt) =>
+			txt
+				.setPlaceholder(strings.labelPlaceholder)
+				.setValue(item.label)
+				.onChange((v) => {
+					item.label = v;
+					ctx.opts.save();
+				}),
+		);
+
+		row.addText((txt) => {
+			txt
+				.setPlaceholder(t().pickers.iconPlaceholder)
+				.setValue(item.icon)
+				.onChange((v) => {
+					item.icon = v;
+					ctx.opts.save();
+				});
+			setTooltip(txt.inputEl, t().editors.iconHelp);
+		});
+		addIconHelp(row.controlEl);
+
+		// A template is addressed by vault path, which is exactly the kind of
+		// thing a fuzzy picker is for. Scoped to Templater's own template folder
+		// when it has one, so the list is the same one Templater itself offers.
+		row.addButton((b) => {
+			b.setButtonText(templateDisplayName(item.template) || strings.pickTemplate);
+			setTooltip(b.buttonEl, strings.pickTemplateTooltip);
+			b.onClick(() => {
+				new FilePickerModal(
+					ctx.app,
+					(file) => {
+						item.template = file.path;
+						// Seed an empty label from the template so the tile isn't
+						// blank; a user-set label is left alone.
+						if (!item.label.trim()) item.label = templateDisplayName(file.path);
+						ctx.opts.save();
+						ctx.opts.rerender();
+						ctx.requestRender();
+					},
+					strings.pickTemplate,
+					(file: TFile) => isTemplaterTemplate(ctx.app, file),
+				).open();
+			});
+		});
+
+		row.addButton((b) => {
+			b.setButtonText(
+				normalizeFolderPath(item.folder ?? "") || t().cards.templater.vaultRoot,
+			);
+			setTooltip(b.buttonEl, strings.pickFolderTooltip);
+			b.onClick(() => {
+				new FolderPickerModal(ctx.app, (folder) => {
+					// The picker offers the root as "/", which normalizes to "" —
+					// the same value as "let Templater decide".
+					item.folder = normalizeFolderPath(folder.path) || undefined;
+					ctx.opts.save();
+					ctx.opts.rerender();
+					ctx.requestRender();
+				}).open();
+			});
+		});
+
+		row.addText((txt) => {
+			txt
+				.setPlaceholder(strings.filenamePlaceholder)
+				.setValue(item.filename ?? "")
+				.onChange((v) => {
+					item.filename = v || undefined;
+					ctx.opts.save();
+				});
+			setTooltip(txt.inputEl, strings.filenameTooltip);
+		});
+
+		row.addExtraButton((b) =>
+			b
+				.setIcon(item.open === false ? "eye-off" : "eye")
+				.setTooltip(item.open === false ? strings.openOff : strings.openOn)
+				.onClick(() => {
+					item.open = item.open === false ? undefined : false;
+					ctx.opts.save();
+					ctx.requestRender();
+				}),
+		);
+		row.addExtraButton((b) =>
+			b
+				.setIcon("chevron-up")
+				.setTooltip(t().editors.links.moveUp)
+				.setDisabled(index === 0)
+				.onClick(() => moveItem(ctx, items, index, index - 1)),
+		);
+		row.addExtraButton((b) =>
+			b
+				.setIcon("chevron-down")
+				.setTooltip(t().editors.links.moveDown)
+				.setDisabled(index === items.length - 1)
+				.onClick(() => moveItem(ctx, items, index, index + 1)),
+		);
+		row.addExtraButton((b) =>
+			b
+				.setIcon("trash-2")
+				.setTooltip(strings.removeTile)
+				.onClick(() => {
+					items.splice(index, 1);
+					ctx.opts.save();
+					ctx.opts.rerender();
+					ctx.requestRender();
+				}),
+		);
+	});
+
+	// Adding starts at the picker rather than at a blank row: a tile with no
+	// template is the one configuration that can never do anything, and the
+	// template is also what names the tile.
+	new Setting(containerEl).addButton((b) =>
+		b.setButtonText(strings.addTile).onClick(() => {
+			new FilePickerModal(
+				ctx.app,
+				(file) => {
+					items.push({
+						id: `templater-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e4)}`,
+						label: templateDisplayName(file.path),
+						icon: "file-plus-2",
+						template: file.path,
+					});
+					ctx.opts.save();
+					ctx.opts.rerender();
+					ctx.requestRender();
+				},
+				strings.pickTemplate,
+				(file: TFile) => isTemplaterTemplate(ctx.app, file),
+			).open();
+		}),
+	);
+
+	const folder = templaterTemplatesFolder(ctx.app);
+	new Setting(containerEl).setDesc(
+		folder ? strings.tokensHelpScoped(folder) : strings.tokensHelp,
+	);
+}
+
+
+/** A launchpad of "new note from this template, here" buttons, driven by the
+ * Templater plugin. Offered whether or not Templater is installed — the card
+ * prompts for it when it isn't. */
+export const templaterCard: CardDefinition<"templater"> = {
+	kind: "templater",
+	templates: [
+		{
+			id: "templater",
+			name: "Templater",
+			icon: "file-plus-2",
+			build: () => ({
+				kind: "templater",
+				title: "New note",
+				templater: { items: [] },
+				w: 6,
+				h: 2,
+			}),
+			requires: {
+				name: "Templater",
+				pluginId: TEMPLATER_PLUGIN_ID,
+				satisfied: (app) => isTemplaterAvailable(app),
+			},
+		},
+	],
+	render: (view, card, body) => renderTemplater(view, card, body),
+	renderEditor: (container, ctx) => templaterEditor(ctx, container),
+	cloneConfig: (source, copy) => {
+		if (source.templater)
+			copy.templater = {
+				...source.templater,
+				items: source.templater.items?.map((i) => ({ ...i })),
+			};
+	},
+	liveness: { mode: "static" },
+	cardClass: "is-tile-card",
+};

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -27,6 +27,7 @@ import { EXCALIDRAW_PLUGIN_ID } from "./filetypes";
 import { GIT_PLUGIN_ID } from "./git";
 import { OMNISEARCH_PLUGIN_ID } from "./omnisearch";
 import { TASKNOTES_PLUGIN_ID } from "./tasknotes";
+import { TEMPLATER_PLUGIN_ID } from "./templater";
 
 /**
  * Ids of the settings ribbon tabs.
@@ -73,6 +74,7 @@ export type IntegrationId =
 	| "tasknotes"
 	| "dataview"
 	| "datacore"
+	| "templater"
 	| "git"
 	| "iconic"
 	| "iconize"
@@ -134,6 +136,12 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
 		id: "datacore",
 		group: "plugin",
 		pluginId: DATACORE_PLUGIN_ID,
+		where: { kind: "card" },
+	},
+	{
+		id: "templater",
+		group: "plugin",
+		pluginId: TEMPLATER_PLUGIN_ID,
 		where: { kind: "card" },
 	},
 	{

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -55,6 +55,11 @@ export const en = {
 			"Hearth: couldn't undo the recurring task completion.",
 		couldNotAddKanbanCard: "Hearth: couldn't add the card to the Kanban board.",
 		couldNotConvertCard: "Hearth: couldn't convert the card into a note.",
+		templaterNoTemplate: (path: string) =>
+			`Hearth: template not found: ${path}`,
+		templaterFailed: (name: string) =>
+			`Hearth: Templater didn't create a note from ${name}.`,
+		templaterCreated: (path: string) => `Hearth: created ${path}`,
 		layoutExported: "Hearth: layout exported.",
 		layoutImported: "Hearth: layout imported.",
 		layoutImportError: (error: string) => `Hearth: ${error}`,
@@ -88,6 +93,7 @@ export const en = {
 	confirm: {
 		confirm: "Confirm",
 		cancel: "Cancel",
+		ok: "OK",
 	},
 
 	// ---- "What's new" release-notes dialog -----------------------------
@@ -292,6 +298,9 @@ export const en = {
 				kanban: "Add a Tasks card showing your Kanban board as columns you can drag between.",
 				dataview: "Add a Dataview card, seeded with a query you can edit.",
 				datacore: "Add a Datacore card ready for a query.",
+				templater:
+					"Add a card of buttons — one per template you already have — that make a " +
+					"note from it in one click.",
 				git: "Add a Git card showing your repository's status, with commit and sync buttons.",
 				omnisearch: "Use Omnisearch as the engine behind Hearth's search bar.",
 				fileIcons: "Show the per-file icons you've already set, instead of Hearth's file-type icons.",
@@ -387,6 +396,7 @@ export const en = {
 				ambience: "A bit of life",
 				dataview: "Dataview is installed",
 				datacore: "Datacore is installed",
+				templater: "Templater templates were found",
 				git: "Git is installed",
 				bases: "A base was found in your vault",
 			},
@@ -967,6 +977,15 @@ export const en = {
 						"Dataview's successor. The Datacore card runs a Datacore query — or a " +
 						"JS/JSX/TS/TSX script — and renders it with Datacore's own live views.",
 				},
+				templater: {
+					name: "Templater",
+					desc:
+						"The “New note from template” card turns your Templater templates into " +
+						"buttons: each tile carries its own template, destination folder and " +
+						"filename pattern, and one click makes the note. Templater does the " +
+						"templating — your user scripts, tp.system.prompt() dialogs and cursor " +
+						"placement all behave as they do from its own command.",
+				},
 				git: {
 					name: "Git",
 					desc:
@@ -1237,6 +1256,7 @@ export const en = {
 			recent: "Recent files",
 			links: "Links / launchpad",
 			commands: "Commands",
+			templater: "New note from template",
 			clock: "Clock & greeting",
 			tasks: "Tasks",
 			calendar: "Mini calendar",
@@ -1712,6 +1732,50 @@ export const en = {
 			moveDown: "Move down",
 			removeCommand: "Remove command",
 			addCommand: "Add command",
+		},
+		templater: {
+			missing: "Templater isn't enabled",
+			missingDesc:
+				"This card creates notes by calling the Templater plugin — install and " +
+				"enable it, and these tiles start working. Nothing else here needs " +
+				"changing in the meantime.",
+			autoShift: "Auto-shift tiles (beta)",
+			autoShiftDesc:
+				"When on, tiles shove each other aside as one is dragged (like phone " +
+				"widgets). Off by default — tiles are pure free-form and may overlap.",
+			buttonSize: "Button size",
+			buttonSizeDesc:
+				"Default size of the tiles. Resize an individual tile by dragging its " +
+				"bottom-right corner.",
+			heading: "Templates",
+			labelPlaceholder: "Label",
+			pickTemplate: "Pick a template…",
+			pickTemplateTooltip: "Choose the Templater template this tile runs",
+			pickFolderTooltip:
+				"Choose the folder the new note goes in. The vault root means “wherever " +
+				"Obsidian puts new notes”.",
+			filenamePlaceholder: "Filename",
+			filenameTooltip:
+				"Name for the new note, without the extension. {{date}}, {{date:FMT}}, " +
+				"{{time}}, {{time:FMT}} and {{prompt}} are substituted. Leave empty to " +
+				"let Templater name it.",
+			openOn: "Opens the new note — click to file it away silently instead",
+			openOff: "Files the new note away silently — click to open it instead",
+			removeTile: "Remove tile",
+			addTile: "Add a template",
+			tokensHelp:
+				"Filenames may use {{date}}, {{date:YYYY-MM}}, {{time}}, {{time:HH-mm}} " +
+				"and {{prompt}}, which asks you for the rest of the name before the note " +
+				"is made. Everything inside the template itself — <% tp.* %>, your user " +
+				"scripts, tp.system.prompt() — is Templater's own, and runs exactly as it " +
+				"does from Templater's command.",
+			tokensHelpScoped: (folder: string) =>
+				`The picker lists the templates in “${folder}”, Templater's own template ` +
+				"folder. Filenames may use {{date}}, {{date:YYYY-MM}}, {{time}}, " +
+				"{{time:HH-mm}} and {{prompt}}, which asks you for the rest of the name " +
+				"before the note is made. Everything inside the template itself — " +
+				"<% tp.* %>, your user scripts, tp.system.prompt() — is Templater's own, " +
+				"and runs exactly as it does from Templater's command.",
 		},
 		tasks: {
 			source: "Source",
@@ -2359,6 +2423,8 @@ export const en = {
 			recentEmpty: "No recent files",
 			linksEmpty: "Add links in settings",
 			commandsEmpty: "Add commands in card settings",
+			templaterEnable: "Enable the Templater plugin to create notes from templates",
+			templaterEmpty: "Add a template in card settings",
 			tasksEnable:
 				"Enable the TaskNotes plugin, or switch source to checkboxes",
 			tasksEmpty: "No open tasks",
@@ -2381,6 +2447,14 @@ export const en = {
 			leafPickView: "Pick a plugin view in card settings",
 			leafViewMissing:
 				"This view isn't available — enable the plugin that provides it",
+		},
+		templater: {
+			untitledTile: "New note",
+			vaultRoot: "Default location",
+			untitledNote: "Untitled",
+			createsIn: (destination: string) => `Creates ${destination}`,
+			promptTitle: "Name the new note",
+			promptPlaceholder: "What is it about?",
 		},
 		pet: {
 			species: {
@@ -2818,6 +2892,7 @@ export const en = {
 		recent: "Recent files",
 		links: "Links / launchpad",
 		commands: "Commands",
+		templater: "New note from template",
 		clock: "Clock & greeting",
 		tasks: "Tasks",
 		calendar: "Mini calendar",
@@ -2855,6 +2930,7 @@ export const en = {
 		recent: "The files you opened most recently",
 		links: "A launchpad of links, notes and folders",
 		commands: "Buttons that run Obsidian commands",
+		templater: "Buttons that make a note from a Templater template, in a folder you pick",
 		clock: "The time, the date and a greeting",
 		tasks: "Checkboxes from your vault, as a list or a board",
 		calendar: "A month at a glance, with your notes on it",

--- a/src/onboarding/detect.ts
+++ b/src/onboarding/detect.ts
@@ -18,6 +18,7 @@ import { ICONIC_PLUGIN_ID, ICONIZE_PLUGIN_ID } from "../fileicons";
 import { GIT_PLUGIN_ID } from "../git";
 import { OMNISEARCH_PLUGIN_ID } from "../omnisearch";
 import { TASKNOTES_PLUGIN_ID, readTaskNotesSetup, type TaskNotesSetup } from "../tasknotes";
+import { TEMPLATER_PLUGIN_ID, templaterTemplateFiles } from "../templater";
 
 /** Community plugin id for the Kanban plugin, whose boards the Tasks card can
  * read as a task source. Declared here rather than in `cards/tasks.ts` because
@@ -38,6 +39,7 @@ export type SetupIntegrationId =
 	| "kanban"
 	| "dataview"
 	| "datacore"
+	| "templater"
 	| "git"
 	| "omnisearch"
 	| "fileIcons"
@@ -71,7 +73,17 @@ export interface SetupDetection {
 	basePath: string | null;
 	/** Path of a Kanban board note, when one exists. */
 	kanbanPath: string | null;
+	/** Paths of the templates Templater would offer, capped at
+	 * {@link TEMPLATER_TILE_LIMIT}. Empty when Templater isn't enabled or has no
+	 * templates yet. The wizard seeds one tile per entry, so the card arrives
+	 * with the user's own templates on it rather than blank. */
+	templaterTemplates: string[];
 }
+
+/** How many template tiles the wizard seeds. Enough to show what the card is
+ * for; a vault with forty templates does not want forty buttons chosen for it,
+ * and adding more is one click in the card's settings. */
+export const TEMPLATER_TILE_LIMIT = 6;
 
 /** Whether a community plugin is installed *and* on. */
 function pluginEnabled(app: App, id: string): boolean {
@@ -178,6 +190,20 @@ export function detectSetup(app: App): SetupDetection {
 		});
 	}
 
+	// Offered on the strength of templates existing, not merely of the plugin
+	// being on: a Templater install with no templates yet has nothing for the
+	// card to put on a tile, and a card of zero buttons is worse than no card.
+	const templaterTemplates = pluginEnabled(app, TEMPLATER_PLUGIN_ID)
+		? findTemplaterTemplates(app)
+		: [];
+	if (templaterTemplates.length > 0) {
+		integrations.push({
+			id: "templater",
+			name: pluginName(app, TEMPLATER_PLUGIN_ID, "Templater"),
+			recommended: false,
+		});
+	}
+
 	if (pluginEnabled(app, GIT_PLUGIN_ID)) {
 		integrations.push({
 			id: "git",
@@ -230,7 +256,20 @@ export function detectSetup(app: App): SetupDetection {
 		taskNotes: taskNotesOn ? readTaskNotesSetup(app) : null,
 		basePath,
 		kanbanPath,
+		templaterTemplates,
 	};
+}
+
+/** The first few templates Templater would offer, by path. Never throws: this
+ * runs while the wizard is being built. */
+function findTemplaterTemplates(app: App): string[] {
+	try {
+		return templaterTemplateFiles(app)
+			.slice(0, TEMPLATER_TILE_LIMIT)
+			.map((file) => file.path);
+	} catch {
+		return [];
+	}
 }
 
 /** The vault's name, or "" when it can't be read. */

--- a/src/onboarding/plan.ts
+++ b/src/onboarding/plan.ts
@@ -23,8 +23,10 @@ import {
 	type Dashboard,
 	type HomeSettings,
 	type OpenIn,
+	type TemplaterItem,
 	newDashboardId,
 } from "../types";
+import { templateDisplayName } from "../templater";
 import type { SetupDetection, SetupIntegrationId } from "./detect";
 import { taskNotesImport } from "./detect";
 
@@ -423,6 +425,22 @@ export function planCards(
 		});
 	}
 
+	if (accepted(answers, "templater") && detection.templaterTemplates.length > 0) {
+		add("templater", "templater", {
+			kind: "templater",
+			title: "New note",
+			// Seeded with the vault's own templates rather than left blank: an
+			// empty launchpad is indistinguishable from a broken one, and the
+			// destination is the one thing the user still has to fill in — which
+			// they can only do once there is a tile to fill it in on.
+			templater: { items: detection.templaterTemplates.map(templaterTile) },
+			x: -1,
+			y: -1,
+			w: 6,
+			h: 2,
+		});
+	}
+
 	if (accepted(answers, "git")) {
 		add("git", "git", { kind: "git", title: "Git", git: {}, x: -1, y: -1, w: 4, h: 4 });
 	}
@@ -444,6 +462,28 @@ export function planCards(
 	const cards: DashboardCard[] = drafts.map((draft, i) => ({ ...draft.card, id: newId(i) }));
 	ensureLayout(cards, PLAN_COLUMNS);
 	return drafts.map((draft, i) => ({ id: draft.id, reason: draft.reason, card: cards[i] }));
+}
+
+/**
+ * One seeded Templater tile: the template, named after itself, with no
+ * destination.
+ *
+ * No folder and no filename pattern on purpose. Both are choices only the user
+ * can make, and both have a sane fallback — the note lands wherever Obsidian
+ * puts new notes and Templater names it — so a tile works on the first click
+ * and is *improved*, not *fixed*, by opening the card's settings.
+ *
+ * Ids are derived from the path rather than generated, so a plan previewed and
+ * then committed produces the same board (nothing in planCards may depend on
+ * the clock or the random seed — the review step renders it twice).
+ */
+function templaterTile(path: string, index: number): TemplaterItem {
+	return {
+		id: `templater-${index}`,
+		label: templateDisplayName(path),
+		icon: "file-plus-2",
+		template: path,
+	};
 }
 
 /** Why the Tasks card is on the board — the integration that asked for it takes

--- a/src/templater.ts
+++ b/src/templater.ts
@@ -1,0 +1,262 @@
+/**
+ * The Templater integration: everything Hearth knows about the
+ * [Templater](https://github.com/SilentVoid13/Templater) community plugin.
+ *
+ * Same rule as Dataview, Datacore and obsidian-git: **Hearth never does the
+ * work itself.** It does not parse `<% tp.* %>` syntax, it does not run user
+ * scripts, and it does not write the note. A tile calls
+ * `create_new_note_from_template` on the running Templater instance, so the
+ * user's own templates folder, user-script functions, cursor placement,
+ * `tp.system.prompt()` dialogs and startup hooks all behave exactly as they do
+ * when the same template is invoked from Templater's own command. The card is a
+ * launchpad onto Templater, not a second templating engine.
+ *
+ * Two consequences shape this file:
+ *
+ * 1. **Everything is optional.** Templater exposes no versioned `api` object;
+ *    what Hearth calls are the plugin instance's own public members
+ *    (`templater`, `editor_handler`, `settings`). They are stable in practice —
+ *    its own commands call the same ones — but they are not a contract, so
+ *    every member is declared optional and every call site checks for the
+ *    function before using it. A build of Templater that renamed something
+ *    disables the card; it never throws inside a dashboard render.
+ * 2. **Hearth decides where the note opens, Templater decides what's in it.**
+ *    `create_new_note_from_template(…, open_new_note = true)` opens the note in
+ *    `getLeaf(false)` — the *active* leaf, which on a dashboard click is the
+ *    Hearth tab itself, so the board would replace itself with the new note
+ *    regardless of the user's "Open notes in" setting. Hearth therefore always
+ *    passes `false` and opens the result through its own opener (#106), then
+ *    asks Templater to run its cursor jump so `<% tp.file.cursor() %>` still
+ *    works.
+ *
+ * The pure helpers at the bottom (filename patterns, folder normalization)
+ * carry no Obsidian dependency beyond moment and are unit-tested in
+ * `test/templater.test.ts`.
+ */
+import { moment as createMoment, TFile, type App, type TFolder } from "obsidian";
+import { sanitizeFilename } from "./eventnote";
+
+/** The community-plugin id Templater registers itself under. */
+export const TEMPLATER_PLUGIN_ID = "templater-obsidian";
+
+/** The slice of `Templater` (the plugin's core object) Hearth calls. */
+interface TemplaterCore {
+	/**
+	 * Create a note from `template` and run it through Templater's parser.
+	 *
+	 * `folder` may be a `TFolder` or a plain vault-relative path string;
+	 * omitting it falls back to Obsidian's "Default location for new notes".
+	 * `filename` is used verbatim (no extension) and de-duplicated by
+	 * `vault.getAvailablePath`, so two clicks give "Note" and "Note 1" rather
+	 * than one overwritten note. Resolves to `undefined` when Templater
+	 * cancelled — a parse error, or a `tp.system.prompt()` the user dismissed.
+	 */
+	create_new_note_from_template?(
+		template: TFile | string,
+		folder?: TFolder | string,
+		filename?: string,
+		open_new_note?: boolean,
+	): Promise<TFile | undefined>;
+}
+
+/** The slice of Templater's editor handler Hearth calls. */
+interface TemplaterEditorHandler {
+	/** Move the cursor to the next `<% tp.file.cursor() %>` marker in `file`.
+	 * With `auto_jump` set, Templater skips it unless the user has its
+	 * "Automatic jump to cursor" setting on — which is the behaviour its own
+	 * create-from-template command has, so Hearth passes the same. */
+	jump_to_next_cursor_location?(file?: TFile | null, auto_jump?: boolean): Promise<void>;
+}
+
+/** The Templater plugin instance, as far as Hearth is concerned. */
+export interface TemplaterPlugin {
+	templater?: TemplaterCore;
+	editor_handler?: TemplaterEditorHandler;
+	settings?: {
+		/** Templater's own "Template folder location". Empty when unset, which
+		 * for Templater means "every file is a template". */
+		templates_folder?: string;
+	};
+}
+
+/** Reach the running Templater plugin, or null when it isn't installed or
+ * enabled. Never throws: `plugins.plugins` is an Obsidian internal and this
+ * runs inside card renders and the settings pane. */
+export function getTemplaterPlugin(app: App): TemplaterPlugin | null {
+	try {
+		return (app.plugins?.plugins?.[TEMPLATER_PLUGIN_ID] as TemplaterPlugin | undefined) ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** Whether Templater is enabled and the one method Hearth needs is reachable
+ * right now. */
+export function isTemplaterAvailable(app: App): boolean {
+	return typeof getTemplaterPlugin(app)?.templater?.create_new_note_from_template === "function";
+}
+
+/** Templater's configured template folder, normalized (no leading/trailing
+ * slash). Empty when Templater is missing or the setting is unset. */
+export function templaterTemplatesFolder(app: App): string {
+	return normalizeFolderPath(getTemplaterPlugin(app)?.settings?.templates_folder ?? "");
+}
+
+/** Whether `file` sits in (or under) Templater's template folder. Always true
+ * when no folder is configured — that is what Templater itself does, since an
+ * unset folder means any file may be used as a template. */
+export function isTemplaterTemplate(app: App, file: TFile): boolean {
+	if (file.extension !== "md") return false;
+	const folder = templaterTemplatesFolder(app);
+	return !folder || file.path.startsWith(`${folder}/`);
+}
+
+/** Every file Templater would offer as a template, in vault order. */
+export function templaterTemplateFiles(app: App): TFile[] {
+	try {
+		return app.vault.getMarkdownFiles().filter((file) => isTemplaterTemplate(app, file));
+	} catch {
+		return [];
+	}
+}
+
+/** Resolve a stored template path to a file, tolerating a missing `.md` — the
+ * same courtesy the daily-note and event-note template settings extend. */
+export function resolveTemplateFile(app: App, path: string): TFile | null {
+	const trimmed = (path || "").trim();
+	if (!trimmed) return null;
+	const direct = app.vault.getAbstractFileByPath(trimmed);
+	if (direct instanceof TFile) return direct;
+	const withExt = app.vault.getAbstractFileByPath(`${trimmed}.md`);
+	return withExt instanceof TFile ? withExt : null;
+}
+
+/** What one tile asks Templater for. */
+export interface TemplaterRunRequest {
+	template: TFile;
+	/** Vault-relative destination folder; "" hands the choice to Templater (and
+	 * so to Obsidian's "Default location for new notes"). */
+	folder: string;
+	/** Filename without extension; "" lets Templater name it "Untitled". */
+	filename: string;
+}
+
+/**
+ * Run one template through Templater and return the note it made, or null when
+ * Templater is unavailable, refused, or threw.
+ *
+ * A `null` return is not necessarily an error the user needs shouting about:
+ * Templater cancels (and reports, through its own error notice) on a parse
+ * failure or a dismissed `tp.system.prompt()`. The caller decides what to say.
+ */
+export async function createNoteFromTemplate(
+	app: App,
+	request: TemplaterRunRequest,
+): Promise<TFile | null> {
+	const core = getTemplaterPlugin(app)?.templater;
+	// Invoked as a member rather than through a saved reference: the method reads
+	// `this.plugin` internally, so it has to keep its receiver.
+	if (typeof core?.create_new_note_from_template !== "function") return null;
+	try {
+		const file = await core.create_new_note_from_template(
+			request.template,
+			request.folder || undefined,
+			request.filename || undefined,
+			// Never let Templater open it — see the module comment.
+			false,
+		);
+		return file ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** Ask Templater to place the cursor at the template's `tp.file.cursor()`
+ * marker, once the note is open. A no-op when Templater doesn't expose the
+ * handler, or when the user has its automatic jump switched off. */
+export async function jumpToTemplaterCursor(app: App, file: TFile): Promise<void> {
+	const handler = getTemplaterPlugin(app)?.editor_handler;
+	if (typeof handler?.jump_to_next_cursor_location !== "function") return;
+	try {
+		await handler.jump_to_next_cursor_location(file, true);
+	} catch {
+		// Cursor placement is a nicety; a Templater that changed this signature
+		// must not turn a created note into a failed click.
+	}
+}
+
+
+// ---- Pure helpers -------------------------------------------------------
+
+const moment = createMoment as unknown as (input?: number | Date) => { format(fmt?: string): string };
+
+/** Default formats for the bare tokens. `time` avoids `:`, which is illegal in
+ * a filename on Windows and stripped by {@link sanitizeFilename} anyway. */
+const TOKEN_FORMATS = { date: "YYYY-MM-DD", time: "HH-mm" } as const;
+
+/** Matches `{{date}}`, `{{date:FMT}}`, `{{time}}`, `{{time:FMT}}` and
+ * `{{prompt}}`. Deliberately the same `{{token}}` shape the event-note filename
+ * pattern and the core daily-note template use, so one convention covers all
+ * three. Anything else is left untouched, so a typo shows up in the filename
+ * instead of silently vanishing. */
+const TOKEN_RE = /\{\{\s*(date|time|prompt)\s*(?::\s*([^}]+?)\s*)?\}\}/gi;
+
+/** Whether a filename pattern asks Hearth for a value before the note is made.
+ * Drives the one-line prompt the tile shows on click. */
+export function filenameNeedsPrompt(pattern: string): boolean {
+	return /\{\{\s*prompt\s*\}\}/i.test(pattern || "");
+}
+
+/**
+ * Expand a filename pattern into a usable, vault-legal file name.
+ *
+ * `now` is passed in rather than read, so the substitution is deterministic
+ * under test. `promptValue` fills `{{prompt}}`; it is sanitized along with
+ * everything else, which is also what stops a typed `../` from escaping the
+ * destination folder.
+ */
+export function expandTemplaterFilename(
+	pattern: string,
+	now: Date,
+	promptValue = "",
+): string {
+	const expanded = (pattern || "").replace(
+		TOKEN_RE,
+		(_whole, name: string, format?: string) => {
+			const token = name.toLowerCase();
+			if (token === "prompt") return promptValue;
+			const fmt = format || TOKEN_FORMATS[token as "date" | "time"];
+			return moment(now).format(fmt);
+		},
+	);
+	return sanitizeFilename(expanded);
+}
+
+/** Trim a folder path to the form the vault uses: no leading or trailing
+ * slashes, no surrounding whitespace. "/" and "" both mean the vault root. */
+export function normalizeFolderPath(raw: string): string {
+	return (raw || "").trim().replace(/^\/+|\/+$/g, "");
+}
+
+/** A template path reduced to its display name — the tile label a freshly
+ * picked template gets, and the label shown on the editor's template button. */
+export function templateDisplayName(path: string): string {
+	const base = (path || "").split("/").pop() ?? "";
+	return base.replace(/\.md$/i, "");
+}
+
+/**
+ * Where a tile's note will land, as one line for the editor to show under the
+ * tile's name. Pure and format-only: `folder` empty reads as the caller's
+ * "default location" wording, and an empty filename as Templater's "Untitled".
+ */
+export function destinationSummary(
+	folder: string,
+	filename: string,
+	rootLabel: string,
+	untitledLabel: string,
+): string {
+	const where = normalizeFolderPath(folder) || rootLabel;
+	const what = (filename || "").trim() || untitledLabel;
+	return `${where}/${what}.md`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export type CardKind =
 	| "recent"
 	| "links"
 	| "commands"
+	| "templater"
 	| "clock"
 	| "tasks"
 	| "calendar"
@@ -92,6 +93,50 @@ export interface CommandItem {
 	col?: number;
 	/** Free-form grid row (1-based). See LinkItem.row. */
 	row?: number;
+}
+
+/**
+ * A single tile inside a "templater" card: one template, one destination.
+ *
+ * Deliberately shaped like {@link LinkItem} and {@link CommandItem} — same
+ * label/icon/size/position fields — because the three render through the same
+ * tile machinery and share their arrange-mode drag and resize. What differs is
+ * only what a click *does*.
+ */
+export interface TemplaterItem {
+	id: string;
+	label: string;
+	/** Lucide icon id, or the vault path of an image (see `applyTileVisual`). */
+	icon: string;
+	/** Vault path of the Templater template file. */
+	template: string;
+	/** Vault-relative destination folder. Empty means Templater decides, which
+	 * in practice is Obsidian's "Default location for new notes". */
+	folder?: string;
+	/** Filename pattern, without extension. Supports `{{date}}`, `{{date:FMT}}`,
+	 * `{{time}}`, `{{time:FMT}}` and `{{prompt}}` (which asks before creating).
+	 * Empty means Templater names it "Untitled". */
+	filename?: string;
+	/** Open the new note after creating it. Default true; turn it off for tiles
+	 * that only file something away (a log entry, an inbox capture). */
+	open?: boolean;
+	/** Optional per-tile width in pixels, overriding the card's default. */
+	sizeW?: number;
+	/** Optional per-tile height in pixels, overriding the card's default. */
+	sizeH?: number;
+	/** Legacy single per-tile pixel size (drove width and height together).
+	 * Migrated to sizeW/sizeH on first read; new code writes those instead. */
+	size?: number;
+	/** Free-form grid position (1-based grid line). See LinkItem.col. */
+	col?: number;
+	/** Free-form grid row (1-based). See LinkItem.row. */
+	row?: number;
+}
+
+/** Per-card configuration for a "templater" card. */
+export interface TemplaterConfig {
+	/** The tiles, in order. */
+	items?: TemplaterItem[];
 }
 
 /** The Tasks-plugin metadata Hearth's Kanban editor reads and writes on a card.
@@ -1181,6 +1226,8 @@ export interface DashboardCard {
 	links?: LinkItem[];
 	/** kind === "commands": command-palette tiles. */
 	commands?: CommandItem[];
+	/** kind === "templater": the new-note-from-template tiles. */
+	templater?: TemplaterConfig;
 	/** kind === "recent": how many recent files to show. */
 	count?: number;
 	/** kind === "recent": file-type group ids (see FILE_TYPE_GROUPS) to include.
@@ -1263,11 +1310,11 @@ export interface DashboardCard {
 	 * only the results show. No effect on non-base embeds. */
 	hideBaseHeader?: boolean;
 
-	/** kind === "commands": pixel size of the command tiles (min column width).
-	 * Omitted means the default tile size. */
+	/** kind === "commands" / "templater": pixel size of the tiles (min column
+	 * width). Omitted means the default tile size. */
 	tileSize?: number;
 
-	/** kind === "links" / "commands" (beta): when true, tiles auto-shift out
+	/** kind === "links" / "commands" / "templater" (beta): when true, tiles auto-shift out
 	 * of the way (swap with a placeholder) as one is dragged, so the layout
 	 * reorders live like phone widgets. Default off — tiles are pure
 	 * free-form and may overlap. */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -90,6 +90,94 @@ export function confirmAction(
 	new ConfirmModal(app, opts).open();
 }
 
+/**
+ * A one-field text dialog: a label, an input, Cancel and OK.
+ *
+ * Used where a click needs one more piece of information before it can do
+ * anything — the Templater card's `{{prompt}}` filename token. Resolves with
+ * the typed text, or `null` when the user cancelled, so "" (an empty answer the
+ * user did confirm) stays distinguishable from "never mind".
+ */
+export class PromptModal extends Modal {
+	private label: string;
+	private initial: string;
+	private placeholder: string;
+	private onDone: (value: string | null) => void;
+	/** Set once the user commits, so onClose knows not to report a cancel. */
+	private settled = false;
+
+	constructor(
+		app: App,
+		opts: {
+			title: string;
+			label: string;
+			initial?: string;
+			placeholder?: string;
+			onDone: (value: string | null) => void;
+		},
+	) {
+		super(app);
+		this.titleEl.setText(opts.title);
+		this.label = opts.label;
+		this.initial = opts.initial ?? "";
+		this.placeholder = opts.placeholder ?? "";
+		this.onDone = opts.onDone;
+	}
+
+	onOpen(): void {
+		let value = this.initial;
+		const submit = (): void => {
+			this.settled = true;
+			this.close();
+			this.onDone(value);
+		};
+		const field = new Setting(this.contentEl).setName(this.label).addText((txt) => {
+			txt
+				.setPlaceholder(this.placeholder)
+				.setValue(value)
+				.onChange((v) => {
+					value = v;
+				});
+			// Enter is how anyone types a name into a one-field dialog; without
+			// this it would submit nothing and close.
+			txt.inputEl.addEventListener("keydown", (e: KeyboardEvent) => {
+				if (e.key !== "Enter") return;
+				e.preventDefault();
+				submit();
+			});
+			window.setTimeout(() => {
+				txt.inputEl.focus();
+				txt.inputEl.select();
+			}, 0);
+		});
+		field.settingEl.addClass("hearth-prompt-field");
+
+		new Setting(this.contentEl)
+			.addButton((b) => b.setButtonText(t().confirm.cancel).onClick(() => this.close()))
+			.addButton((b) => b.setButtonText(t().confirm.ok).setCta().onClick(submit));
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+		// Dismissing the modal any other way (Escape, the backdrop, Cancel) is a
+		// cancel, and the caller must hear about it exactly once.
+		if (!this.settled) {
+			this.settled = true;
+			this.onDone(null);
+		}
+	}
+}
+
+/** Convenience: open a one-field prompt and await the answer (null = cancelled). */
+export function promptForText(
+	app: App,
+	opts: { title: string; label: string; initial?: string; placeholder?: string },
+): Promise<string | null> {
+	return new Promise((resolve) => {
+		new PromptModal(app, { ...opts, onDone: resolve }).open();
+	});
+}
+
 /** Trigger a download of `content` as a file named `filename`. Uses a transient
  * object URL and a synthesized anchor click — the standard, dependency-free way
  * to save a generated file from a plugin. */

--- a/styles.css
+++ b/styles.css
@@ -2646,6 +2646,16 @@
 	transform: translateY(-1px);
 }
 
+/* A tile whose action is still running — the Templater card creating a note,
+   which may involve a prompt of Templater's own. The tile stays in place and
+   keeps its label; it just stops accepting a second click, so an impatient
+   double-click can't make two notes. */
+.hearth-link-tile.is-busy {
+	opacity: 0.6;
+	pointer-events: none;
+	cursor: progress;
+}
+
 /* A tile fully/partially hidden behind another tile — an undesirable overlap.
  * Glow it with the accent (and a warning tint) so the user notices and fixes
  * it. Only applied in arrange mode. */

--- a/test/cards-registry.test.ts
+++ b/test/cards-registry.test.ts
@@ -76,6 +76,13 @@ describe("CARD_TEMPLATES (add-card menu)", () => {
 			{ id: "web", icon: "globe", category: "tools", requires: null, build: { kind: "web", title: "Web", url: "", w: 6, h: 4 } },
 
 			// ---- Integrations ----
+			{
+				id: "templater",
+				icon: "file-plus-2",
+				category: "integrations",
+				requires: "Templater",
+				build: { kind: "templater", title: "New note", templater: { items: [] }, w: 6, h: 2 },
+			},
 			{ id: "dataview", icon: "database", category: "integrations", requires: "Dataview", build: { kind: "dataview", title: "Dataview", dataview: {}, w: 6, h: 4 } },
 			{ id: "datacore", icon: "database-zap", category: "integrations", requires: "Datacore", build: { kind: "datacore", title: "Datacore", datacore: {}, w: 6, h: 4 } },
 			{
@@ -143,7 +150,7 @@ describe("CARD_TEMPLATES (add-card menu)", () => {
 	// only how to badge it.
 	it("offers plugin-backed cards even when the plugin is missing", () => {
 		const app = { plugins: { enabledPlugins: new Set<string>(), plugins: {} } } as unknown as App;
-		for (const id of ["dataview", "datacore", "git"]) {
+		for (const id of ["dataview", "datacore", "git", "templater"]) {
 			const template = CARD_TEMPLATES.find((tpl) => tpl.id === id);
 			expect(template, id).toBeDefined();
 			expect(unmetRequirement(app, template!)?.name, id).toBeTruthy();
@@ -183,6 +190,9 @@ function maximalCard(): DashboardCard {
 		title: "Everything",
 		links: [{ label: "A", href: "a" } as never],
 		commands: [{ id: "c", name: "C" }],
+		templater: {
+			items: [{ id: "t1", label: "Meeting", icon: "file-plus-2", template: "Templates/Meeting.md" }],
+		},
 		secondView: { target: "sv" },
 		slideshow: { slides: [{ id: "s1", path: "Photos/a.png", caption: "A" }] },
 		tasks: {
@@ -235,6 +245,8 @@ describe("cloneCard deep-clone independence", () => {
 		// Mutate every nested structure on the copy...
 		copy.links![0].label = "B";
 		copy.commands![0].name = "D";
+		copy.templater!.items![0].label = "Standup";
+		copy.templater!.items!.push({ id: "t2", label: "Book", icon: "book", template: "Templates/Book.md" });
 		(copy.secondView as { target: string }).target = "sv2";
 		copy.slideshow!.slides![0].caption = "B";
 		copy.slideshow!.slides!.push({ id: "s2", path: "Photos/b.png" });
@@ -272,6 +284,7 @@ describe("cloneCard deep-clone independence", () => {
 		const pristine = maximalCard();
 		expect(orig.links).toEqual(pristine.links);
 		expect(orig.commands).toEqual(pristine.commands);
+		expect(orig.templater).toEqual(pristine.templater);
 		expect(orig.secondView).toEqual(pristine.secondView);
 		expect(orig.slideshow).toEqual(pristine.slideshow);
 		expect(orig.tasks).toEqual(pristine.tasks);
@@ -312,6 +325,7 @@ describe("liveness classification", () => {
 			recent: "static",
 			links: "static",
 			commands: "static",
+			templater: "static",
 			clock: "static",
 			tasks: "vault",
 			calendar: "vault",

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -42,6 +42,7 @@ function emptyDetection(over: Partial<SetupDetection> = {}): SetupDetection {
 		taskNotes: null,
 		basePath: null,
 		kanbanPath: null,
+		templaterTemplates: [],
 		...over,
 	};
 }
@@ -330,6 +331,48 @@ describe("planCards", () => {
 			kanbanFile: "Boards/Work.md",
 			layout: "kanban",
 		});
+	});
+
+	it("seeds a tile per detected Templater template", () => {
+		const templater = planCards(
+			blankAnswers({ integrations: ["templater"] }),
+			emptyDetection({
+				templaterTemplates: ["Templates/Meeting.md", "Templates/Book note.md"],
+			}),
+			(i) => `c${i}`,
+		).find((p) => p.id === "templater");
+
+		expect(templater?.card.templater?.items).toEqual([
+			{ id: "templater-0", label: "Meeting", icon: "file-plus-2", template: "Templates/Meeting.md" },
+			{ id: "templater-1", label: "Book note", icon: "file-plus-2", template: "Templates/Book note.md" },
+		]);
+	});
+
+	// The review step draws the plan and then the finish step builds it again, so
+	// a card whose contents depended on the clock or the RNG would arrive
+	// different from the one that was previewed.
+	it("plans the same Templater card twice in a row", () => {
+		const plan = (): unknown =>
+			planCards(
+				blankAnswers({ integrations: ["templater"] }),
+				emptyDetection({ templaterTemplates: ["Templates/Meeting.md"] }),
+				(i) => `c${i}`,
+			).find((p) => p.id === "templater")?.card;
+
+		expect(plan()).toEqual(plan());
+	});
+
+	// Accepting an integration whose evidence has gone (the templates were moved
+	// between the detection pass and the finish step) must drop the card rather
+	// than plant an empty launchpad.
+	it("skips the Templater card when no templates were found", () => {
+		const planned = planCards(
+			blankAnswers({ integrations: ["templater"] }),
+			emptyDetection(),
+			(i) => `c${i}`,
+		);
+
+		expect(planned.some((p) => p.id === "templater")).toBe(false);
 	});
 
 	it("embeds the detected base under its own name", () => {

--- a/test/templater.test.ts
+++ b/test/templater.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import { TFile, type App } from "obsidian";
+import {
+	TEMPLATER_PLUGIN_ID,
+	destinationSummary,
+	expandTemplaterFilename,
+	filenameNeedsPrompt,
+	getTemplaterPlugin,
+	isTemplaterAvailable,
+	isTemplaterTemplate,
+	normalizeFolderPath,
+	templateDisplayName,
+	templaterTemplatesFolder,
+} from "../src/templater";
+
+/**
+ * The Templater integration. The calls *into* Templater are Obsidian API and
+ * stay untested (per the no-mocks rule); what's covered here is everything
+ * Hearth decides on its own — which files count as templates, what a filename
+ * pattern expands to, and where the note is going to land — plus that the
+ * plugin probes survive every shape of app object Obsidian can hand them.
+ */
+
+/** A stand-in `App` exposing only what the probes read. */
+function fakeApp(plugin?: unknown): App {
+	return {
+		plugins: { plugins: plugin === undefined ? {} : { [TEMPLATER_PLUGIN_ID]: plugin } },
+	} as unknown as App;
+}
+
+/** A stand-in `TFile`: the probes only read `path` and `extension`. */
+function file(path: string): TFile {
+	return Object.assign(new TFile(), { path, extension: path.split(".").pop() ?? "" });
+}
+
+/** A Templater instance shaped like the real one. */
+function templaterPlugin(templatesFolder = "Templates"): unknown {
+	return {
+		templater: { create_new_note_from_template: () => Promise.resolve(undefined) },
+		editor_handler: { jump_to_next_cursor_location: () => Promise.resolve() },
+		settings: { templates_folder: templatesFolder },
+	};
+}
+
+describe("reaching the plugin", () => {
+	it("reports unavailable when Templater isn't installed", () => {
+		expect(getTemplaterPlugin(fakeApp())).toBeNull();
+		expect(isTemplaterAvailable(fakeApp())).toBe(false);
+	});
+
+	it("reports unavailable when the one method Hearth needs is gone", () => {
+		// A Templater that renamed create_new_note_from_template must disable the
+		// card, not throw inside a dashboard render.
+		expect(isTemplaterAvailable(fakeApp({ templater: {} }))).toBe(false);
+		expect(isTemplaterAvailable(fakeApp({}))).toBe(false);
+	});
+
+	it("reports available for a plugin exposing it", () => {
+		expect(isTemplaterAvailable(fakeApp(templaterPlugin()))).toBe(true);
+	});
+
+	it("survives an app with no plugin registry at all", () => {
+		const bare = {} as App;
+		expect(getTemplaterPlugin(bare)).toBeNull();
+		expect(isTemplaterAvailable(bare)).toBe(false);
+		expect(templaterTemplatesFolder(bare)).toBe("");
+	});
+
+	it("normalizes Templater's own template folder", () => {
+		expect(templaterTemplatesFolder(fakeApp(templaterPlugin("/Meta/Templates/")))).toBe(
+			"Meta/Templates",
+		);
+		expect(templaterTemplatesFolder(fakeApp(templaterPlugin("")))).toBe("");
+	});
+});
+
+describe("which files count as templates", () => {
+	it("takes only Markdown files under Templater's template folder", () => {
+		const app = fakeApp(templaterPlugin("Templates"));
+		expect(isTemplaterTemplate(app, file("Templates/Meeting.md"))).toBe(true);
+		expect(isTemplaterTemplate(app, file("Templates/Work/Standup.md"))).toBe(true);
+		expect(isTemplaterTemplate(app, file("Notes/Meeting.md"))).toBe(false);
+		expect(isTemplaterTemplate(app, file("Templates/logo.png"))).toBe(false);
+	});
+
+	// A folder prefix must match on a path *segment*: "Templates archive" is a
+	// different folder from "Templates" and its notes are not templates.
+	it("doesn't mistake a sibling folder with a shared prefix for the folder", () => {
+		const app = fakeApp(templaterPlugin("Templates"));
+		expect(isTemplaterTemplate(app, file("Templates archive/Old.md"))).toBe(false);
+	});
+
+	// Templater treats an unset folder as "any file may be a template", and the
+	// picker has to offer the same set or a working setup becomes unreachable.
+	it("takes every Markdown file when no template folder is configured", () => {
+		const app = fakeApp(templaterPlugin(""));
+		expect(isTemplaterTemplate(app, file("Notes/Meeting.md"))).toBe(true);
+		expect(isTemplaterTemplate(app, file("Notes/photo.jpg"))).toBe(false);
+	});
+});
+
+describe("filename patterns", () => {
+	// 14:05 on 2024-03-09, in the frozen UTC test timezone.
+	const now = new Date(Date.UTC(2024, 2, 9, 14, 5));
+
+	it("substitutes the bare date and time tokens", () => {
+		expect(expandTemplaterFilename("Meeting {{date}}", now)).toBe("Meeting 2024-03-09");
+		expect(expandTemplaterFilename("Log {{time}}", now)).toBe("Log 14-05");
+	});
+
+	it("honours an explicit moment format", () => {
+		expect(expandTemplaterFilename("{{date:YYYY-MM}} review", now)).toBe("2024-03 review");
+		expect(expandTemplaterFilename("{{time:HHmm}}", now)).toBe("1405");
+	});
+
+	it("leaves an unknown token alone so a typo is visible", () => {
+		expect(expandTemplaterFilename("{{titel}} note", now)).toBe("{{titel}} note");
+	});
+
+	it("fills {{prompt}} with what the user typed", () => {
+		expect(expandTemplaterFilename("Idea — {{prompt}}", now, "kanban ideas")).toBe(
+			"Idea — kanban ideas",
+		);
+	});
+
+	it("drops {{prompt}} to nothing when nothing was typed", () => {
+		expect(expandTemplaterFilename("{{prompt}}", now, "")).toBe("");
+	});
+
+	// The default time format avoids ":" deliberately — it is illegal in a
+	// filename on Windows, and sanitizing would swallow it either way.
+	it("never emits a character illegal in a vault filename", () => {
+		expect(expandTemplaterFilename("{{time}}", now)).not.toContain(":");
+		expect(expandTemplaterFilename("{{date:YYYY/MM}}", now)).toBe("2024 03");
+	});
+
+	// The typed value goes straight into a path, so this is the check that stops
+	// a prompt answer from writing outside the tile's folder.
+	it("can't escape the destination folder through the prompt", () => {
+		expect(expandTemplaterFilename("{{prompt}}", now, "../../secrets")).toBe(".. .. secrets");
+	});
+
+	it("knows which patterns need asking about", () => {
+		expect(filenameNeedsPrompt("{{prompt}}")).toBe(true);
+		expect(filenameNeedsPrompt("Idea — {{ PROMPT }}")).toBe(true);
+		expect(filenameNeedsPrompt("Meeting {{date}}")).toBe(false);
+		expect(filenameNeedsPrompt("")).toBe(false);
+	});
+});
+
+describe("folder paths", () => {
+	it("strips the slashes a picker or a typo leaves behind", () => {
+		expect(normalizeFolderPath("/Journal/")).toBe("Journal");
+		expect(normalizeFolderPath("  Journal/Daily  ")).toBe("Journal/Daily");
+	});
+
+	// The folder picker offers the vault root as "/", and "" is what the card
+	// stores for "let Templater decide" — the two must collapse to one value.
+	it("collapses the vault root to the empty path", () => {
+		expect(normalizeFolderPath("/")).toBe("");
+		expect(normalizeFolderPath("")).toBe("");
+	});
+});
+
+describe("display strings", () => {
+	it("names a template after its file", () => {
+		expect(templateDisplayName("Templates/Meeting note.md")).toBe("Meeting note");
+		expect(templateDisplayName("Meeting.MD")).toBe("Meeting");
+		expect(templateDisplayName("")).toBe("");
+	});
+
+	it("spells out where a tile's note will land", () => {
+		expect(destinationSummary("Journal", "{{date}}", "Default", "Untitled")).toBe(
+			"Journal/{{date}}.md",
+		);
+	});
+
+	it("falls back to the caller's wording for the unset halves", () => {
+		expect(destinationSummary("", "", "Default location", "Untitled")).toBe(
+			"Default location/Untitled.md",
+		);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds a **Templater** integration as a new card kind — a third tile card beside Links and Commands, except each button *makes* a note.

A tile carries three things: one of your [Templater](https://github.com/SilentVoid13/Templater) templates, the folder the note goes in, and what it is called. One click creates it.

**The destination is the point.** Templater's own per-template commands drop the note wherever Obsidian's "Default location for new notes" says, so one template can only ever land in one place. A tile carries its own folder, so *Meeting* → `Work/Meetings`, *Book note* → `Library` and *Idea* → `Inbox` are three buttons over one or three templates.

**Filenames are patterns.** `{{date}}`, `{{date:YYYY-MM}}`, `{{time}}` and `{{time:HH-mm}}` are substituted on click, and `{{prompt}}` asks for the rest of the name first — so `Meeting {{date}} — {{prompt}}` is one click and one line typed. Empty lets Templater name the note, as its own command does.

**Hearth does none of the templating.** `src/templater.ts` calls `create_new_note_from_template` on the running plugin and nothing else, so user scripts, `tp.system.prompt()` dialogs, folder templates and `tp.file.cursor()` behave exactly as they do everywhere else. Templater exposes no versioned `api` object, so — as with obsidian-git — every member is declared optional and every call site checks for the function first: a renamed method disables the card rather than throwing inside a dashboard render.

**One deliberate override: where the note opens.** `create_new_note_from_template(open_new_note = true)` opens into `getLeaf(false)` — the *active* leaf, which on a dashboard click is the Hearth tab itself, so the board would replace itself regardless of the user's "Open notes in" setting. The call therefore always passes `false` and the result goes through Hearth's own opener (#106), then asks Templater to run its cursor jump so `tp.file.cursor()` still works.

Tiles drag, resize and overlap through the existing tile machinery, take a Lucide icon or a vault image, and can be told to file the note away silently instead of opening it. The template picker is scoped to Templater's own template folder.

Also in this PR:

- **Templater joins the integrations catalogue** (`src/integrations.ts`), so the Integrations tab reports its live status like every other plugin.
- **The setup wizard offers the card** when the vault actually has templates — seeded with a tile per template, capped at six — so it arrives usable rather than blank. Offered on the strength of *templates existing*, not merely the plugin being on: a launchpad of zero buttons is worse than no card.
- **`PromptModal` / `promptForText` in `ui.ts`** — a generic one-field dialog, which is what `{{prompt}}` needs. Resolves `null` on cancel, so an empty-but-confirmed answer stays distinguishable from "never mind".

### Files

| File | |
| --- | --- |
| `src/templater.ts` | new — plugin access + pure helpers (filename expansion, folder normalization, template scoping) |
| `src/cards/templater.ts` | new — render, editor, `CardDefinition` |
| `src/onboarding/{detect,plan}.ts` | wizard detection and the planned card |
| `src/types.ts`, `src/cards/index.ts`, `src/integrations.ts`, `src/locales/en.ts`, `src/ui.ts`, `styles.css` | registration, strings, one CSS rule for a busy tile |
| `test/templater.test.ts` | new — 22 cases over the pure logic and the plugin probes |
| `test/{cards-registry,onboarding}.test.ts` | the characterization snapshots, extended for the new kind |

## Related issue

None — happy to open one retroactively if you'd rather have the discussion on record.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault

`npm run typecheck`, `npm run lint` (0 errors — the single new warning is the same `setDynamicTooltip` deprecation every other slider in the repo carries), `npm test` (786 passed) and `npm run build` are all clean.

**Not** vault-tested: this ran in a headless container with no Obsidian and no Templater install, so every call *into* Templater is verified against its source rather than exercised. Worth a run in a real vault before merging — particularly the `{{prompt}}` flow and the cursor jump after opening.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQXSWKmndEVXdg2uZmz9Bs)_