### PR TITLE
fix(daily): resolve daily notes whose name depends on the locale (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,17 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **Daily notes are found even when their name spells the weekday in another
+  language.** A daily-note format with a locale-dependent token — `dd`, `dddd`,
+  `Do` — was resolved by formatting the date in whatever locale Obsidian is
+  running in now, so a note written under a different one ("Wed, 19.08.2026"
+  next to a moment locale that spells it "Mi") looked missing: the day streak
+  read 0, the calendar day lost its dot and the daily card offered to create a
+  note that already existed. For those formats Hearth now reads the date back
+  out of the filenames in the daily-note folder, ignoring the parts only the
+  locale decides, so notes made by Periodic Notes with its own locale override
+  — or carried over from another machine — resolve the same as any other
+  (#229).
 - **Filtering tasks by date honours TaskNotes' scheduled dates.** A task due
   next week but scheduled for today vanished from a **Today** filter: the card
   looked only at the due date and fell back to the scheduled one when there was

--- a/src/cardbodies.ts
+++ b/src/cardbodies.ts
@@ -1,6 +1,7 @@
 import { Component, debounce, MarkdownRenderer, moment as createMoment, setIcon, Setting, TFile } from "obsidian";
 import { type CardEditorContext } from "./cards/definition";
 import { type CheckboxScanOptions, countCheckboxes, toggleCheckboxAt } from "./checkboxes";
+import { dailyNameMatcher } from "./dailyformat";
 import { localDayKey } from "./dates";
 import { t } from "./i18n";
 import { mountMarkdownEditor } from "./leafview";
@@ -552,6 +553,57 @@ export function todaysDailyNotePath(options: DailyNotesOptions): string {
 }
 
 
+/**
+ * A lookup for *existing* daily notes that survives a locale mismatch.
+ *
+ * The formatted path is tried first — that's the answer in every ordinary vault
+ * and costs one map lookup. It misses when the note's name contains a
+ * locale-dependent token (`dd`, `dddd`, `Do`) and the file was written under a
+ * different locale than the one moment is running in now — Periodic Notes with
+ * its own locale override, or a note carried over from another machine
+ * (issue #229). For those formats only, the daily-note folder is scanned once
+ * per finder and indexed by day, so the note is found by the date it encodes
+ * rather than by the weekday name moment would spell today.
+ *
+ * Create one finder per render and reuse it across days: the scan is lazy and
+ * happens at most once, however many days are probed.
+ */
+export function dailyNoteFinder(
+	view: HomeView,
+	options: DailyNotesOptions,
+): (day: Moment) => TFile | null {
+	const format = (options.format || "").trim() || "YYYY-MM-DD";
+	const folder = (options.folder || "").trim().replace(/^\/+|\/+$/g, "");
+	const matcher = dailyNameMatcher(format);
+	const prefix = folder ? `${folder}/` : "";
+	// Only a format that nests (YYYY/MM/DD) may match a name containing a
+	// separator; otherwise notes deeper in the tree aren't daily notes.
+	const nested = format.includes("/");
+	let index: Map<string, TFile> | null = null;
+
+	const scan = (): Map<string, TFile> => {
+		const found = new Map<string, TFile>();
+		for (const file of view.app.vault.getMarkdownFiles()) {
+			if (!file.path.startsWith(prefix)) continue;
+			const name = file.path.slice(prefix.length, -".md".length);
+			if (!nested && name.includes("/")) continue;
+			const key = matcher?.dayKey(name);
+			// First match wins, so a duplicate never displaces the earlier note.
+			if (key && !found.has(key)) found.set(key, file);
+		}
+		return found;
+	};
+
+	return (day: Moment): TFile | null => {
+		const direct = view.app.vault.getAbstractFileByPath(dailyNotePath(day, options));
+		if (direct instanceof TFile) return direct;
+		if (!matcher?.localeDependent) return null;
+		index ??= scan();
+		return index.get(day.format("YYYY-MM-DD")) ?? null;
+	};
+}
+
+
 /** The vault path an embed/daily card currently tracks, used to refresh the card
  * live when that file changes. Returns null when there's nothing to watch. */
 export function watchedCardPath(view: HomeView, card: DashboardCard): string | null {
@@ -561,7 +613,9 @@ export function watchedCardPath(view: HomeView, card: DashboardCard): string | n
 	if (card.kind === "daily") {
 		const options = dailyNotesOptions(view);
 		if (!options) return null;
-		return todaysDailyNotePath(options);
+		// Watch the note the card actually shows: with a locale-dependent format
+		// that can be a different name than today's path formats to (issue #229).
+		return dailyNoteFinder(view, options)(moment())?.path ?? todaysDailyNotePath(options);
 	}
 	return null;
 }

--- a/src/cards/calendar.ts
+++ b/src/cards/calendar.ts
@@ -1,7 +1,7 @@
 import { Component, setIcon, Setting, TFile } from "obsidian";
 import {
 	activityByDay,
-	dailyNotePath,
+	dailyNoteFinder,
 	dailyNotesOptions,
 	emptyState,
 	heatLevel,
@@ -252,6 +252,8 @@ function renderCalendarGrid(
 	operon: OperonOverlay,
 ): void {
 	const grid = wrap.createDiv("hearth-calendar-grid");
+	// One finder for the whole month, so its (lazy) folder scan runs at most once.
+	const noteAt = options ? dailyNoteFinder(view, options) : null;
 	const startOfWeek = moment.localeData().firstDayOfWeek();
 	const weekNumbers = cfg.showWeekNumbers === true;
 	if (weekNumbers) {
@@ -286,8 +288,7 @@ function renderCalendarGrid(
 			grid.createDiv({ cls: "hearth-calendar-wk", text: day.format("W") });
 		}
 		const dayKey = day.format("YYYY-MM-DD");
-		const path = options ? dailyNotePath(day, options) : null;
-		const file = path ? view.app.vault.getAbstractFileByPath(path) : null;
+		const file = noteAt?.(day) ?? null;
 		const isToday = dayKey === today;
 		const events = ics.on(dayKey);
 
@@ -369,6 +370,7 @@ function renderCalendarAgenda(
 	operon: OperonOverlay,
 ): void {
 	wrap.addClass("is-agenda");
+	const noteAt = options ? dailyNoteFinder(view, options) : null;
 	const days = cfg.agendaDays && cfg.agendaDays > 0 ? Math.min(cfg.agendaDays, 60) : 14;
 	const start = moment().startOf("day");
 
@@ -392,9 +394,8 @@ function renderCalendarAgenda(
 			lastMonth = day.month();
 		}
 
-		const path = options ? dailyNotePath(day, options) : null;
-		const file = path ? view.app.vault.getAbstractFileByPath(path) : null;
-		const hasNote = file instanceof TFile;
+		const file = noteAt?.(day) ?? null;
+		const hasNote = file !== null;
 		const isToday = i === 0;
 		const events = ics.on(dayKey);
 

--- a/src/cards/daily.ts
+++ b/src/cards/daily.ts
@@ -1,13 +1,14 @@
-import { Component, Notice, setIcon, Setting, TFile } from "obsidian";
+import { Component, Notice, setIcon, Setting } from "obsidian";
 import {
 	cardOverlayButton,
+	dailyNoteFinder,
 	dailyNotesOptions,
 	emptyState,
 	livePreviewSetting,
+	moment,
 	renderEditableEmbed,
 	renderLivePreviewEmbed,
 	renderMarkdownFile,
-	todaysDailyNotePath,
 	watchedCardPath,
 } from "../cardbodies";
 import { t } from "../i18n";
@@ -34,10 +35,9 @@ export function renderDaily(
 		return;
 	}
 
-	const path = todaysDailyNotePath(options);
-	const file = view.app.vault.getAbstractFileByPath(path);
+	const file = dailyNoteFinder(view, options)(moment());
 
-	if (!(file instanceof TFile)) {
+	if (!file) {
 		const empty = body.createDiv("hearth-card-empty");
 		setIcon(empty.createDiv("hearth-card-empty-icon"), "calendar-plus");
 		empty.createDiv({ cls: "hearth-card-empty-text", text: t().cards.daily.noNoteYet });

--- a/src/cards/schedule.ts
+++ b/src/cards/schedule.ts
@@ -1,6 +1,6 @@
 import { Component, setIcon, setTooltip, Setting, TFile } from "obsidian";
 import {
-	dailyNotePath,
+	dailyNoteFinder,
 	dailyNotesOptions,
 	emptyState,
 	moment,
@@ -91,7 +91,8 @@ export function renderSchedule(
 		);
 		if (cfg.hideToolbar !== true) renderToolbar(wrap, state, cfg, range.label, draw);
 		const main = wrap.createDiv("hearth-sched-body");
-		const ctx: ViewContext = { view, cfg, options, ics, component, redraw: draw };
+		const noteAt = options ? dailyNoteFinder(view, options) : null;
+		const ctx: ViewContext = { view, cfg, options, noteAt, ics, component, redraw: draw };
 		if (state.view === "month") renderMonth(main, state, ctx);
 		else if (state.view === "list") renderList(main, state, ctx);
 		else renderTimeGrid(main, state, ctx);
@@ -109,6 +110,8 @@ interface ViewContext {
 	cfg: ScheduleConfig;
 	/** Daily-notes settings, or null when the card doesn't touch daily notes. */
 	options: DailyNotesOptions | null;
+	/** Locale-tolerant lookup of a day's existing note, paired with `options`. */
+	noteAt: ((day: Moment) => TFile | null) | null;
 	ics: IcsContext;
 	component: Component;
 	/** Redraw the whole card (after navigating or switching view). */
@@ -305,9 +308,7 @@ function viewName(view: ScheduleView): string {
 
 /** The daily note for a day, when the card is showing daily notes at all. */
 function noteFor(ctx: ViewContext, day: Moment): TFile | null {
-	if (!ctx.options) return null;
-	const file = ctx.view.app.vault.getAbstractFileByPath(dailyNotePath(day, ctx.options));
-	return file instanceof TFile ? file : null;
+	return ctx.noteAt?.(day) ?? null;
 }
 
 /** Clicking a day's number: its daily note, opened or offered for creation.

--- a/src/cards/stats.ts
+++ b/src/cards/stats.ts
@@ -1,5 +1,5 @@
 import { getAllTags, setIcon, Setting, TFile, TFolder } from "obsidian";
-import { dailyNotePath, dailyNotesOptions, moment, type Moment } from "../cardbodies";
+import { dailyNoteFinder, dailyNotesOptions, moment, type Moment } from "../cardbodies";
 import { addResetButton, moveItem } from "../editors";
 import { FILE_TYPE_GROUPS, fileTypeLabel, FOLDERS_GROUP_ID, groupById, groupForFile } from "../filetypes";
 import { t } from "../i18n";
@@ -116,13 +116,15 @@ function dailyNoteStreak(view: HomeView): number | null {
 	const options = dailyNotesOptions(view);
 	if (!options) return null;
 
+	// One finder for the whole walk: the folder scan its locale-tolerant path
+	// may need happens once, not once per day (issue #229).
+	const noteAt = dailyNoteFinder(view, options);
+
 	let day: Moment = moment();
-	if (!(view.app.vault.getAbstractFileByPath(dailyNotePath(day, options)) instanceof TFile)) {
-		day = day.clone().subtract(1, "day");
-	}
+	if (!noteAt(day)) day = day.clone().subtract(1, "day");
 
 	let streak = 0;
-	while (view.app.vault.getAbstractFileByPath(dailyNotePath(day, options)) instanceof TFile) {
+	while (noteAt(day)) {
 		streak++;
 		day = day.clone().subtract(1, "day");
 		if (streak > 3650) break;

--- a/src/dailyformat.ts
+++ b/src/dailyformat.ts
@@ -1,0 +1,183 @@
+/**
+ * Locale-tolerant matching of daily-note filenames (issue #229).
+ *
+ * A daily note is named by a moment format string, and several of its tokens
+ * render differently per locale: `dd`/`ddd`/`dddd` (weekday), `Do` (ordinal
+ * day), `MMM`/`MMMM` (month name), `A`/`a` (meridiem). The file on disk was
+ * written by whoever created it — the core Daily notes plugin, Periodic Notes
+ * with its own locale override, a template, or another machine — so formatting
+ * the same date under the locale moment happens to be running in *now* can
+ * produce a different name than the one that exists: "Mi, 19.08.2026.md" for
+ * an existing "Wed, 19.08.2026.md". A caller that only builds a path and looks
+ * it up then misses the note entirely (a day streak reads 0, a calendar day
+ * loses its dot).
+ *
+ * `dailyNameMatcher` turns the format into a regular expression that reads the
+ * date back *out* of a filename, wildcarding every locale-dependent token —
+ * none of them carries date information a numeric token doesn't already pin
+ * down. It only reports a matcher when the format fixes the year, month and
+ * day numerically; any other format (a month spelled out, a day-of-year, an
+ * ISO-week date) keeps the exact-path behaviour it has always had, because
+ * there the filename can't be read back without knowing the writing locale.
+ */
+
+export interface DailyNameMatcher {
+	/** True when the format contains a token that renders per locale — the only
+	 * case where scanning the folder can find a note a formatted path missed. */
+	localeDependent: boolean;
+	/** The `YYYY-MM-DD` day a filename (no folder, no `.md`) encodes, or null
+	 * when the name isn't a daily note in this format. */
+	dayKey(name: string): string | null;
+}
+
+
+/** moment format tokens, longest first so `YYYY` wins over `YY`. */
+const TOKEN =
+	/^(?:YYYY|YY|MMMM|MMM|MM|M|DDDD|DDD|Do|DD|D|dddd|ddd|dd|do|d|E|e|Q|Wo|WW|W|wo|ww|w|gggg|gg|GGGG|GG|HH|H|hh|h|kk|k|mm|m|ss|s|SSS|SS|S|ZZ|Z|A|a|X|x)/;
+
+/** Tokens whose rendering depends on the active locale. */
+const LOCALE_TOKENS = new Set(["MMMM", "MMM", "Do", "do", "dddd", "ddd", "dd", "Wo", "wo", "A", "a"]);
+
+/** Tokens we can't invert: they either name the date in words (month names) or
+ * express it in a numbering we'd have to reconstruct (day of year, ISO weeks).
+ * A format using one keeps exact-path matching. */
+const OPAQUE_TOKENS = new Set([
+	"MMMM",
+	"MMM",
+	"DDDD",
+	"DDD",
+	"Wo",
+	"WW",
+	"W",
+	"wo",
+	"ww",
+	"w",
+	"gggg",
+	"gg",
+	"GGGG",
+	"GG",
+]);
+
+/** Everything else: the regex fragment a token matches, with no date meaning. */
+const FILLERS: Record<string, string> = {
+	dddd: "[^/]+?",
+	ddd: "[^/]+?",
+	dd: "[^/]+?",
+	do: "\\d{1,2}[^\\d/]{0,3}",
+	d: "\\d",
+	E: "\\d",
+	e: "\\d",
+	Q: "\\d",
+	HH: "\\d{2}",
+	H: "\\d{1,2}",
+	hh: "\\d{2}",
+	h: "\\d{1,2}",
+	kk: "\\d{2}",
+	k: "\\d{1,2}",
+	mm: "\\d{2}",
+	m: "\\d{1,2}",
+	ss: "\\d{2}",
+	s: "\\d{1,2}",
+	SSS: "\\d{3}",
+	SS: "\\d{2}",
+	S: "\\d",
+	ZZ: "[+-]\\d{4}",
+	Z: "[+-]\\d{2}:\\d{2}",
+	A: "[^/]+?",
+	a: "[^/]+?",
+	X: "\\d+",
+	x: "\\d+",
+};
+
+
+function escapeLiteral(text: string): string {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+
+/**
+ * Build a matcher for a daily-note filename format, or null when the format
+ * can't be read back (no numeric year/month/day, or an opaque token).
+ */
+export function dailyNameMatcher(format: string): DailyNameMatcher | null {
+	let source = "";
+	let localeDependent = false;
+	let groups = 0;
+	// Capture-group index per date part; 0 means "not seen yet". A repeated
+	// token (say two `DD`) is matched non-capturing the second time, so the
+	// group numbering stays stable.
+	let year = 0;
+	let yearShort = false;
+	let month = 0;
+	let day = 0;
+
+	for (let i = 0; i < format.length; ) {
+		const ch = format[i];
+		// moment's own escaping: [text] is emitted verbatim.
+		if (ch === "[") {
+			const end = format.indexOf("]", i + 1);
+			if (end === -1) return null;
+			source += escapeLiteral(format.slice(i + 1, end));
+			i = end + 1;
+			continue;
+		}
+		const token = TOKEN.exec(format.slice(i))?.[0];
+		if (!token) {
+			source += escapeLiteral(ch);
+			i += 1;
+			continue;
+		}
+		i += token.length;
+		if (OPAQUE_TOKENS.has(token)) return null;
+		if (LOCALE_TOKENS.has(token)) localeDependent = true;
+
+		if (token === "YYYY" || token === "YY") {
+			const digits = token === "YYYY" ? "\\d{4}" : "\\d{2}";
+			if (year) source += `(?:${digits})`;
+			else {
+				year = ++groups;
+				yearShort = token === "YY";
+				source += `(${digits})`;
+			}
+		} else if (token === "MM" || token === "M") {
+			const digits = token === "MM" ? "\\d{2}" : "\\d{1,2}";
+			if (month) source += `(?:${digits})`;
+			else {
+				month = ++groups;
+				source += `(${digits})`;
+			}
+		} else if (token === "DD" || token === "D" || token === "Do") {
+			const digits = token === "DD" ? "\\d{2}" : "\\d{1,2}";
+			const suffix = token === "Do" ? "[^\\d/]{0,3}" : "";
+			if (day) source += `(?:${digits})${suffix}`;
+			else {
+				day = ++groups;
+				source += `(${digits})${suffix}`;
+			}
+		} else {
+			source += FILLERS[token] ?? escapeLiteral(token);
+		}
+	}
+
+	if (!year || !month || !day) return null;
+
+	const re = new RegExp(`^${source}$`);
+	return {
+		localeDependent,
+		dayKey(name: string): string | null {
+			const m = re.exec(name);
+			if (!m) return null;
+			let y = Number(m[year]);
+			// moment's two-digit year rule: 00–68 is 2000s, 69–99 is 1900s.
+			if (yearShort) y += y < 69 ? 2000 : 1900;
+			const mo = Number(m[month]);
+			const d = Number(m[day]);
+			// Reject a name that parses but isn't a real date (31.02, month 13).
+			const date = new Date(Date.UTC(y, mo - 1, d));
+			if (date.getUTCFullYear() !== y || date.getUTCMonth() !== mo - 1 || date.getUTCDate() !== d) {
+				return null;
+			}
+			return `${String(y).padStart(4, "0")}-${String(mo).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+		},
+	};
+}

--- a/test/dailyformat.test.ts
+++ b/test/dailyformat.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { dailyNameMatcher } from "../src/dailyformat";
+
+/**
+ * Reading a date back out of a daily-note filename (issue #229). The point of
+ * the matcher is that the weekday in a name like "Wed, 19.08.2026" is noise:
+ * whatever locale wrote it, the numbers still say which day it is.
+ */
+
+describe("dailyNameMatcher", () => {
+	it("reads a plain ISO format without calling it locale-dependent", () => {
+		const m = dailyNameMatcher("YYYY-MM-DD");
+		expect(m?.localeDependent).toBe(false);
+		expect(m?.dayKey("2026-08-19")).toBe("2026-08-19");
+		expect(m?.dayKey("2026-08-19 notes")).toBeNull();
+		expect(m?.dayKey("Random")).toBeNull();
+	});
+
+	it("ignores the weekday in a locale-dependent format", () => {
+		const m = dailyNameMatcher("dd, DD.MM.YYYY");
+		expect(m?.localeDependent).toBe(true);
+		// Same day, three locales' short weekday names — all resolve.
+		expect(m?.dayKey("Wed, 19.08.2026")).toBe("2026-08-19");
+		expect(m?.dayKey("Mi, 19.08.2026")).toBe("2026-08-19");
+		expect(m?.dayKey("st, 19.08.2026")).toBe("2026-08-19");
+		expect(m?.dayKey("19.08.2026")).toBeNull();
+	});
+
+	it("handles long weekday names and other separators", () => {
+		const m = dailyNameMatcher("dddd D MMMM");
+		// A spelled-out month can't be read back without knowing the locale.
+		expect(m).toBeNull();
+		const ok = dailyNameMatcher("dddd YYYY-MM-DD");
+		expect(ok?.localeDependent).toBe(true);
+		expect(ok?.dayKey("Wednesday 2026-08-19")).toBe("2026-08-19");
+	});
+
+	it("honours moment's [escaped] literals", () => {
+		const m = dailyNameMatcher("[Daily] YYYY-MM-DD");
+		expect(m?.dayKey("Daily 2026-08-19")).toBe("2026-08-19");
+		expect(m?.dayKey("2026-08-19")).toBeNull();
+		// A literal token inside brackets stays literal, not a wildcard.
+		const lit = dailyNameMatcher("[dd] YYYY-MM-DD");
+		expect(lit?.localeDependent).toBe(false);
+		expect(lit?.dayKey("dd 2026-08-19")).toBe("2026-08-19");
+		expect(lit?.dayKey("Wed 2026-08-19")).toBeNull();
+	});
+
+	it("supports nested folder formats and time tokens", () => {
+		const nested = dailyNameMatcher("YYYY/MM/YYYY-MM-DD");
+		expect(nested?.dayKey("2026/08/2026-08-19")).toBe("2026-08-19");
+		const timed = dailyNameMatcher("YYYY-MM-DD HHmm");
+		expect(timed?.dayKey("2026-08-19 0930")).toBe("2026-08-19");
+	});
+
+	it("reads an ordinal day whatever suffix the locale spells", () => {
+		const m = dailyNameMatcher("Do MM YYYY");
+		expect(m?.localeDependent).toBe(true);
+		expect(m?.dayKey("19th 08 2026")).toBe("2026-08-19");
+		expect(m?.dayKey("19e 08 2026")).toBe("2026-08-19");
+		expect(m?.dayKey("1st 08 2026")).toBe("2026-08-01");
+	});
+
+	it("expands a two-digit year the way moment does", () => {
+		const m = dailyNameMatcher("DD.MM.YY");
+		expect(m?.dayKey("19.08.26")).toBe("2026-08-19");
+		expect(m?.dayKey("19.08.99")).toBe("1999-08-19");
+	});
+
+	it("rejects a name that matches the shape but isn't a real date", () => {
+		const m = dailyNameMatcher("YYYY-MM-DD");
+		expect(m?.dayKey("2026-02-31")).toBeNull();
+		expect(m?.dayKey("2026-13-01")).toBeNull();
+	});
+
+	it("declines formats it can't invert", () => {
+		// No day at all — a weekly note, not a daily one.
+		expect(dailyNameMatcher("YYYY-[W]ww")).toBeNull();
+		// Day of year, ISO week year: nothing to read the calendar date from.
+		expect(dailyNameMatcher("YYYY-DDD")).toBeNull();
+		expect(dailyNameMatcher("gggg-MM-DD")).toBeNull();
+		expect(dailyNameMatcher("")).toBeNull();
+	});
+
+	it("keeps group numbering stable when a token repeats", () => {
+		const m = dailyNameMatcher("YYYY-MM-DD (YYYY)");
+		expect(m?.dayKey("2026-08-19 (2026)")).toBe("2026-08-19");
+	});
+});


### PR DESCRIPTION
## What does this PR do?

A daily-note format containing a locale-dependent token (`dd`, `dddd`, `Do`) was only ever resolved by formatting the date under the locale moment happens to be running in. A note written under a *different* locale — Periodic Notes with its own locale override, or a vault synced from another machine — then looked missing: the Stats **day streak** read 0 next to existing `Wed, 19.08.2026.md` / `Thu, 20.08.2026.md` notes, calendar days lost their dot, and the daily card offered to create a note that already existed.

New `src/dailyformat.ts` turns the format into a regular expression that reads the date back *out* of a filename, wildcarding every token only the locale decides (weekday names, ordinal suffixes, meridiem) and requiring the format to pin year, month and day down numerically. `dailyNoteFinder` in `cardbodies.ts` uses it:

- the formatted path is tried first, so an ordinary vault still costs a single map lookup and nothing changes;
- only on a miss, and only for a locale-dependent format, is the daily-note folder scanned once and indexed by day;
- the scan is lazy and per-finder — the streak walk (up to 3650 days), the calendar grid, the agenda and the schedule card each create one finder per render.

Call sites moved onto the finder: the day streak (stats), the calendar grid and agenda dots, the schedule card's `noteFor`, the daily card's "today's note", and `watchedCardPath` so the daily card watches the file it actually shows. Creating a note is unchanged — it still formats a fresh path under the current locale.

Formats that can't be read back — a spelled-out month (`MMMM`), a day of year (`DDD`), an ISO week date (`gggg`/`ww`) — return no matcher and keep exactly the exact-path behaviour they had.

Scope note: this fixes the path/locale mismatch described in the issue. Hearth still reads its daily-note folder and format from the **core Daily notes** plugin; reading them from Periodic Notes' own settings would be a separate feature.

## Related issue

Closes #229

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (also `npm run lint` — 0 errors — and `npm test`: 956 passed, incl. 10 new tests in `test/dailyformat.test.ts`)
- [ ] I've tested this in an actual vault — not possible from this environment; the matcher is covered by unit tests (weekday tokens across locales, `[escaped]` literals, ordinals, two-digit years, nested folder formats, invalid dates, unsupported formats)

---
_Generated by [Claude Code](https://claude.ai/code/session_019jUWGB4X9CiWc6UZy7VFf3)_