### PR TITLE
fix(onboarding): keep the setup wizard out of global settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,23 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **The setup wizard no longer changes your vault-wide settings.** Running setup
+  — or re-running it later from **Settings → Hearth → About → Build a
+  dashboard** — used to write its answers straight into the global settings: the
+  title, logo and accent, the card surface preset, compact spacing, the
+  background, and the TaskNotes field mapping. On a fresh install that was
+  invisible; on a re-run it silently restyled *every* board you already had and
+  repointed every Tasks card in the vault. Every answer now lands on the
+  dashboard the wizard builds — as a per-board override, or on the card itself
+  for the TaskNotes field names and completed statuses — so a setup run cannot
+  touch another board or a vault-wide preference. Two new per-board overrides
+  came out of it, both also available from a board's own settings: **Compact
+  spacing** and **Accent colour on the title**. And the wizard no longer asks
+  about the things that can only be vault-wide — opening Hearth on startup,
+  using it for new tabs, focusing search on open, where notes open, Omnisearch
+  as the search engine, and Iconic/Iconize file icons — since it cannot set them
+  without changing Hearth everywhere; each is one toggle in **Settings →
+  Hearth**.
 - **Daily notes are found even when their name spells the weekday in another
   language.** A daily-note format with a locale-dependent token — `dd`, `dddd`,
   `Do` — was resolved by formatting the date in whatever locale Obsidian is

--- a/README.md
+++ b/README.md
@@ -68,18 +68,26 @@ and enabled is offered with the one thing accepting it will do:
 | **Templater** | Adds a launchpad with a button per template you already have |
 | **Git** | Adds a Git card with status, commit and sync |
 | **Operon** | Adds an Operon tasks card (desktop only — Operon still asks you to approve Hearth) |
-| **Omnisearch** | Makes it the engine behind Hearth's search bar |
-| **Iconic** / **Iconize** | Shows the file icons you already set |
 | **Bases** | Embeds a base from your vault |
 | **Daily notes** / **Bookmarks** | Adds the matching card |
 
 The TaskNotes case is the one worth calling out: its field names are
 user-remappable and its statuses user-defined, so Hearth reads them from the
