### PR TITLE
fix(recent): honour a file count above ten, and offer fit-to-height (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,17 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **Recent files shows every file you asked for — or as many as the card is
+  tall.** Setting **Number of files** to 15 listed ten and left the rest of the
+  card empty, because Obsidian's own recent-files list stops at ten entries and
+  no amount of asking afterwards makes it longer. Hearth now keeps its own
+  recent-file history — up to 50 files, deduplicated, most recent first, stored
+  per vault on this machine like Obsidian's own and following renames — so a
+  larger number is a number the card can actually fill. The setting is clamped
+  to what that history holds rather than accepting a value it would quietly
+  ignore. And a new **Fit to card height** toggle lists as many files as the
+  card has room for, so a tall card fills instead of ending in a band of unused
+  space, and resizing it changes how many appear.
 - **Arranging a fit-to-page board keeps the arrangement.** On a board whose
   cards are taller than the pane — which is what happens as soon as you zoom
   Obsidian in, so it depended on your screen and zoom level rather than on

--- a/src/cards/recent.ts
+++ b/src/cards/recent.ts
@@ -1,10 +1,18 @@
-import { setIcon, Setting, TFile } from "obsidian";
+import { type Component, debounce, setIcon, Setting, TFile } from "obsidian";
 import { emptyState } from "../cardbodies";
 import { addResetButton } from "../editors";
 import { applyFileIcon, fileIconOptions, resolveFileIcon } from "../fileicons";
 import { FILE_TYPE_GROUPS, fileTypeLabel, FOLDERS_GROUP_ID, groupForFile } from "../filetypes";
 import { t } from "../i18n";
 import { openFile } from "../opener";
+import {
+	clampRecentCount,
+	RECENT_COUNT_DEFAULT,
+	RECENT_COUNT_MIN,
+	RECENT_HISTORY_MAX,
+	recentFilePaths,
+	rowsThatFit,
+} from "../recentfiles";
 import { type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -13,15 +21,24 @@ import { type CardDefinition, type CardEditorContext } from "./definition";
 
 // ---- Recent files -------------------------------------------------------
 
-export function renderRecent(view: HomeView, card: DashboardCard, body: HTMLElement): void {
-	const count = card.count && card.count > 0 ? card.count : 8;
+export function renderRecent(
+	view: HomeView,
+	card: DashboardCard,
+	body: HTMLElement,
+	component?: Component,
+): void {
+	// "Fit to card height" asks for everything Hearth remembers and then hides
+	// whatever doesn't fit, so the row count follows the card's size. A fixed
+	// count is clamped to what the history can actually hold, so the card shows
+	// the number the editor accepted (#228).
+	const auto = card.recentAuto === true;
+	const count = auto ? RECENT_HISTORY_MAX : clampRecentCount(card.count);
 	// Optional file-type filter: keep only files whose group is selected. An
 	// empty/undefined list means no filtering (show every type). The filter is
 	// applied before the count is capped, so the card shows the N most recent
 	// files of the chosen types rather than the N most recent overall.
 	const types = card.recentTypes && card.recentTypes.length > 0 ? new Set(card.recentTypes) : null;
-	const files = view.app.workspace
-		.getLastOpenFiles()
+	const files = recentFilePaths(view.app)
 		.map((p) => view.app.vault.getAbstractFileByPath(p))
 		.filter((f): f is TFile => f instanceof TFile)
 		.filter((f) => {
@@ -46,26 +63,96 @@ export function renderRecent(view: HomeView, card: DashboardCard, body: HTMLElem
 		row.addEventListener("click", open);
 		makeClickable(row, open, file.basename);
 	}
+
+	if (auto) fitRowsToBody(body, list, component);
+}
+
+
+/**
+ * Hide the rows that don't fit the card's current height, and keep doing so as
+ * the card is resized.
+ *
+ * Measured rather than calculated: a row's height depends on the theme's font
+ * size and Obsidian's icon scale, so the only honest source is the row the
+ * browser actually laid out. Every row is un-hidden before each measurement so
+ * the step is read from a real pair of rows rather than from a remembered one,
+ * which keeps the fit correct after a font or theme change too.
+ */
+function fitRowsToBody(body: HTMLElement, list: HTMLElement, component?: Component): void {
+	const rows = Array.from(list.children).filter((el): el is HTMLElement =>
+		el.instanceOf(HTMLElement),
+	);
+	if (rows.length === 0) return;
+
+	const fit = () => {
+		if (!list.isConnected) return;
+		for (const row of rows) row.removeClass("hearth-list-item-clipped");
+		// Rows are measured against the viewport, so a body left scrolled would
+		// read the list as starting higher than it does. Nothing is meant to
+		// scroll in this mode anyway — the whole point is that the list stops at
+		// the card's edge.
+		body.scrollTop = 0;
+		const first = rows[0].getBoundingClientRect();
+		const step = rows.length > 1
+			? rows[1].getBoundingClientRect().top - first.top
+			: first.height;
+		const padBottom = parseFloat(getComputedStyle(body).paddingBottom) || 0;
+		const available = body.getBoundingClientRect().bottom - padBottom - first.top;
+		const visible = rowsThatFit(available, first.height, Math.max(0, step - first.height));
+		for (let i = visible; i < rows.length; i++) rows[i].addClass("hearth-list-item-clipped");
+	};
+
+	// Fit before the first paint, so a tall card never flashes its full list and
+	// then snaps back, then follow every resize of the card.
+	window.requestAnimationFrame(fit);
+	const observer = new ResizeObserver(debounce(fit, 60, true));
+	observer.observe(body);
+	// Without a component to hang it on (a caller that renders the card outside
+	// the dashboard's lifecycle) the observer is dropped on the next render with
+	// the element it watched; the initial fit still applies.
+	component?.register(() => observer.disconnect());
 }
 
 
 export function recentEditor(ctx: CardEditorContext, containerEl: HTMLElement): void {
 	const card = ctx.card;
-	const recent = new Setting(containerEl)
-		.setName(t().editors.recent.count)
-		.setDesc(t().editors.recent.countDesc);
-	recent.addText((txt) => {
-		txt.setValue(String(card.count ?? 8)).onChange((v) => {
-			const n = parseInt(v, 10);
-			card.count = Number.isNaN(n) ? undefined : n;
+
+	// Fit-to-height and a fixed count are the same decision, so only one of them
+	// is on screen at a time.
+	const fit = new Setting(containerEl)
+		.setName(t().editors.recent.fit)
+		.setDesc(t().editors.recent.fitDesc);
+	fit.addToggle((tg) => {
+		tg.setValue(card.recentAuto === true).onChange((v) => {
+			card.recentAuto = v ? true : undefined;
 			ctx.opts.save();
+			ctx.requestRender();
 		});
-		txt.inputEl.type = "number";
-		txt.inputEl.addClass("hearth-count-input");
 	});
-	addResetButton(ctx, recent, t().settings.resetField, () => {
-		card.count = undefined;
-	});
+
+	if (card.recentAuto !== true) {
+		const recent = new Setting(containerEl)
+			.setName(t().editors.recent.count)
+			.setDesc(t().editors.recent.countDesc(RECENT_HISTORY_MAX));
+		recent.addText((txt) => {
+			txt.setValue(String(card.count ?? RECENT_COUNT_DEFAULT)).onChange((v) => {
+				const n = parseInt(v, 10);
+				// Clamped on the way in, not on the way out: a card must never store
+				// a number it cannot honour, or the setting silently means something
+				// other than what it says (#228).
+				card.count = Number.isNaN(n) ? undefined : clampRecentCount(n);
+				ctx.opts.save();
+			});
+			txt.inputEl.type = "number";
+			txt.inputEl.min = String(RECENT_COUNT_MIN);
+			txt.inputEl.max = String(RECENT_HISTORY_MAX);
+			txt.inputEl.addClass("hearth-count-input");
+		});
+		addResetButton(ctx, recent, t().settings.resetField, () => {
+			card.count = undefined;
+		});
+	}
+
 	recentTypesEditor(ctx, containerEl, card);
 }
 
@@ -120,7 +207,7 @@ export const recentCard: CardDefinition<"recent"> = {
 	templates: [
 		{ id: "recent", name: "Recent files", icon: "history", build: () => ({ kind: "recent", title: "Recent", count: 8, w: 4, h: 3 }) },
 	],
-	render: (view, card, body) => renderRecent(view, card, body),
+	render: (view, card, body, component) => renderRecent(view, card, body, component),
 	renderEditor: (container, ctx) => recentEditor(ctx, container),
 	liveness: { mode: "static" },
 };

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -349,6 +349,7 @@ function sanitizeCard(raw: unknown, index: number): DashboardCard | null {
 	const background = str(r.background);
 	if (background !== undefined) card.background = background;
 	if (typeof r.count === "number") card.count = r.count;
+	if (typeof r.recentAuto === "boolean") card.recentAuto = r.recentAuto;
 	if (typeof r.scale === "number") card.scale = r.scale;
 	const cardImageFit = sanitizeImageFit(r.imageFit);
 	if (cardImageFit !== undefined) card.imageFit = cardImageFit;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1546,8 +1546,14 @@ export const en = {
 			refreshIntervalAria: "Refresh interval in seconds",
 		},
 		recent: {
+			fit: "Fit to card height",
+			fitDesc:
+				"List as many files as the card is tall enough to show, instead of a " +
+				"fixed number. Resizing the card changes how many appear.",
 			count: "Number of files",
-			countDesc: "How many recently-opened files to list.",
+			countDesc: (max: number) =>
+				`How many recently-opened files to list — at most ${max}, which is as ` +
+				`far back as Hearth's recent-file history goes.`,
 			types: "File types",
 			typesDesc: "Only list files of the selected types. Pick any combination; none selected shows every type.",
 		},

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { setLanguage, t } from "./i18n";
 import { maybeShowWhatsNew } from "./whatsnew";
 import { maybeRunSetup, openSetupWizard } from "./onboarding";
 import { clearContentSearchCache } from "./query";
+import { recordRecentFile, renameRecentFile } from "./recentfiles";
 import { forgetTaxonomy, OperonSession } from "./operon";
 
 /** Core "Audio recorder" plugin id, used by the "Record voice" mobile action. */
@@ -154,6 +155,19 @@ export default class HearthPlugin extends Plugin {
 		this.registerEvent(this.app.vault.on("delete", onVaultChange));
 		this.registerEvent(this.app.vault.on("rename", onVaultChange));
 		this.registerEvent(this.app.vault.on("modify", onVaultChange));
+
+		// Hearth's own recent-file history (#228). Obsidian's getLastOpenFiles()
+		// stops at ten entries, so a Recent files card asking for more has to be
+		// told about opens as they happen; a rename is followed so a moved file
+		// keeps its place instead of vanishing from the list.
+		this.registerEvent(
+			this.app.workspace.on("file-open", (file) => recordRecentFile(this.app, file)),
+		);
+		this.registerEvent(
+			this.app.vault.on("rename", (file, oldPath) =>
+				renameRecentFile(this.app, oldPath, file.path),
+			),
+		);
 
 		// Follow core-Workspace loads: when the active workspace matches a
 		// dashboard's linked workspace, switch to that dashboard. There is no

--- a/src/recentfiles.ts
+++ b/src/recentfiles.ts
@@ -1,0 +1,117 @@
+import { type App, TFile } from "obsidian";
+
+/**
+ * Hearth's own recent-file history (#228).
+ *
+ * Obsidian's `workspace.getLastOpenFiles()` is documented as returning only the
+ * ten most recently opened files, so a Recent files card asking for fifteen
+ * could never get more than ten no matter what it did with the answer. Hearth
+ * therefore keeps its own history alongside it: every file open appends a path,
+ * deduplicated, most-recent-first and capped at {@link RECENT_HISTORY_MAX}.
+ *
+ * It lives in Obsidian's per-vault local storage rather than in the plugin's
+ * settings, for the same reason Obsidian's own list lives in `workspace.json`:
+ * which files this machine opened is not a setting, and writing one on every
+ * file open would put a stream of sync traffic (and merge conflicts) through
+ * `data.json` for something no other device wants.
+ *
+ * The stored history is a supplement, never the authority. Reads start from
+ * Obsidian's list — it also covers opens from before Hearth was installed, and
+ * from other plugins' vault windows — and only then append the older tail this
+ * module remembers.
+ */
+
+/** localStorage key for the path history, per vault. */
+const HISTORY_KEY = "hearth:recent-files";
+
+/** How many paths the history keeps, and so the most a Recent files card can
+ * ever show. A ceiling, not a target: it bounds both the stored value and the
+ * work a "fit to height" card does when the card is tall. */
+export const RECENT_HISTORY_MAX = 50;
+
+/** Smallest honourable "Number of files". */
+export const RECENT_COUNT_MIN = 1;
+
+/** Default number of files a Recent files card lists. */
+export const RECENT_COUNT_DEFAULT = 8;
+
+/**
+ * Clamp a configured file count into the range Hearth can actually honour.
+ * `undefined` (the field was cleared) falls back to the default rather than to
+ * zero, which would render an empty card that looks broken.
+ */
+export function clampRecentCount(count: number | undefined): number {
+	if (count == null || Number.isNaN(count)) return RECENT_COUNT_DEFAULT;
+	return Math.min(Math.max(Math.floor(count), RECENT_COUNT_MIN), RECENT_HISTORY_MAX);
+}
+
+/**
+ * Merge Obsidian's recent-files list with Hearth's stored history, most recent
+ * first and with no path twice. Obsidian's list wins on order: it is the live
+ * truth for the last ten opens, and the history's own first entries mirror it.
+ */
+export function mergeRecentPaths(recent: readonly string[], history: readonly string[]): string[] {
+	const seen = new Set<string>();
+	const merged: string[] = [];
+	for (const path of [...recent, ...history]) {
+		if (!path || seen.has(path)) continue;
+		seen.add(path);
+		merged.push(path);
+	}
+	return merged;
+}
+
+/** Prepend `path`, dropping any earlier occurrence and anything past the cap. */
+export function pushRecentPath(history: readonly string[], path: string): string[] {
+	return [path, ...history.filter((p) => p !== path)].slice(0, RECENT_HISTORY_MAX);
+}
+
+function readHistory(app: App): string[] {
+	const raw: unknown = app.loadLocalStorage(HISTORY_KEY);
+	return Array.isArray(raw) ? raw.filter((p): p is string => typeof p === "string") : [];
+}
+
+function writeHistory(app: App, history: string[]): void {
+	app.saveLocalStorage(HISTORY_KEY, history);
+}
+
+/** Note an opened file. Cheap no-op when it is already the newest entry, so
+ * re-focusing the same tab doesn't rewrite the list. */
+export function recordRecentFile(app: App, file: TFile | null): void {
+	if (!(file instanceof TFile)) return;
+	const history = readHistory(app);
+	if (history[0] === file.path) return;
+	writeHistory(app, pushRecentPath(history, file.path));
+}
+
+/** Follow a rename so a moved file keeps its place in the history instead of
+ * silently dropping out of it (the path is all that is stored). */
+export function renameRecentFile(app: App, oldPath: string, newPath: string): void {
+	const history = readHistory(app);
+	if (!history.includes(oldPath)) return;
+	writeHistory(
+		app,
+		history.map((p) => (p === oldPath ? newPath : p)),
+	);
+}
+
+/** Recently opened vault paths, most recent first. Paths only — callers resolve
+ * them, so files deleted since are dropped by that lookup. */
+export function recentFilePaths(app: App): string[] {
+	return mergeRecentPaths(app.workspace.getLastOpenFiles(), readHistory(app));
+}
+
+/**
+ * How many rows of `rowHeight` (separated by `gap`) fit into `available`
+ * pixels. Used by the card's "fit to card height" mode, where the row count
+ * follows the card's size instead of a number typed into the editor.
+ *
+ * Always at least one: a card too short for a single row shows one clipped row
+ * rather than an empty body that reads as "no recent files".
+ */
+export function rowsThatFit(available: number, rowHeight: number, gap: number): number {
+	if (!(rowHeight > 0)) return 1;
+	// The last row carries no trailing gap, so lend one to the measurement and
+	// charge every row for it.
+	return Math.max(1, Math.floor((available + gap) / (rowHeight + gap)));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1303,8 +1303,13 @@ export interface DashboardCard {
 	commands?: CommandItem[];
 	/** kind === "templater": the new-note-from-template tiles. */
 	templater?: TemplaterConfig;
-	/** kind === "recent": how many recent files to show. */
+	/** kind === "recent": how many recent files to show. Clamped to what Hearth's
+	 * own recent-file history can hold (see RECENT_HISTORY_MAX); ignored when
+	 * `recentAuto` is on. */
 	count?: number;
+	/** kind === "recent": show as many files as fit the card's height instead of
+	 * a fixed count. Undefined/false is the fixed-count behaviour. */
+	recentAuto?: boolean;
 	/** kind === "recent": file-type group ids (see FILE_TYPE_GROUPS) to include.
 	 * Any combination of the search filter's types; undefined or empty means all
 	 * types are shown. */

--- a/styles.css
+++ b/styles.css
@@ -1954,6 +1954,14 @@
 	cursor: pointer;
 }
 
+/* A Recent files card set to "fit to card height" renders every file it
+   remembers and then clips the rows past the card's edge, so the visible count
+   follows the card's size (#228). display:none rather than visibility so the
+   hidden rows take no space and the flex column doesn't scroll. */
+.hearth-list-item-clipped {
+	display: none;
+}
+
 .hearth-list-item:hover {
 	background: var(--background-modifier-hover);
 }

--- a/test/recentfiles.test.ts
+++ b/test/recentfiles.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+	clampRecentCount,
+	mergeRecentPaths,
+	pushRecentPath,
+	RECENT_COUNT_DEFAULT,
+	RECENT_HISTORY_MAX,
+	rowsThatFit,
+} from "../src/recentfiles";
+
+/**
+ * Hearth's own recent-file history and the Recent files card's row maths
+ * (#228). Obsidian's getLastOpenFiles() stops at ten entries, so a card asking
+ * for more needs a history of its own — these cover the pure parts of it. The
+ * reads and writes themselves are Obsidian API (localStorage, workspace) and
+ * stay untested, per the no-mocks rule.
+ */
+
+describe("clampRecentCount", () => {
+	it("keeps a count Hearth can honour", () => {
+		expect(clampRecentCount(1)).toBe(1);
+		expect(clampRecentCount(8)).toBe(8);
+		expect(clampRecentCount(RECENT_HISTORY_MAX)).toBe(RECENT_HISTORY_MAX);
+	});
+
+	it("caps a count past what the history holds", () => {
+		// The bug: 15 was accepted and 10 shown. Now the stored value is one the
+		// card can actually fill.
+		expect(clampRecentCount(15)).toBe(15);
+		expect(clampRecentCount(RECENT_HISTORY_MAX + 1)).toBe(RECENT_HISTORY_MAX);
+		expect(clampRecentCount(9999)).toBe(RECENT_HISTORY_MAX);
+	});
+
+	it("refuses to render nothing", () => {
+		expect(clampRecentCount(0)).toBe(1);
+		expect(clampRecentCount(-4)).toBe(1);
+	});
+
+	it("falls back to the default when the field is empty or unparsable", () => {
+		expect(clampRecentCount(undefined)).toBe(RECENT_COUNT_DEFAULT);
+		expect(clampRecentCount(NaN)).toBe(RECENT_COUNT_DEFAULT);
+	});
+
+	it("takes the whole part of a typed decimal", () => {
+		expect(clampRecentCount(4.7)).toBe(4);
+	});
+});
+
+describe("mergeRecentPaths", () => {
+	it("puts Obsidian's list first and appends the older tail", () => {
+		expect(mergeRecentPaths(["b.md", "a.md"], ["b.md", "a.md", "old.md"])).toEqual([
+			"b.md",
+			"a.md",
+			"old.md",
+		]);
+	});
+
+	it("never lists a path twice, whichever side it came from", () => {
+		const merged = mergeRecentPaths(["a.md", "b.md"], ["b.md", "a.md", "c.md"]);
+		expect(merged).toEqual(["a.md", "b.md", "c.md"]);
+		expect(new Set(merged).size).toBe(merged.length);
+	});
+
+	it("follows Obsidian's order even when the history disagrees", () => {
+		// A file reopened in another window updates Obsidian's list; the stored
+		// history of this device is the stale one.
+		expect(mergeRecentPaths(["new.md", "a.md"], ["a.md", "new.md"])).toEqual([
+			"new.md",
+			"a.md",
+		]);
+	});
+
+	it("survives an empty side and drops empty entries", () => {
+		expect(mergeRecentPaths([], ["a.md"])).toEqual(["a.md"]);
+		expect(mergeRecentPaths(["a.md"], [])).toEqual(["a.md"]);
+		expect(mergeRecentPaths([""], ["a.md"])).toEqual(["a.md"]);
+	});
+});
+
+describe("pushRecentPath", () => {
+	it("prepends the newest open", () => {
+		expect(pushRecentPath(["a.md"], "b.md")).toEqual(["b.md", "a.md"]);
+	});
+
+	it("moves a re-opened file to the front instead of duplicating it", () => {
+		expect(pushRecentPath(["a.md", "b.md", "c.md"], "c.md")).toEqual([
+			"c.md",
+			"a.md",
+			"b.md",
+		]);
+	});
+
+	it("stays bounded", () => {
+		const full = Array.from({ length: RECENT_HISTORY_MAX }, (_, i) => `f${i}.md`);
+		const next = pushRecentPath(full, "new.md");
+		expect(next).toHaveLength(RECENT_HISTORY_MAX);
+		expect(next[0]).toBe("new.md");
+		// The oldest entry is the one that fell off the end.
+		expect(next).not.toContain(`f${RECENT_HISTORY_MAX - 1}.md`);
+	});
+});
+
+describe("rowsThatFit", () => {
+	it("charges every row but the last for its gap", () => {
+		// Three 30px rows with 2px gaps measure 94px, so 94 fits three and 93
+		// fits two.
+		expect(rowsThatFit(94, 30, 2)).toBe(3);
+		expect(rowsThatFit(93, 30, 2)).toBe(2);
+	});
+
+	it("fills a taller card with more rows", () => {
+		expect(rowsThatFit(320, 30, 2)).toBe(10);
+		expect(rowsThatFit(640, 30, 2)).toBe(20);
+	});
+
+	it("shows one row rather than an empty card when nothing fits", () => {
+		expect(rowsThatFit(10, 30, 2)).toBe(1);
+		expect(rowsThatFit(0, 30, 2)).toBe(1);
+		expect(rowsThatFit(-50, 30, 2)).toBe(1);
+	});
+
+	it("survives an unmeasurable row", () => {
+		// A body that hasn't been laid out yet measures zero; the observer
+		// re-fits once it has, so the interim answer only has to be sane.
+		expect(rowsThatFit(300, 0, 0)).toBe(1);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

The Recent files card accepted any **Number of files** but never showed more than ten. `workspace.getLastOpenFiles()` is documented as returning only the ten most recent opens, so applying a larger configured limit to its answer could not produce more entries — the setting quietly meant something other than what it said, and a card tall enough for more rows ended in a band of unused space.

**A recent-file history of Hearth's own** (`src/recentfiles.ts`). Every file open prepends a path, deduplicated, most-recent-first, capped at 50. It lives in Obsidian's per-vault local storage rather than in `data.json`, for the same reason Obsidian's own list lives in `workspace.json`: which files this machine opened is not a setting, and writing one on every open would push a stream of sync traffic (and merge conflicts) through the settings file for something no other device wants. Reads start from Obsidian's list — it stays the authority for the last ten and covers opens from before Hearth was installed — and only then append the older tail. Renames are followed, so a moved file keeps its place instead of dropping out.

**The count setting is clamped on the way in**, to `[1, 50]`, so a card can never store a number it cannot fill; the input carries the same `min`/`max` and the description names the ceiling.

**A new "Fit to card height" toggle** lists as many files as the card has room for. Rows are measured after layout rather than calculated — a row's height follows the theme's font size and Obsidian's icon scale — and the rows past the card's edge are clipped, re-fitted on every resize (debounced `ResizeObserver`, disconnected with the card's component). It replaces the count field in the editor while it is on, and leaves the stored count untouched so switching back restores it.

Layout import learned `recentAuto` so the toggle survives an export/import round trip.

## Related issue

Closes #228

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (the fit-to-height mode the issue asks for)

## Checklist

- [x] `npm run build` passes locally (`npm run typecheck`, `npm run lint` — no new warnings — and `npm test`: 919 passing, including 16 new cases in `test/recentfiles.test.ts` covering the clamp, the merge, the bounded push and the row maths, all pure per the repo's no-mocks rule)
- [x] I've tested this in an actual vault — not possible from this environment; the DOM-measuring part of the fit (row step, available height, clipping) has had no manual pass in Obsidian

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkYpTcp65hUJ615AFc8bmN)_