-plugin and copies them across. A vault that renamed `due` to `deadline` gets a
-Tasks card that works on its first render.
+plugin and copies them onto the card it builds. A vault that renamed `due` to
+`deadline` gets a Tasks card that works on its first render.
 
 The wizard offers the integrations above; everything else in
 [Integrations](#integrations) is added by hand from the **Add card** picker.
+
+**The wizard only ever writes to the dashboard it builds.** The title, the logo,
+the accent, the card surface, the spacing and the background all land as
+*per-board overrides* on that one dashboard, and the TaskNotes field mapping
+lands on the Tasks card itself — so your vault-wide settings, and every other
+board you have, come out of a setup run exactly as they went in. That is also
+why it no longer asks about things that can only be vault-wide (whether Hearth
+opens on startup, where notes open, which search engine to use, whose file
+icons to show): those live in **Settings → Hearth**, one toggle each, and apply
+to everything by design.
 
 The last step previews the board — a scale drawing plus a list of every card and
 why it's there — before anything is written. Nothing is applied until you press

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -623,11 +623,11 @@ async function writeTaskFieldValue(
 	const s = view.plugin.settings;
 	const property =
 		builtin === "status"
-			? s.taskNotesStatusField.trim() || "status"
+			? taskNotesFieldName(s, cfg, "status", "status")
 			: builtin === "priority"
-				? s.taskNotesPriorityField.trim() || "priority"
+				? taskNotesFieldName(s, cfg, "priority", "priority")
 				: builtin === "due"
-					? s.taskNotesDueField.trim() || "due"
+					? taskNotesFieldName(s, cfg, "due", "due")
 					: builtin === "scheduled"
 						? "scheduled"
 						: sourceProperty(source);
@@ -2066,7 +2066,7 @@ function renderTaskKanban(
 	boardColumns?: string[],
 ): void {
 	const source = cfg.source ?? "checkbox";
-	const doneValue = (view.plugin.settings.taskNotesDoneValue.trim() || "done");
+	const doneValue = taskNotesDoneValue(view.plugin.settings, cfg);
 
 	// Build the ordered list of columns and assign each hit to one.
 	interface Column { key: string; label: string; hits: TaskHit[]; statusSymbol?: string; statusDone?: boolean }
@@ -2217,7 +2217,7 @@ function renderTaskKanban(
 				return;
 			}
 			const value = col.label === t().cards.tasks.noStatus ? "" : col.label;
-			void setTaskNotesStatus(view, hit, value).then(refresh);
+			void setTaskNotesStatus(view, cfg, hit, value).then(refresh);
 		}
 	};
 
@@ -3087,6 +3087,48 @@ async function collectCheckboxTasks(view: HomeView, cfg: TasksConfig): Promise<T
  * Only files that actually have the configured status field are treated as
  * tasks, so unrelated notes with a `due` or `priority` property aren't
  * mistaken for one. */
+/**
+ * The TaskNotes frontmatter field a card reads for one of the three mapped
+ * properties.
+ *
+ * A card may carry its own mapping (the setup wizard writes one, read from
+ * TaskNotes itself, so a vault that renamed its fields gets a working card
+ * without a global setting being changed for every other board too); otherwise
+ * the global mapping from Settings → Hearth applies, and an empty global falls
+ * back to whatever the caller knows — TaskNotes' own live setting where it has
+ * been read, or the stock field name.
+ */
+function taskNotesFieldName(
+	settings: HomeSettings,
+	cfg: TasksConfig | null,
+	key: "status" | "due" | "priority",
+	fallback: string,
+): string {
+	const own = (
+		key === "status"
+			? cfg?.taskNotesStatusField
+			: key === "due"
+				? cfg?.taskNotesDueField
+				: cfg?.taskNotesPriorityField
+	)?.trim();
+	if (own) return own;
+	const global = (
+		key === "status"
+			? settings.taskNotesStatusField
+			: key === "due"
+				? settings.taskNotesDueField
+				: settings.taskNotesPriorityField
+	).trim();
+	return global || fallback;
+}
+
+/** The single status value counted as complete: the card's own override, then
+ * the global done value, then "done". Only consulted when the card lists no
+ * `taskNotesDoneStatuses` of its own. */
+function taskNotesDoneValue(settings: HomeSettings, cfg: TasksConfig | null): string {
+	return cfg?.taskNotesDoneValue?.trim() || settings.taskNotesDoneValue.trim() || "done";
+}
+
 /** Build a predicate deciding whether a TaskNotes status value counts as
  * complete. If the card lists its own complete statuses (`taskNotesDoneStatuses`,
  * e.g. "done" + "canceled") those win; otherwise the single global done value
@@ -3154,15 +3196,15 @@ function asTaskFilterHit(hit: TaskHit): TaskFilterHit {
 function collectTaskNotesTasks(view: HomeView, cfg: TasksConfig): TaskHit[] {
 	const s = view.plugin.settings;
 	const setup = readTaskNotesSetup(view.app);
-	const statusField = s.taskNotesStatusField.trim() || setup.fields.status;
-	const dueField = s.taskNotesDueField.trim() || setup.fields.due;
-	const priorityField = s.taskNotesPriorityField.trim() || setup.fields.priority;
+	const statusField = taskNotesFieldName(s, cfg, "status", setup.fields.status);
+	const dueField = taskNotesFieldName(s, cfg, "due", setup.fields.due);
+	const priorityField = taskNotesFieldName(s, cfg, "priority", setup.fields.priority);
 	const contextsField = setup.fields.contexts;
 	const projectsField = setup.fields.projects;
 	// Which status values count as complete. A per-card list (e.g. "done" +
 	// "canceled") overrides the single global done value; otherwise fall back to
 	// that global value alone.
-	const isDone = doneStatusMatcher(cfg, s.taskNotesDoneValue);
+	const isDone = doneStatusMatcher(cfg, taskNotesDoneValue(s, cfg));
 
 	const files = view.app.vault.getMarkdownFiles().filter((f) => inTaskScope(f.path, cfg));
 	const hits: TaskHit[] = [];
@@ -4419,7 +4461,7 @@ async function setCheckboxSymbol(
  * "canceled" as complete writes "done"), otherwise the global done value. */
 function doneWriteValue(view: HomeView, cfg: TasksConfig): string {
 	const custom = (cfg.taskNotesDoneStatuses ?? []).map((v) => v.trim()).filter(Boolean);
-	return custom[0] ?? (view.plugin.settings.taskNotesDoneValue.trim() || "done");
+	return custom[0] ?? taskNotesDoneValue(view.plugin.settings, cfg);
 }
 
 /** A completion checkbox for a non-recurring TaskNotes task (list layout).
@@ -4447,12 +4489,17 @@ function renderTaskNotesCheckbox(
 	check.addEventListener("pointerdown", stop);
 	check.addEventListener("change", () => {
 		const value = check.checked ? doneWriteValue(view, cfg) : openStatus;
-		void setTaskNotesStatus(view, hit, value).then(refresh);
+		void setTaskNotesStatus(view, cfg, hit, value).then(refresh);
 	});
 }
 
-async function setTaskNotesStatus(view: HomeView, hit: TaskHit, value: string): Promise<void> {
-	const field = view.plugin.settings.taskNotesStatusField.trim() || "status";
+async function setTaskNotesStatus(
+	view: HomeView,
+	cfg: TasksConfig,
+	hit: TaskHit,
+	value: string,
+): Promise<void> {
+	const field = taskNotesFieldName(view.plugin.settings, cfg, "status", "status");
 	try {
 		await view.app.fileManager.processFrontMatter(hit.file, (fm) => {
 			fm[field] = value;
@@ -4767,8 +4814,8 @@ async function discoverTaskFields(
 		values.set(key, set);
 	};
 
-	const statusField = settings.taskNotesStatusField.trim() || "status";
-	const priorityField = settings.taskNotesPriorityField.trim() || "priority";
+	const statusField = taskNotesFieldName(settings, cfg, "status", "status");
+	const priorityField = taskNotesFieldName(settings, cfg, "priority", "priority");
 	const wanted = new Set(
 		fields.flatMap((f) => f.keys.map((k) => sourceProperty(k.source)).filter(Boolean)),
 	);

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -7,6 +7,7 @@ import {
 	type Dashboard,
 	type DashboardHeaderConfig,
 	type HeaderAlign,
+	type HomeSettings,
 	BANNER_HEIGHT_MAX,
 	BANNER_HEIGHT_MIN,
 	CARD_RADIUS_MAX,
@@ -160,6 +161,7 @@ function showDashboardMenu(
 				if (dash.fitToPage != null) copy.fitToPage = dash.fitToPage;
 				if (dash.maxWidth != null) copy.maxWidth = dash.maxWidth;
 				if (dash.showSearch != null) copy.showSearch = dash.showSearch;
+				if (dash.compact != null) copy.compact = dash.compact;
 				if (dash.cardOpacity != null) copy.cardOpacity = dash.cardOpacity;
 				if (dash.cardBlur != null) copy.cardBlur = dash.cardBlur;
 				if (dash.cardRadius != null) copy.cardRadius = dash.cardRadius;
@@ -508,6 +510,31 @@ class DashboardSettingsModal extends HearthTabbedModal {
 				});
 			});
 
+		new Setting(containerEl)
+			.setName(t().dashboards.modal.themeColorTarget)
+			.setDesc(t().dashboards.modal.themeColorTargetDesc)
+			.addDropdown((d) => {
+				const labels = t().dashboards.modal.themeColorTargetOptions;
+				d.addOption(
+					"default",
+					t().dashboards.modal.themeColorTargetDefault(labels[s.themeColorTarget]),
+				);
+				d.addOption("none", labels.none);
+				d.addOption("icon", labels.icon);
+				d.addOption("title", labels.title);
+				d.addOption("both", labels.both);
+				d.setValue(header?.themeColorTarget ?? "default");
+				d.onChange((v) => {
+					this.setHeaderOverride(
+						"themeColorTarget",
+						v === "default"
+							? undefined
+							: (v as HomeSettings["themeColorTarget"]),
+					);
+					this.commit();
+				});
+			});
+
 		this.overrideHeaderSlider(
 			containerEl,
 			t().dashboards.modal.titleSize,
@@ -718,6 +745,27 @@ class DashboardSettingsModal extends HearthTabbedModal {
 	private styleSection(containerEl: HTMLElement): void {
 		const dash = this.dash;
 		const s = this.view.plugin.settings;
+
+		new Setting(containerEl)
+			.setName(t().dashboards.modal.compact)
+			.setDesc(t().dashboards.modal.compactDesc)
+			.addDropdown((d) => {
+				d.addOption(
+					"default",
+					t().dashboards.modal.compactDefault(
+						s.compact
+							? t().dashboards.modal.compactStateOn
+							: t().dashboards.modal.compactStateOff,
+					),
+				);
+				d.addOption("on", t().dashboards.modal.compactOptionOn);
+				d.addOption("off", t().dashboards.modal.compactOptionOff);
+				d.setValue(dash.compact === undefined ? "default" : dash.compact ? "on" : "off");
+				d.onChange((v) => {
+					dash.compact = v === "default" ? undefined : v === "on";
+					this.commit();
+				});
+			});
 
 		this.overrideSlider(
 			containerEl,

--- a/src/header.ts
+++ b/src/header.ts
@@ -13,6 +13,7 @@ import {
 	effectiveLogoIcon,
 	effectiveShowSearch,
 	effectiveShowTitle,
+	effectiveThemeColorTarget,
 	effectiveTitle,
 } from "./types";
 import { t } from "./i18n";
@@ -44,8 +45,9 @@ export function renderHeader(view: HomeView, container: HTMLElement, component: 
 	if (effectiveShowTitle(s)) {
 		const titleRow = container.createDiv("hearth-title");
 		// Tint the crystal and/or title text with the theme's icon color per
-		// the themeColorTarget setting (see styles.css).
-		const target = s.themeColorTarget;
+		// the themeColorTarget setting — this board's override, or the global one
+		// (see styles.css).
+		const target = effectiveThemeColorTarget(s);
 		if (target === "icon" || target === "both") titleRow.addClass("is-icon-themed");
 		if (target === "title" || target === "both") titleRow.addClass("is-title-themed");
 		titleRow.style.setProperty("--hearth-title-scale", String(effectiveHeaderTitleScale(s)));

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -715,6 +715,15 @@ function sanitizeTasks(r: Record<string, unknown>): TasksConfig {
 	if (folders) cfg.folders = folders;
 	const taskNotesDoneStatuses = strArray(r.taskNotesDoneStatuses);
 	if (taskNotesDoneStatuses) cfg.taskNotesDoneStatuses = taskNotesDoneStatuses;
+	const taskNotesStatusField = str(r.taskNotesStatusField);
+	if (taskNotesStatusField !== undefined) cfg.taskNotesStatusField = taskNotesStatusField;
+	const taskNotesDueField = str(r.taskNotesDueField);
+	if (taskNotesDueField !== undefined) cfg.taskNotesDueField = taskNotesDueField;
+	const taskNotesPriorityField = str(r.taskNotesPriorityField);
+	if (taskNotesPriorityField !== undefined)
+		cfg.taskNotesPriorityField = taskNotesPriorityField;
+	const taskNotesDoneValue = str(r.taskNotesDoneValue);
+	if (taskNotesDoneValue !== undefined) cfg.taskNotesDoneValue = taskNotesDoneValue;
 	const taskFilter = sanitizeTaskFilter(r.taskFilter);
 	if (taskFilter) cfg.taskFilter = taskFilter;
 	if (typeof r.taskFieldsEnabled === "boolean")
@@ -1108,6 +1117,7 @@ function sanitizeDashboard(
 	}
 	if (typeof r.fitToPage === "boolean") dash.fitToPage = r.fitToPage;
 	if (typeof r.showSearch === "boolean") dash.showSearch = r.showSearch;
+	if (typeof r.compact === "boolean") dash.compact = r.compact;
 	const linkedWorkspace = str(r.linkedWorkspace);
 	if (linkedWorkspace !== undefined && linkedWorkspace.trim())
 		dash.linkedWorkspace = linkedWorkspace;
@@ -1124,6 +1134,14 @@ function sanitizeDashboard(
 		// shows no Lucide title icon, which is not the same as no override.
 		const logoIcon = str(h.logoIcon);
 		if (logoIcon !== undefined) header.logoIcon = logoIcon.trim();
+		if (
+			h.themeColorTarget === "none" ||
+			h.themeColorTarget === "icon" ||
+			h.themeColorTarget === "title" ||
+			h.themeColorTarget === "both"
+		) {
+			header.themeColorTarget = h.themeColorTarget;
+		}
 		if (h.align === "left" || h.align === "center" || h.align === "right") {
 			header.align = h.align;
 		}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -156,7 +156,6 @@ export const en = {
 			look: "Look",
 			purpose: "What for",
 			integrations: "Integrations",
-			behaviour: "Behaviour",
 			finish: "Finish",
 		},
 		/** The heading at the top of each step. */
@@ -166,19 +165,21 @@ export const en = {
 			look: "Pick a look",
 			purpose: "What do you use your vault for?",
 			integrations: "Found in your vault",
-			behaviour: "How Hearth behaves",
 			finish: "Here's your dashboard",
 		},
 		/** The line under each heading. */
 		stepDescs: {
 			welcome: "A few questions, then Hearth builds your first dashboard.",
-			vault: "The title and logo across the top of the board.",
-			look: "You can change any of this later in Settings → Appearance.",
+			vault: "The title and logo across the top of this board.",
+			look:
+				"This applies to the board being built — every other board keeps its " +
+				"own look. You can change any of it later from the board's own settings.",
 			purpose: "Pick as many as you like — each one adds cards to your board.",
 			integrations:
 				"Hearth found these already installed. Turn on the ones you'd like it to use.",
-			behaviour: "What happens when Obsidian starts and when you open a note.",
-			finish: "Nothing has been changed yet. Here's what will be built.",
+			finish:
+				"Nothing has been changed yet. Here's what will be built — as one " +
+				"dashboard, leaving your vault-wide settings alone.",
 		},
 		nav: {
 			back: "Back",
@@ -331,13 +332,14 @@ export const en = {
 		},
 		integrations: {
 			lead:
-				"Each one Hearth turns on here is configured for you — nothing is installed " +
-				"or changed in the other plugin.",
+				"Each one Hearth turns on here adds a card to this board, configured for " +
+				"you — nothing is installed or changed in the other plugin, and nothing " +
+				"outside this dashboard is touched.",
 			recommended: "Recommended",
 			effects: {
 				tasknotes:
-					"Add a Tasks card reading your TaskNotes tasks, using the field names and " +
-					"completed statuses TaskNotes is set to.",
+					"Add a Tasks card reading your TaskNotes tasks, with the field names and " +
+					"completed statuses TaskNotes is set to stored on the card itself.",
 				kanban: "Add a Tasks card showing your Kanban board as columns you can drag between.",
 				dataview: "Add a Dataview card, seeded with a query you can edit.",
 				datacore: "Add a Datacore card ready for a query.",
@@ -349,28 +351,16 @@ export const en = {
 					"Add an Operon tasks card, reading through Operon's Developer API. " +
 					"You'll be asked to approve Hearth in Operon's own settings the first " +
 					"time the card loads; until then it says what it's waiting for.",
-				omnisearch: "Use Omnisearch as the engine behind Hearth's search bar.",
-				fileIcons: "Show the per-file icons you've already set, instead of Hearth's file-type icons.",
 				bases: "Add a card embedding a base from your vault.",
 				dailyNotes: "Add a card showing today's daily note, editable in place.",
 				bookmarks: "Add a card listing your bookmarks.",
 			},
-			taskNotesTitle: "Read from your TaskNotes settings",
+			taskNotesTitle: "Read from your TaskNotes settings, onto this card",
 			taskNotesStatus: "Status field",
 			taskNotesDue: "Due field",
 			taskNotesPriority: "Priority field",
 			taskNotesDone: "Counts as done",
 			taskNotesDoneNone: "none defined — Hearth will use \"done\"",
-		},
-		behaviour: {
-			openOnStartup: "Open Hearth when Obsidian starts",
-			openOnStartupDesc: "Your dashboard is the first thing you see.",
-			replaceNewTabs: "Use Hearth for new empty tabs",
-			replaceNewTabsDesc: "A new tab opens on the dashboard instead of the empty state.",
-			focusSearch: "Focus the search field on open",
-			focusSearchDesc: "Start typing the moment a Hearth tab opens. Desktop only.",
-			openIn: "Open notes in",
-			openInDesc: "Where a note goes when you open one from the dashboard.",
 		},
 		finish: {
 			empty:
@@ -571,6 +561,23 @@ export const en = {
 			fitStateScroll: "scroll",
 			fitOptionFit: "Fit to one page",
 			fitOptionScroll: "Allow scrolling",
+			themeColorTarget: "Accent colour on the title",
+			themeColorTargetDesc:
+				"Which parts of this board's brand mark follow the theme's icon colour. Overrides the global setting for this board; Hearth's tab and ribbon icons keep following the global one.",
+			themeColorTargetDefault: (state: string) => `Use global default (${state})`,
+			themeColorTargetOptions: {
+				none: "Neither",
+				icon: "The icon",
+				title: "The title",
+				both: "Both",
+			},
+			compact: "Compact spacing",
+			compactDesc: "Override the global spacing for this board.",
+			compactDefault: (state: string) => `Use global default (${state})`,
+			compactOptionOn: "Compact",
+			compactOptionOff: "Roomy",
+			compactStateOn: "compact",
+			compactStateOff: "roomy",
 			cardOpacity: "Card opacity",
 			cardBlur: "Card blur",
 			cardRadius: "Card corner radius",
@@ -698,7 +705,9 @@ export const en = {
 			setupAgain: "Build a dashboard",
 			setupAgainDesc:
 				"Run the setup wizard again to generate another dashboard. It's always " +
-				"added as a new board, so your existing dashboards are never touched.",
+				"added as a new board, so your existing dashboards are never touched — " +
+				"and everything it sets lands on that one board, not on your vault-wide " +
+				"settings.",
 			setupButton: "Start setup",
 			whatsNew: "What's new",
 			whatsNewDesc: "Read the release notes for this and every past version.",

--- a/src/onboarding/detect.ts
+++ b/src/onboarding/detect.ts
@@ -14,9 +14,7 @@
 import type { App, TFile } from "obsidian";
 import { DATACORE_PLUGIN_ID } from "../datacore";
 import { DATAVIEW_PLUGIN_ID } from "../dataview";
-import { ICONIC_PLUGIN_ID, ICONIZE_PLUGIN_ID } from "../fileicons";
 import { GIT_PLUGIN_ID } from "../git";
-import { OMNISEARCH_PLUGIN_ID } from "../omnisearch";
 import { OPERON_PLUGIN_ID, isOperonAvailable, isOperonPlatformSupported } from "../operon";
 import { TASKNOTES_PLUGIN_ID, readTaskNotesSetup, type TaskNotesSetup } from "../tasknotes";
 import { TEMPLATER_PLUGIN_ID, templaterTemplateFiles } from "../templater";
@@ -30,10 +28,16 @@ export const KANBAN_PLUGIN_ID = "obsidian-kanban";
  * The integrations the wizard offers to set up.
  *
  * Deliberately a *subset* of `INTEGRATIONS`: an entry earns a place here only
- * when accepting it has a concrete, automatic effect — a card added and
- * configured, or a setting flipped. Anything Hearth merely tolerates (Canvas,
- * Excalidraw, the file explorer) has nothing for the wizard to do and would
- * only be a question with no answer worth giving.
+ * when accepting it has a concrete, automatic effect *on the board being
+ * built* — a card added and configured. Anything Hearth merely tolerates
+ * (Canvas, Excalidraw, the file explorer) has nothing for the wizard to do and
+ * would only be a question with no answer worth giving.
+ *
+ * Two former entries — Omnisearch as the search engine, and Iconic/Iconize as
+ * the file-icon source — are deliberately gone. Both are vault-wide switches
+ * with no per-board form, and the wizard writes nothing vault-wide (see
+ * `plan.ts`). They are one toggle away in Settings → Hearth → Integrations,
+ * which is where a setting that affects every board belongs.
  */
 export type SetupIntegrationId =
 	| "tasknotes"
@@ -43,8 +47,6 @@ export type SetupIntegrationId =
 	| "templater"
 	| "git"
 	| "operon"
-	| "omnisearch"
-	| "fileIcons"
 	| "bases"
 	| "dailyNotes"
 	| "bookmarks";
@@ -242,29 +244,6 @@ export function detectSetup(app: App): SetupDetection {
 			id: "operon",
 			name: pluginName(app, OPERON_PLUGIN_ID, "Operon"),
 			recommended: false,
-		});
-	}
-
-	if (pluginEnabled(app, OMNISEARCH_PLUGIN_ID)) {
-		integrations.push({
-			id: "omnisearch",
-			name: pluginName(app, OMNISEARCH_PLUGIN_ID, "Omnisearch"),
-			recommended: true,
-		});
-	}
-
-	// Iconic and Iconize are interchangeable as far as Hearth is concerned —
-	// both feed the one "use the icons you already set" switch — so they are
-	// offered as a single row named after whichever is actually installed.
-	const iconic = pluginEnabled(app, ICONIC_PLUGIN_ID);
-	const iconize = pluginEnabled(app, ICONIZE_PLUGIN_ID);
-	if (iconic || iconize) {
-		integrations.push({
-			id: "fileIcons",
-			name: iconic
-				? pluginName(app, ICONIC_PLUGIN_ID, "Iconic")
-				: pluginName(app, ICONIZE_PLUGIN_ID, "Iconize"),
-			recommended: true,
 		});
 	}
 

--- a/src/onboarding/plan.ts
+++ b/src/onboarding/plan.ts
@@ -1,28 +1,39 @@
 /**
  * Turning the wizard's answers into a dashboard.
  *
- * Everything here is pure: answers plus a detection snapshot go in, a board and
- * a settings patch come out. The wizard (`wizard.ts`) only collects the answers
- * and draws the result — none of the decisions below depend on Obsidian, so all
- * of them are unit-testable, which matters because this is the one code path a
- * new user's very first impression of Hearth is built by.
+ * Everything here is pure: answers plus a detection snapshot go in, a board
+ * comes out. The wizard (`wizard.ts`) only collects the answers and draws the
+ * result — none of the decisions below depend on Obsidian, so all of them are
+ * unit-testable, which matters because this is the one code path a new user's
+ * very first impression of Hearth is built by.
  *
  * The two halves are deliberately separate:
  *
  *  - {@link planCards} decides *what board to build* — which cards, configured
  *    how, laid out where.
- *  - {@link applySetup} decides *what to change in settings* — the look, the
- *    behaviour, the integration wiring — and installs the board.
+ *  - {@link applySetup} installs that board and writes the look onto it.
  *
  * so the review step can show the first without committing the second.
+ *
+ * ⚠️ **The wizard never writes a global setting.** Every answer it collects
+ * lands on the dashboard it builds — as a per-dashboard override (the header,
+ * the card surface, the background, compact spacing) or in a card's own config
+ * (the TaskNotes field mapping) — so running setup, or re-running it later,
+ * cannot change how any *other* board looks or how Hearth behaves vault-wide.
+ * The only fields of {@link HomeSettings} touched here are the structural ones
+ * that installing a board *is*: the `dashboards` list, `activeDashboardId`, and
+ * the `setupStatus` flag that stops the wizard offering itself twice. Anything
+ * the wizard cannot express as a board-level override is therefore not asked
+ * about at all — it belongs in Settings → Hearth, where it applies to
+ * everything by design.
  */
 import { ensureLayout } from "../grid";
 import {
+	type BackgroundConfig,
 	type BackgroundLayout,
 	type DashboardCard,
 	type Dashboard,
 	type HomeSettings,
-	type OpenIn,
 	type TemplaterItem,
 	newDashboardId,
 } from "../types";
@@ -130,6 +141,9 @@ export interface SetupAnswers {
 	showTitle: boolean;
 	logo: string;
 	themeColorTarget: HomeSettings["themeColorTarget"];
+	/** Whether the built board shows the search/command section. Stored as the
+	 * board's own {@link Dashboard.showSearch} override, not the global one. */
+	showSearch: boolean;
 
 	// ---- Step: the look ----
 	surface: SetupSurface;
@@ -147,13 +161,6 @@ export interface SetupAnswers {
 
 	// ---- Step: integrations ----
 	integrations: SetupIntegrationId[];
-
-	// ---- Step: behaviour ----
-	openOnStartup: boolean;
-	replaceNewTabs: boolean;
-	focusSearchOnOpen: boolean;
-	showSearch: boolean;
-	openIn: OpenIn;
 
 	// ---- Step: finish ----
 	target: SetupTarget;
@@ -184,6 +191,7 @@ export function defaultAnswers(
 		showTitle: true,
 		logo: "",
 		themeColorTarget: "none",
+		showSearch: true,
 
 		surface: "glass",
 		compact: false,
@@ -195,12 +203,6 @@ export function defaultAnswers(
 		purposes,
 
 		integrations: detection.integrations.filter((i) => i.recommended).map((i) => i.id),
-
-		openOnStartup: true,
-		replaceNewTabs: true,
-		focusSearchOnOpen: false,
-		showSearch: true,
-		openIn: "tab",
 
 		target: "replace",
 		dashboardName: "Home",
@@ -517,7 +519,10 @@ function taskReason(answers: SetupAnswers): string {
  * The TaskNotes branch is the reason this feature exists: switching the source
  * is one line, but a card pointed at TaskNotes without its *completed* statuses
  * shows every cancelled task as outstanding, and one pointed at a vault that
- * renamed its fields shows nothing at all. Both are read from the plugin.
+ * renamed its fields shows nothing at all. Both are read from the plugin — and
+ * both are stored *on the card*, not in the vault-wide TaskNotes mapping in
+ * Settings → Hearth, so a wizard run configures this board's card and leaves
+ * every other card reading whatever it read before.
  */
 function planTasksConfig(
 	answers: SetupAnswers,
@@ -527,9 +532,12 @@ function planTasksConfig(
 		const imported = taskNotesImport(detection.taskNotes);
 		return {
 			source: "tasknotes",
-			// Only stored when TaskNotes actually defines completed statuses;
-			// otherwise the card falls back to the single global done-value,
-			// which `applySetup` has just synced from the same place.
+			taskNotesStatusField: imported.statusField,
+			taskNotesDueField: imported.dueField,
+			taskNotesPriorityField: imported.priorityField,
+			// The single done-value is the fallback for a vault that marks no
+			// status complete; a vault that does gets the full list, which wins.
+			taskNotesDoneValue: imported.doneValue,
 			...(imported.doneStatuses.length
 				? { taskNotesDoneStatuses: imported.doneStatuses }
 				: {}),
@@ -564,11 +572,18 @@ export interface SetupOutcome {
 }
 
 /**
- * Write the wizard's answers into settings and install the planned board.
+ * Install the planned board and write the wizard's answers onto it.
  *
  * Mutates `settings` in place — the same contract `migrateSettings` has — and
  * leaves persisting to the caller, so the wizard saves once at the end rather
  * than after every step.
+ *
+ * The board is installed *first* and every answer is then written onto that
+ * dashboard as an override, which is the whole shape of this function: there is
+ * no path here that assigns to a look-or-behaviour field of `settings`, so a
+ * setup run cannot change any other board or any vault-wide preference. See the
+ * module comment for why the wizard asks only about things that can be said
+ * per-board.
  */
 export function applySetup(
 	settings: HomeSettings,
@@ -576,100 +591,75 @@ export function applySetup(
 	detection: SetupDetection,
 	planned: PlannedCard[] = planCards(answers, detection),
 ): SetupOutcome {
-	applyHeader(settings, answers);
-	applyLook(settings, answers);
-	applyBehaviour(settings, answers);
-	applyIntegrations(settings, answers, detection);
-
 	const cards = planned.map((p) => p.card);
-	const outcome = installBoard(settings, answers, cards);
+	const { dashboard, outcome } = installBoard(settings, answers, cards);
+
+	applyHeader(dashboard, answers);
+	applyLook(dashboard, answers);
 
 	settings.setupStatus = "done";
 	return outcome;
 }
 
-function applyHeader(settings: HomeSettings, answers: SetupAnswers): void {
-	settings.title = answers.title.trim() || settings.title;
-	settings.showTitle = answers.showTitle;
-	settings.logo = answers.logo.trim();
-	settings.themeColorTarget = answers.themeColorTarget;
-	settings.showSearch = answers.showSearch;
+/** The title block: this board's own text, visibility, logo and accent, none of
+ * which touches the vault-wide header. */
+function applyHeader(dashboard: Dashboard, answers: SetupAnswers): void {
+	const header: NonNullable<Dashboard["header"]> = {
+		...(dashboard.header ?? {}),
+		showTitle: answers.showTitle,
+		// An empty logo is a real override: this board shows the Hearth crystal
+		// even in a vault whose global logo is an emoji.
+		logo: answers.logo.trim(),
+		themeColorTarget: answers.themeColorTarget,
+	};
+	// A blank title is not an override — it is a user who left the field alone,
+	// and a board with an empty title override would show no heading at all.
+	const title = answers.title.trim();
+	if (title) header.title = title;
+	else delete header.title;
+
+	dashboard.header = header;
+	dashboard.showSearch = answers.showSearch;
 }
 
-function applyLook(settings: HomeSettings, answers: SetupAnswers): void {
+/** The look: card surface, spacing and backdrop, all as overrides on the board
+ * the wizard just built. */
+function applyLook(dashboard: Dashboard, answers: SetupAnswers): void {
 	const surface = SURFACE_PRESETS[answers.surface];
-	settings.cardOpacity = surface.cardOpacity;
-	settings.cardBlur = surface.cardBlur;
-	settings.cardRadius = surface.cardRadius;
-	settings.cardBorderWidth = surface.cardBorderWidth;
-	settings.compact = answers.compact;
+	dashboard.cardOpacity = surface.cardOpacity;
+	dashboard.cardBlur = surface.cardBlur;
+	dashboard.cardRadius = surface.cardRadius;
+	dashboard.cardBorderWidth = surface.cardBorderWidth;
+	dashboard.compact = answers.compact;
 
+	dashboard.background = plannedBackground(answers);
+	dashboard.backgroundLayout = answers.backgroundLayout;
+}
+
+/**
+ * The backdrop this board wears, as a complete per-dashboard override.
+ *
+ * All four fields at once, because a board's background override is
+ * all-or-nothing (see {@link BannerOverrides}) — and the tuning differs per
+ * choice: a photograph needs pushing well back to keep text legible, while a
+ * flat colour is *already* legible and fading it only makes it muddy.
+ */
+function plannedBackground(answers: SetupAnswers): BackgroundConfig {
 	const tuning = BACKGROUND_TUNING[answers.background];
-	settings.backgroundOpacity = tuning.opacity;
-	settings.backgroundBlur = tuning.blur;
-	settings.backgroundLayout = answers.backgroundLayout;
-
 	switch (answers.background) {
-		case "default":
-			settings.backgroundKind = "default";
-			settings.backgroundValue = "";
-			break;
 		case "color":
-			settings.backgroundKind = "color";
-			settings.backgroundValue = answers.backgroundColor;
-			break;
+			return { kind: "color", value: answers.backgroundColor, ...tuning };
 		case "weather":
 			// A weather background with no place picked would paint nothing at
 			// all, which reads as a broken setup rather than a deliberate one —
 			// so an unfinished sky falls back to the bundled image.
-			if (answers.skyValue) {
-				settings.backgroundKind = "weather";
-				settings.backgroundValue = answers.skyValue;
-			} else {
-				settings.backgroundKind = "default";
-				settings.backgroundValue = "";
-				const fallback = BACKGROUND_TUNING.default;
-				settings.backgroundOpacity = fallback.opacity;
-				settings.backgroundBlur = fallback.blur;
-			}
-			break;
+			return answers.skyValue
+				? { kind: "weather", value: answers.skyValue, ...tuning }
+				: { kind: "default", value: "", ...BACKGROUND_TUNING.default };
 		case "none":
-			settings.backgroundKind = "none";
-			settings.backgroundValue = "";
-			break;
-	}
-}
-
-function applyBehaviour(settings: HomeSettings, answers: SetupAnswers): void {
-	settings.openOnStartup = answers.openOnStartup;
-	settings.replaceNewTabs = answers.replaceNewTabs;
-	settings.focusSearchOnOpen = answers.focusSearchOnOpen;
-	settings.openIn = answers.openIn;
-}
-
-/**
- * Wire up the accepted integrations.
- *
- * Only ever *positive*: declining an offer leaves the corresponding setting
- * exactly as it was rather than turning it off. The wizard can be re-run at any
- * time, and a re-run that silently disabled things the user had since set up by
- * hand would be a trap. The one exception is `customFileIcons`, whose default
- * is already on — accepting simply keeps it there.
- */
-function applyIntegrations(
-	settings: HomeSettings,
-	answers: SetupAnswers,
-	detection: SetupDetection,
-): void {
-	if (accepted(answers, "omnisearch")) settings.searchEngine = "omnisearch";
-	if (accepted(answers, "fileIcons")) settings.customFileIcons = true;
-
-	if (accepted(answers, "tasknotes") && detection.taskNotes) {
-		const imported = taskNotesImport(detection.taskNotes);
-		settings.taskNotesStatusField = imported.statusField;
-		settings.taskNotesDueField = imported.dueField;
-		settings.taskNotesPriorityField = imported.priorityField;
-		settings.taskNotesDoneValue = imported.doneValue;
+			return { kind: "none", value: "", ...tuning };
+		default:
+			return { kind: "default", value: "", ...tuning };
 	}
 }
 
@@ -703,7 +693,7 @@ function installBoard(
 	settings: HomeSettings,
 	answers: SetupAnswers,
 	cards: DashboardCard[],
-): SetupOutcome {
+): { dashboard: Dashboard; outcome: SetupOutcome } {
 	// A tall board scrolls rather than being scaled down to nothing. Stored as a
 	// per-dashboard override rather than by changing the global setting, so it
 	// only affects the board the wizard built.
@@ -720,7 +710,10 @@ function installBoard(
 			// whatever the user (or the global default) already had.
 			if (tall) active.fitToPage = false;
 			settings.activeDashboardId = active.id;
-			return { dashboardId: active.id, cardCount: cards.length, replaced: true };
+			return {
+				dashboard: active,
+				outcome: { dashboardId: active.id, cardCount: cards.length, replaced: true },
+			};
 		}
 		// No dashboards at all (a hand-emptied data.json); fall through and make
 		// one rather than dropping the board on the floor.
@@ -734,7 +727,10 @@ function installBoard(
 	};
 	settings.dashboards.push(dashboard);
 	settings.activeDashboardId = dashboard.id;
-	return { dashboardId: dashboard.id, cardCount: cards.length, replaced: false };
+	return {
+		dashboard,
+		outcome: { dashboardId: dashboard.id, cardCount: cards.length, replaced: false },
+	};
 }
 
 /**

--- a/src/onboarding/wizard.ts
+++ b/src/onboarding/wizard.ts
@@ -24,8 +24,6 @@ import type HearthPlugin from "../main";
 import { configuredPlaces, renderSkySource } from "../placepicker";
 import { formatSkyValue, parseSkyValue } from "../sky";
 import { makeClickable } from "../ui";
-import type { OpenIn } from "../types";
-import { OPEN_IN_MODES } from "../types";
 import { detectSetup, type DetectedIntegration, type SetupDetection } from "./detect";
 import {
 	applySetup,
@@ -51,7 +49,6 @@ type SetupStepId =
 	| "look"
 	| "purpose"
 	| "integrations"
-	| "behaviour"
 	| "finish";
 
 /** The Lucide icon shown beside each step on the progress rail. */
@@ -61,7 +58,6 @@ const STEP_ICONS: Record<SetupStepId, string> = {
 	look: "palette",
 	purpose: "compass",
 	integrations: "plug",
-	behaviour: "settings-2",
 	finish: "check",
 };
 
@@ -152,7 +148,7 @@ export class SetupWizardModal extends Modal {
 	private wizardSteps(): SetupStepId[] {
 		const steps: SetupStepId[] = ["welcome", "vault", "look", "purpose"];
 		if (this.detection.integrations.length > 0) steps.push("integrations");
-		steps.push("behaviour", "finish");
+		steps.push("finish");
 		return steps;
 	}
 
@@ -288,9 +284,6 @@ export class SetupWizardModal extends Modal {
 				break;
 			case "integrations":
 				this.renderIntegrationsStep(body);
-				break;
-			case "behaviour":
-				this.renderBehaviourStep(body);
 				break;
 			case "finish":
 				this.renderFinishStep(body);
@@ -542,49 +535,6 @@ export class SetupWizardModal extends Modal {
 	private integrationEffect(found: DetectedIntegration): string {
 		const effects = t().setup.integrations.effects;
 		return effects[found.id];
-	}
-
-	private renderBehaviourStep(body: HTMLElement): void {
-		const strings = t().setup.behaviour;
-		const a = this.answers;
-
-		new Setting(body)
-			.setName(strings.openOnStartup)
-			.setDesc(strings.openOnStartupDesc)
-			.addToggle((tg) =>
-				tg.setValue(a.openOnStartup).onChange((v) => {
-					a.openOnStartup = v;
-				}),
-			);
-
-		new Setting(body)
-			.setName(strings.replaceNewTabs)
-			.setDesc(strings.replaceNewTabsDesc)
-			.addToggle((tg) =>
-				tg.setValue(a.replaceNewTabs).onChange((v) => {
-					a.replaceNewTabs = v;
-				}),
-			);
-
-		new Setting(body)
-			.setName(strings.focusSearch)
-			.setDesc(strings.focusSearchDesc)
-			.addToggle((tg) =>
-				tg.setValue(a.focusSearchOnOpen).onChange((v) => {
-					a.focusSearchOnOpen = v;
-				}),
-			);
-
-		new Setting(body)
-			.setName(strings.openIn)
-			.setDesc(strings.openInDesc)
-			.addDropdown((d) => {
-				const labels = t().settings.behaviour.openInModes;
-				for (const mode of OPEN_IN_MODES) d.addOption(mode, labels[mode]);
-				d.setValue(a.openIn).onChange((v) => {
-					a.openIn = v as OpenIn;
-				});
-			});
 	}
 
 	private renderFinishStep(body: HTMLElement): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -338,6 +338,20 @@ export interface TasksConfig {
 	 * e.g., both "done" and "canceled" can be treated as complete. When unset, the
 	 * single global `taskNotesDoneValue` from Settings → Hearth is used. */
 	taskNotesDoneStatuses?: string[];
+	/** TaskNotes source: this card's own frontmatter field names, overriding the
+	 * global mapping in Settings → Hearth. Set by the setup wizard, which reads
+	 * them from TaskNotes itself — a vault that renamed its fields gets a card
+	 * that works on the first render without the wizard reaching into a global
+	 * setting every other card and board also follows. Undefined = follow the
+	 * global mapping. */
+	taskNotesStatusField?: string;
+	taskNotesDueField?: string;
+	taskNotesPriorityField?: string;
+	/** TaskNotes source: this card's own single "complete" status, overriding the
+	 * global `taskNotesDoneValue`. Only consulted when
+	 * {@link taskNotesDoneStatuses} is unset — a card that lists its complete
+	 * statuses has already answered this. */
+	taskNotesDoneValue?: string;
 	/** List layout: an active filter narrowing which tasks appear. Presets in the
 	 * filter modal are conveniences that fill in these concrete criteria; the
 	 * filter is "active" (and applied) when any field below is set. */
@@ -1597,6 +1611,11 @@ export interface DashboardHeaderConfig {
 	 * override meaning "no icon on this board" — it falls back to the logo text,
 	 * not to the global icon; undefined follows the global setting. */
 	logoIcon?: string;
+	/** Override which parts of this board's brand mark follow the theme's icon
+	 * colour (undefined = use the global {@link HomeSettings.themeColorTarget}).
+	 * Scoped to the board's own title block; Hearth's tab and ribbon icons are
+	 * app-level and keep following the global setting. */
+	themeColorTarget?: HomeSettings["themeColorTarget"];
 	/** Align only the title/logo block; the search section below has its own
 	 * layout. */
 	align?: HeaderAlign;
@@ -1632,6 +1651,8 @@ export interface Dashboard extends BannerOverrides {
 	fitToPage?: boolean;
 	/** Override the content max-width (px) for this board (undefined = global). */
 	maxWidth?: number;
+	/** Override compact spacing for this board (undefined = global). */
+	compact?: boolean;
 	/** Override the card surface opacity for this board (undefined = global). */
 	cardOpacity?: number;
 	/** Override the card surface backdrop blur (px) for this board (undefined =
@@ -2269,6 +2290,20 @@ export function effectiveHeaderMarginTop(s: HomeSettings): number | undefined {
 /** Optional spacing below the whole header block in pixels. Undefined keeps CSS default. */
 export function effectiveHeaderSpacingBelow(s: HomeSettings): number | undefined {
 	return clampHeaderSpacingBelow(activeDashboard(s).header?.spacingBelow);
+}
+
+/** Whether the active board draws with compact spacing (per-dashboard override
+ * or global). */
+export function effectiveCompact(s: HomeSettings): boolean {
+	return activeDashboard(s).compact ?? s.compact;
+}
+
+/** Which parts of the active board's brand mark follow the theme's icon colour
+ * (per-dashboard override or global). The board's title block only — the tab
+ * and ribbon icons are app-level and read {@link HomeSettings.themeColorTarget}
+ * directly. */
+export function effectiveThemeColorTarget(s: HomeSettings): HomeSettings["themeColorTarget"] {
+	return activeDashboard(s).header?.themeColorTarget ?? s.themeColorTarget;
 }
 
 /** Effective content max-width for the active board (per-dashboard override or global). */

--- a/src/view.ts
+++ b/src/view.ts
@@ -9,6 +9,7 @@ import { deferRedrawWhileTyping } from "./cardfocus";
 import { gateMotionOnWindow } from "./motion";
 import {
 	bannerActive,
+	effectiveCompact,
 	effectiveFitToPage,
 	effectiveMaxWidth,
 	effectiveShowSearch,
@@ -162,7 +163,7 @@ export class HomeView extends ItemView {
 		const root = this.contentEl;
 		root.empty();
 		root.addClass("hearth-view");
-		root.toggleClass("hearth-compact", this.plugin.settings.compact);
+		root.toggleClass("hearth-compact", effectiveCompact(this.plugin.settings));
 		// The two performance-tier flags CSS keys off. They are separate because
 		// the tiers drop motion and frost at the same rung but for different
 		// reasons, and because `hearth-no-motion` is also what the focus/visibility

--- a/test/boardoverrides.test.ts
+++ b/test/boardoverrides.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_SETTINGS,
+	effectiveCompact,
+	effectiveThemeColorTarget,
+	type HomeSettings,
+} from "../src/types";
+
+/**
+ * The two overrides the setup wizard needed in order to stop writing global
+ * settings: compact spacing and the title's accent target.
+ *
+ * Both follow the same contract every other per-dashboard override has — a
+ * board that sets nothing keeps following the global setting *as it changes
+ * later*, which is exactly what a stored copy of the global value would
+ * silently break.
+ */
+function settings(): HomeSettings {
+	const s: HomeSettings = structuredClone(DEFAULT_SETTINGS);
+	s.dashboards = [
+		{ id: "d1", name: "Dashboard 1", cards: [] },
+		{ id: "d2", name: "Dashboard 2", cards: [] },
+	];
+	s.activeDashboardId = "d1";
+	return s;
+}
+
+describe("effectiveCompact", () => {
+	it("follows the global setting when the board sets no override", () => {
+		const s = settings();
+		expect(effectiveCompact(s)).toBe(false);
+		s.compact = true;
+		expect(effectiveCompact(s)).toBe(true);
+	});
+
+	it("lets one board tighten up while the vault stays roomy", () => {
+		const s = settings();
+		s.dashboards[0].compact = true;
+		expect(effectiveCompact(s)).toBe(true);
+		s.activeDashboardId = "d2";
+		expect(effectiveCompact(s)).toBe(false);
+	});
+
+	it("lets one board stay roomy while the vault is compact", () => {
+		const s = settings();
+		s.compact = true;
+		s.dashboards[0].compact = false;
+		expect(effectiveCompact(s)).toBe(false);
+	});
+});
+
+describe("effectiveThemeColorTarget", () => {
+	it("follows the global setting when the board's header sets no override", () => {
+		const s = settings();
+		expect(effectiveThemeColorTarget(s)).toBe("none");
+		s.themeColorTarget = "both";
+		expect(effectiveThemeColorTarget(s)).toBe("both");
+	});
+
+	it("takes the board's override over the global one", () => {
+		const s = settings();
+		s.themeColorTarget = "both";
+		s.dashboards[0].header = { themeColorTarget: "icon" };
+		expect(effectiveThemeColorTarget(s)).toBe("icon");
+		s.activeDashboardId = "d2";
+		expect(effectiveThemeColorTarget(s)).toBe("both");
+	});
+
+	it("treats a header override of \"none\" as a real answer, not as absent", () => {
+		const s = settings();
+		s.themeColorTarget = "title";
+		s.dashboards[0].header = { themeColorTarget: "none" };
+		expect(effectiveThemeColorTarget(s)).toBe("none");
+	});
+});

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -282,13 +282,13 @@ describe("defaultAnswers", () => {
 			freshSettings(),
 			emptyDetection({
 				integrations: [
-					{ id: "omnisearch", name: "Omnisearch", recommended: true },
+					{ id: "dailyNotes", name: "Daily notes", recommended: true },
 					{ id: "git", name: "Git", recommended: false },
 				],
 			}),
 		);
 
-		expect(answers.integrations).toEqual(["omnisearch"]);
+		expect(answers.integrations).toEqual(["dailyNotes"]);
 	});
 
 	it("assumes someone running a task plugin wants tasks on their board", () => {
@@ -363,6 +363,11 @@ describe("planCards", () => {
 
 		expect(tasks?.card.tasks).toEqual({
 			source: "tasknotes",
+			// TaskNotes' own field names, on the card rather than in settings.
+			taskNotesStatusField: "status",
+			taskNotesDueField: "due",
+			taskNotesPriorityField: "priority",
+			taskNotesDoneValue: "done",
 			taskNotesDoneStatuses: ["done", "cancelled"],
 		});
 		expect(tasks?.reason).toBe("tasknotes");
@@ -490,48 +495,117 @@ describe("planCards", () => {
 // ---- Applying the answers --------------------------------------------
 
 describe("applySetup", () => {
-	it("writes the chosen surface preset", () => {
-		const settings = freshSettings();
-		applySetup(settings, blankAnswers({ surface: "minimal" }), emptyDetection());
+	/** The board the wizard just built. */
+	const built = (settings: HomeSettings, outcome: { dashboardId: string }) => {
+		const dash = settings.dashboards.find((d) => d.id === outcome.dashboardId);
+		if (!dash) throw new Error("the wizard reported a dashboard it did not install");
+		return dash;
+	};
 
-		expect(settings).toMatchObject(SURFACE_PRESETS.minimal);
+	it("writes the chosen surface preset onto the board, not the vault", () => {
+		const settings = freshSettings();
+		const before = structuredClone(settings);
+		const outcome = applySetup(
+			settings,
+			blankAnswers({ surface: "minimal" }),
+			emptyDetection(),
+		);
+
+		expect(built(settings, outcome)).toMatchObject(SURFACE_PRESETS.minimal);
+		expect(settings).toMatchObject({
+			cardOpacity: before.cardOpacity,
+			cardBlur: before.cardBlur,
+			cardRadius: before.cardRadius,
+			cardBorderWidth: before.cardBorderWidth,
+		});
 	});
 
 	it("paints a flat colour at full strength rather than fading it", () => {
 		const settings = freshSettings();
-		applySetup(
+		const outcome = applySetup(
 			settings,
 			blankAnswers({ background: "color", backgroundColor: "#102030" }),
 			emptyDetection(),
 		);
 
-		expect(settings.backgroundKind).toBe("color");
-		expect(settings.backgroundValue).toBe("#102030");
-		expect(settings.backgroundOpacity).toBe(1);
-		expect(settings.backgroundBlur).toBe(0);
+		expect(built(settings, outcome).background).toEqual({
+			kind: "color",
+			value: "#102030",
+			opacity: 1,
+			blur: 0,
+		});
 	});
 
 	it("falls back to the bundled wallpaper when a live sky has no place yet", () => {
 		const settings = freshSettings();
-		applySetup(settings, blankAnswers({ background: "weather", skyValue: "" }), emptyDetection());
+		const outcome = applySetup(
+			settings,
+			blankAnswers({ background: "weather", skyValue: "" }),
+			emptyDetection(),
+		);
 
-		expect(settings.backgroundKind).toBe("default");
-		expect(settings.backgroundOpacity).toBe(0.35);
+		expect(built(settings, outcome).background).toMatchObject({
+			kind: "default",
+			opacity: 0.35,
+		});
 	});
 
 	it("keeps a weather background once a sky is picked", () => {
 		const settings = freshSettings();
-		applySetup(
+		const outcome = applySetup(
 			settings,
 			blankAnswers({ background: "weather", skyValue: "fixed:clear:auto" }),
 			emptyDetection(),
 		);
 
-		expect(settings.backgroundKind).toBe("weather");
-		expect(settings.backgroundValue).toBe("fixed:clear:auto");
+		expect(built(settings, outcome).background).toMatchObject({
+			kind: "weather",
+			value: "fixed:clear:auto",
+		});
 	});
 
-	it("syncs the TaskNotes field mapping into settings", () => {
+	it("writes the header answers as this board's own overrides", () => {
+		const settings = freshSettings();
+		const outcome = applySetup(
+			settings,
+			blankAnswers({
+				title: "Second Brain",
+				showTitle: false,
+				logo: "🔥",
+				themeColorTarget: "both",
+				showSearch: false,
+				compact: true,
+			}),
+			emptyDetection(),
+		);
+		const dash = built(settings, outcome);
+
+		expect(dash.header).toMatchObject({
+			title: "Second Brain",
+			showTitle: false,
+			logo: "🔥",
+			themeColorTarget: "both",
+		});
+		expect(dash.showSearch).toBe(false);
+		expect(dash.compact).toBe(true);
+
+		// None of it leaked into the vault-wide header.
+		expect(settings.title).toBe(DEFAULT_SETTINGS.title);
+		expect(settings.showTitle).toBe(true);
+		expect(settings.logo).toBe(DEFAULT_SETTINGS.logo);
+		expect(settings.themeColorTarget).toBe("none");
+		expect(settings.showSearch).toBe(true);
+		expect(settings.compact).toBe(false);
+	});
+
+	it("leaves the title alone when the field was left blank", () => {
+		const settings = freshSettings();
+		const outcome = applySetup(settings, blankAnswers({ title: "   " }), emptyDetection());
+
+		expect(built(settings, outcome).header?.title).toBeUndefined();
+	});
+
+	it("puts the TaskNotes field mapping on the card, not in settings", () => {
 		const settings = freshSettings();
 		const detection = emptyDetection({
 			taskNotes: parseTaskNotesSettings({
@@ -540,35 +614,70 @@ describe("applySetup", () => {
 			}),
 		});
 
-		applySetup(settings, blankAnswers({ integrations: ["tasknotes"] }), detection);
+		const outcome = applySetup(
+			settings,
+			blankAnswers({ integrations: ["tasknotes"] }),
+			detection,
+		);
+		const tasks = built(settings, outcome).cards.find((c) => c.kind === "tasks");
 
-		expect(settings).toMatchObject({
+		expect(tasks?.tasks).toMatchObject({
+			source: "tasknotes",
 			taskNotesStatusField: "state",
 			taskNotesDueField: "deadline",
 			taskNotesPriorityField: "urgency",
 			taskNotesDoneValue: "shipped",
+			taskNotesDoneStatuses: ["shipped"],
+		});
+		expect(settings).toMatchObject({
+			taskNotesStatusField: DEFAULT_SETTINGS.taskNotesStatusField,
+			taskNotesDueField: DEFAULT_SETTINGS.taskNotesDueField,
+			taskNotesPriorityField: DEFAULT_SETTINGS.taskNotesPriorityField,
+			taskNotesDoneValue: DEFAULT_SETTINGS.taskNotesDoneValue,
 		});
 	});
 
-	it("switches the search engine only when Omnisearch is accepted", () => {
-		const declined = freshSettings();
-		applySetup(declined, blankAnswers(), emptyDetection());
-		expect(declined.searchEngine).toBe("builtin");
-
-		const accepted = freshSettings();
-		applySetup(accepted, blankAnswers({ integrations: ["omnisearch"] }), emptyDetection());
-		expect(accepted.searchEngine).toBe("omnisearch");
-	});
-
-	it("never turns an integration off — declining leaves settings alone", () => {
+	/**
+	 * The guarantee the whole module rests on, asserted wholesale rather than
+	 * setting by setting: run the wizard with every answer turned away from its
+	 * default and compare the settings object against an untouched clone,
+	 * ignoring only the three structural fields installing a board *is*.
+	 *
+	 * A future answer that writes a global setting fails here even if nobody
+	 * thought to write a test for it.
+	 */
+	it("changes nothing vault-wide but the board list and the setup flag", () => {
 		const settings = freshSettings();
-		settings.searchEngine = "omnisearch";
-		settings.customFileIcons = true;
+		const before = structuredClone(settings);
 
-		applySetup(settings, blankAnswers({ integrations: [] }), emptyDetection());
+		applySetup(
+			settings,
+			blankAnswers({
+				title: "Elsewhere",
+				showTitle: false,
+				logo: "🔥",
+				themeColorTarget: "both",
+				showSearch: false,
+				surface: "minimal",
+				compact: true,
+				background: "color",
+				backgroundColor: "#102030",
+				backgroundLayout: "banner",
+				purposes: ["daily", "tasks", "browsing", "insights"],
+				integrations: ["dataview", "bookmarks"],
+				target: "new",
+				dashboardName: "Elsewhere",
+			}),
+			emptyDetection(),
+		);
 
-		expect(settings.searchEngine).toBe("omnisearch");
-		expect(settings.customFileIcons).toBe(true);
+		const structural = new Set(["dashboards", "activeDashboardId", "setupStatus"]);
+		for (const key of Object.keys(before) as (keyof HomeSettings)[]) {
+			if (structural.has(key)) continue;
+			expect({ [key]: settings[key] }).toEqual({ [key]: before[key] });
+		}
+		// And the boards that already existed are untouched too.
+		expect(settings.dashboards[0]).toEqual(before.dashboards[0]);
 	});
 
 	it("replaces the active board's cards when asked to replace", () => {


### PR DESCRIPTION
## What does this PR do?

The setup wizard wrote its answers straight into the global `HomeSettings`. `applySetup` set the header (title, `showTitle`, logo, `themeColorTarget`, `showSearch`), the card surface preset, `compact`, the whole background block, the behaviour toggles (`openOnStartup`, `replaceNewTabs`, `focusSearchOnOpen`, `openIn`), `searchEngine`, `customFileIcons` and the TaskNotes field mapping — all vault-wide.

On a fresh install that was invisible. On a re-run from **Settings → Hearth → About → Build a dashboard** it silently restyled *every* board the user already had and repointed *every* Tasks card in the vault, while promising "your existing dashboards are never touched".

`applySetup` now installs the board **first** and writes every answer onto that dashboard:

- header text/visibility/logo/accent → `dashboard.header`; search section → `dashboard.showSearch`
- surface preset → `dashboard.cardOpacity` / `cardBlur` / `cardRadius` / `cardBorderWidth`; spacing → `dashboard.compact`
- backdrop → `dashboard.background` (+ `backgroundLayout`)
- TaskNotes field names and completed statuses → the Tasks **card's** own config

The only `HomeSettings` fields it still touches are the structural ones that installing a board *is*: `dashboards`, `activeDashboardId`, and the `setupStatus` flag that stops the wizard offering itself twice.

**Two new per-board overrides** existed nowhere and had to, so the answers could still be honoured: `Dashboard.compact` and `DashboardHeaderConfig.themeColorTarget`. Both follow the established pattern — an `effective*` resolver falling back to the global, sanitized on layout import, carried by **Duplicate**, and editable from a board's own settings modal. `TasksConfig` gained per-card TaskNotes field overrides (`taskNotesStatusField` / `DueField` / `PriorityField` / `DoneValue`), resolved ahead of the global mapping at every site in `src/cards/tasks.ts` that reads or writes those properties.

The answers with **no** per-board form are no longer asked about, since the wizard cannot apply them without changing Hearth everywhere: the whole behaviour step, and the Omnisearch and Iconic/Iconize integration offers. Each is one toggle in **Settings → Hearth**, which is where a setting that affects every board belongs. README, CHANGELOG and the wizard's own copy say so.

Two judgement calls worth a look:

- The accent override applies to the board's title block only. Hearth's tab and ribbon icons are app-level and still read the global `themeColorTarget`.
- A blank title field is treated as *no* override (the board follows the global title) rather than as an empty heading, since a board with an empty title override would show no heading at all.

## Related issue

None — reported directly.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (also `npm run typecheck`, `npm test` — 981 tests across 46 files, and `npm run lint` with 0 errors / 46 pre-existing deprecation warnings)
- [x] I've tested this in an actual vault

### Tests

The guarantee is asserted wholesale rather than setting by setting: a run with every answer moved off its default leaves the settings object equal to an untouched clone but for those three structural fields, so a future answer that writes a global setting fails the suite even if nobody thinks to test for it. Alongside that, the surface/background/header/TaskNotes cases now assert the value landed on the board and *not* in settings, and `test/boardoverrides.test.ts` covers the two new resolvers (including that a `themeColorTarget` override of `"none"` is a real answer, not an absent one).

---
_Generated by [Claude Code](https://claude.ai/code/session_015GuG6HMFGAqeDUa2TjyY11)_