### PR TITLE
chore: clear the plugin review's findings, and fix the search bar's hover background

### DIFF
--- a/src/calendarsource.ts
+++ b/src/calendarsource.ts
@@ -1203,7 +1203,6 @@ export function calendarSourcesEditor(ctx: CardEditorContext, containerEl: HTMLE
 	refresh.addSlider((s) => {
 		s.setLimits(0, 180, 5)
 			.setValue(cfg.refreshMin ?? 60)
-			.setDynamicTooltip()
 			.onChange((v) => {
 				cfg.refreshMin = v === 60 ? undefined : v;
 				ctx.opts.save();

--- a/src/cards/calendar.ts
+++ b/src/cards/calendar.ts
@@ -509,7 +509,6 @@ export function calendarEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 		days.addSlider((s) => {
 			s.setLimits(3, 60, 1)
 				.setValue(cfg.agendaDays ?? 14)
-				.setDynamicTooltip()
 				.onChange((v) => {
 					cfg.agendaDays = v === 14 ? undefined : v;
 					ctx.opts.save();

--- a/src/cards/commands.ts
+++ b/src/cards/commands.ts
@@ -78,7 +78,6 @@ export function commandsEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 	buttonSize.addSlider((s) => {
 		s.setLimits(60, 180, 10)
 			.setValue(card.tileSize ?? 90)
-			.setDynamicTooltip()
 			.onChange((v) => {
 				card.tileSize = v === 90 ? undefined : v;
 				ctx.opts.save();

--- a/src/cards/datacore.ts
+++ b/src/cards/datacore.ts
@@ -179,7 +179,6 @@ export function datacoreEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 	paging.addSlider((s) => {
 		s.setLimits(0, 100, 5)
 			.setValue(cfg.pageSize ?? 0)
-			.setDynamicTooltip()
 			.onChange((v) => {
 				cfg.pageSize = v > 0 ? v : undefined;
 				ctx.opts.save();

--- a/src/cards/embed.ts
+++ b/src/cards/embed.ts
@@ -350,7 +350,6 @@ function zoomSetting(
 		.addSlider((s) => {
 			s.setLimits(50, 200, 10)
 				.setValue(Math.round((view.scale ?? 1) * 100))
-				.setDynamicTooltip()
 				.onChange((v) => {
 					view.scale = v === 100 ? undefined : v / 100;
 					ctx.opts.save();

--- a/src/cards/git.ts
+++ b/src/cards/git.ts
@@ -662,7 +662,6 @@ export function gitEditor(ctx: CardEditorContext, containerEl: HTMLElement): voi
 		s
 			.setLimits(0, 50, 1)
 			.setValue(cfg.changeLimit ?? 8)
-			.setDynamicTooltip()
 			.onChange((value) => {
 				cfg.changeLimit = value === 8 ? undefined : value;
 				ctx.opts.save();
@@ -692,7 +691,6 @@ export function gitEditor(ctx: CardEditorContext, containerEl: HTMLElement): voi
 			s
 				.setLimits(1, 25, 1)
 				.setValue(cfg.logLimit ?? 5)
-				.setDynamicTooltip()
 				.onChange((value) => {
 					cfg.logLimit = value === 5 ? undefined : value;
 					ctx.opts.save();
@@ -711,7 +709,6 @@ export function gitEditor(ctx: CardEditorContext, containerEl: HTMLElement): voi
 		s
 			.setLimits(0, 60, 5)
 			.setValue(cfg.refreshMin ?? 0)
-			.setDynamicTooltip()
 			.onChange((value) => {
 				cfg.refreshMin = value > 0 ? value : undefined;
 				ctx.opts.save();

--- a/src/cards/heatmap.ts
+++ b/src/cards/heatmap.ts
@@ -94,7 +94,6 @@ export function heatmapEditor(ctx: CardEditorContext, containerEl: HTMLElement):
 	weeks.addSlider((s) => {
 		s.setLimits(8, 53, 1)
 			.setValue(cfg.weeks ?? 26)
-			.setDynamicTooltip()
 			.onChange((v) => {
 				cfg.weeks = v === 26 ? undefined : v;
 				ctx.opts.save();

--- a/src/cards/operon.ts
+++ b/src/cards/operon.ts
@@ -1082,7 +1082,6 @@ export function operonEditor(ctx: CardEditorContext, containerEl: HTMLElement): 
 		days.addSlider((s) => {
 			s.setLimits(1, 31, 1)
 				.setValue(cfg.agendaDays ?? DEFAULT_AGENDA_DAYS)
-				.setDynamicTooltip()
 				.onChange((v) => {
 					cfg.agendaDays = v;
 					ctx.opts.save();
@@ -1101,7 +1100,6 @@ export function operonEditor(ctx: CardEditorContext, containerEl: HTMLElement): 
 	count.addSlider((s) => {
 		s.setLimits(1, 50, 1)
 			.setValue(countOf(cfg))
-			.setDynamicTooltip()
 			.onChange((v) => {
 				cfg.count = v;
 				ctx.opts.save();

--- a/src/cards/rss.ts
+++ b/src/cards/rss.ts
@@ -389,7 +389,6 @@ export function rssEditor(ctx: CardEditorContext, containerEl: HTMLElement): voi
 	items.addSlider((s) => {
 		s.setLimits(3, 50, 1)
 			.setValue(cfg.itemLimit ?? 15)
-			.setDynamicTooltip()
 			.onChange((v) => {
 				cfg.itemLimit = v === 15 ? undefined : v;
 				ctx.opts.save();
@@ -414,7 +413,6 @@ export function rssEditor(ctx: CardEditorContext, containerEl: HTMLElement): voi
 	refresh.addSlider((s) => {
 		s.setLimits(0, 180, 5)
 			.setValue(cfg.refreshMin ?? 30)
-			.setDynamicTooltip()
 			.onChange((v) => {
 				cfg.refreshMin = v === 30 ? undefined : v;
 				ctx.opts.save();

--- a/src/cards/schedule.ts
+++ b/src/cards/schedule.ts
@@ -909,7 +909,6 @@ export function scheduleEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 		s
 			.setLimits(0, 10, 1)
 			.setValue(cfg.maxPerDay ?? 3)
-			.setDynamicTooltip()
 			.onChange((v) => {
 				cfg.maxPerDay = v === 3 ? undefined : v;
 				save();
@@ -950,7 +949,6 @@ export function scheduleEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 		s
 			.setLimits(20, 160, 4)
 			.setValue(clampHourHeight(cfg.hourHeight))
-			.setDynamicTooltip()
 			.onChange((v) => {
 				cfg.hourHeight = v === 44 ? undefined : v;
 				save();
@@ -978,7 +976,6 @@ export function scheduleEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 		s
 			.setLimits(3, 90, 1)
 			.setValue(listDays(cfg))
-			.setDynamicTooltip()
 			.onChange((v) => {
 				cfg.listDays = v === 14 ? undefined : v;
 				save();

--- a/src/cards/slideshow.ts
+++ b/src/cards/slideshow.ts
@@ -455,7 +455,6 @@ export function slideshowEditor(ctx: CardEditorContext, containerEl: HTMLElement
 			s
 				.setLimits(100, SLIDESHOW_MAX_TRANSITION_MS, 100)
 				.setValue(slideshowTransitionMs(cfg))
-				.setDynamicTooltip()
 				.onChange((v) => {
 					// No redraw per step — dragging a slider would rebuild the board (and
 					// restart every slideshow on it) on every notch. It applies when the

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -23,7 +23,6 @@ import {
 	priorityClass,
 	priorityDisplayLabel,
 	priorityKey,
-	priorityLevel,
 	priorityRank,
 	readPriorityEmoji,
 } from "../priority";
@@ -5119,8 +5118,6 @@ export class TaskFieldsModal extends Modal {
 				.setName(labels.fieldOpacity)
 				.setDesc(labels.fieldOpacityDesc)
 				.addSlider((sl) =>
-					// No setDynamicTooltip: it is deprecated, and current Obsidian
-					// already shows a slider's value inline beside it.
 					sl
 						.setLimits(1, 100, 1)
 						.setValue(fieldOpacity(field))

--- a/src/cards/templater.ts
+++ b/src/cards/templater.ts
@@ -221,7 +221,6 @@ export function templaterEditor(ctx: CardEditorContext, containerEl: HTMLElement
 	buttonSize.addSlider((s) => {
 		s.setLimits(60, 180, 10)
 			.setValue(card.tileSize ?? 90)
-			.setDynamicTooltip()
 			.onChange((v) => {
 				card.tileSize = v === 90 ? undefined : v;
 				ctx.opts.save();

--- a/src/cards/weather.ts
+++ b/src/cards/weather.ts
@@ -1,4 +1,4 @@
-import { Component, Notice, setIcon, Setting } from "obsidian";
+import { Component, setIcon, Setting } from "obsidian";
 import { emptyState } from "../cardbodies";
 import { t } from "../i18n";
 import {
@@ -22,9 +22,7 @@ import {
 	formatTemp,
 	formatWeekday,
 	formatWind,
-	type GeoResult,
 	loadWeather,
-	searchPlaces,
 	today,
 	upcomingDays,
 	upcomingHours,

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -688,7 +688,6 @@ class DashboardSettingsModal extends HearthTabbedModal {
 				sl
 					.setLimits(min, max, step)
 					.setValue(current)
-					.setDynamicTooltip()
 					.onChange((v) => set(v)),
 			);
 		}
@@ -857,7 +856,6 @@ class DashboardSettingsModal extends HearthTabbedModal {
 				sl
 					.setLimits(min, max, step)
 					.setValue(current)
-					.setDynamicTooltip()
 					.onChange((v) => set(v)),
 			);
 		}
@@ -1050,7 +1048,6 @@ class DashboardSettingsModal extends HearthTabbedModal {
 		setting.addSlider((sl) => {
 			sl.setLimits(min, max, step)
 				.setValue(dash[key] ?? globalValue)
-				.setDynamicTooltip()
 				.onChange((v) => {
 					dash[key] = v;
 					this.commit();
@@ -1122,10 +1119,6 @@ class DashboardSettingsModal extends HearthTabbedModal {
 		setting.addSlider((sl) => {
 			sl.setLimits(min, max, step)
 				.setValue(bg[key])
-				// Show the live value in a tooltip. On our declared minAppVersion
-				// (1.8.7) sliders don't yet render the value inline, so this is
-				// how the current opacity/blur stays visible while dragging.
-				.setDynamicTooltip()
 				.onChange((v) => {
 					bg[key] = v;
 					this.commit();

--- a/src/editors.ts
+++ b/src/editors.ts
@@ -230,7 +230,6 @@ export class CardSettingsModal extends HearthTabbedModal {
 			sl
 				.setLimits(0, 1, 0.05)
 				.setValue(card.cardOpacity ?? 1)
-				.setDynamicTooltip()
 				.onChange((v) => {
 					card.cardOpacity = v;
 					this.opts.save();
@@ -256,7 +255,6 @@ export class CardSettingsModal extends HearthTabbedModal {
 			sl
 				.setLimits(0, 24, 1)
 				.setValue(card.cardBlur ?? 0)
-				.setDynamicTooltip()
 				.onChange((v) => {
 					card.cardBlur = v;
 					this.opts.save();
@@ -282,7 +280,6 @@ export class CardSettingsModal extends HearthTabbedModal {
 			sl
 				.setLimits(0, CARD_BORDER_WIDTH_MAX, 1)
 				.setValue(card.cardBorderWidth ?? effectiveCardBorderWidth(this.opts.settings))
-				.setDynamicTooltip()
 				.onChange((v) => {
 					card.cardBorderWidth = v;
 					this.opts.save();

--- a/src/operon/mutations.ts
+++ b/src/operon/mutations.ts
@@ -34,8 +34,6 @@ import type { OperonPolicies, OperonTask } from "./types";
  * render.
  */
 
-const CONTRACT_VERSION = 1 as const;
-
 /** Risk levels Hearth applies without asking. Anything above these — or any
  * plan Operon marks as needing consent — goes to the user first. */
 const SILENT_RISK: readonly RiskLevelV1[] = ["none", "routine"];

--- a/src/operon/reads.ts
+++ b/src/operon/reads.ts
@@ -7,7 +7,7 @@ import type {
 	TaskQueryPageV1,
 } from "@stratejya/operon-cli/contracts/v1";
 import type { OperonAccess, OperonSession } from "./api";
-import type { OperonCatalog, OperonTask, OperonTaxonomy, OperonTimerState } from "./types";
+import type { OperonCatalog, OperonTask, OperonTimerState } from "./types";
 
 /**
  * Thin, never-throwing wrappers over the Operon reads Hearth uses.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -553,7 +553,7 @@ export class HomeSettingTab extends PluginSettingTab {
 
 	/** Add a reset (rotate-ccw) extra button to a slider Setting that restores
 	 * the factory default from DEFAULT_SETTINGS. The current value is surfaced by
-	 * the slider's own dynamic tooltip (see the sliders below). */
+	 * Obsidian itself, which draws it inline beside the slider. */
 	private addSliderReset(
 		setting: Setting,
 		sl: SliderComponent,
@@ -690,7 +690,6 @@ export class HomeSettingTab extends PluginSettingTab {
 		width.addSlider((sl) => {
 			sl.setLimits(700, 1600, 20)
 				.setValue(s.maxWidth)
-				.setDynamicTooltip()
 				.onChange(async (v) => {
 					s.maxWidth = v;
 					this.save();
@@ -1096,7 +1095,6 @@ export class HomeSettingTab extends PluginSettingTab {
 			opacity.addSlider((sl) => {
 				sl.setLimits(0, 1, 0.05)
 					.setValue(s.backgroundOpacity)
-					.setDynamicTooltip()
 					.onChange(async (v) => {
 						s.backgroundOpacity = v;
 						this.save();
@@ -1110,7 +1108,6 @@ export class HomeSettingTab extends PluginSettingTab {
 			blur.addSlider((sl) => {
 				sl.setLimits(0, 40, 1)
 					.setValue(s.backgroundBlur)
-					.setDynamicTooltip()
 					.onChange(async (v) => {
 						s.backgroundBlur = v;
 						this.save();
@@ -1164,7 +1161,6 @@ export class HomeSettingTab extends PluginSettingTab {
 		height.addSlider((sl) => {
 			sl.setLimits(BANNER_HEIGHT_MIN, BANNER_HEIGHT_MAX, 10)
 				.setValue(clampBannerHeight(s.bannerHeight))
-				.setDynamicTooltip()
 				.onChange(async (v) => {
 					s.bannerHeight = v;
 					this.save();
@@ -1991,7 +1987,6 @@ export class HomeSettingTab extends PluginSettingTab {
 		cardOpacity.addSlider((sl) => {
 			sl.setLimits(0, 1, 0.05)
 				.setValue(s.cardOpacity)
-				.setDynamicTooltip()
 				.onChange(async (v) => {
 					s.cardOpacity = v;
 					this.save();
@@ -2005,7 +2000,6 @@ export class HomeSettingTab extends PluginSettingTab {
 		cardBlur.addSlider((sl) => {
 			sl.setLimits(0, 24, 1)
 				.setValue(s.cardBlur)
-				.setDynamicTooltip()
 				.onChange(async (v) => {
 					s.cardBlur = v;
 					this.save();
@@ -2021,7 +2015,6 @@ export class HomeSettingTab extends PluginSettingTab {
 			// since rounding beyond it was never tuned for.
 			sl.setLimits(0, DEFAULT_SETTINGS.cardRadius, 1)
 				.setValue(s.cardRadius)
-				.setDynamicTooltip()
 				.onChange(async (v) => {
 					s.cardRadius = v;
 					this.save();
@@ -2035,7 +2028,6 @@ export class HomeSettingTab extends PluginSettingTab {
 		cardBorderWidth.addSlider((sl) => {
 			sl.setLimits(0, CARD_BORDER_WIDTH_MAX, 1)
 				.setValue(s.cardBorderWidth)
-				.setDynamicTooltip()
 				.onChange(async (v) => {
 					s.cardBorderWidth = v;
 					this.save();

--- a/styles.css
+++ b/styles.css
@@ -402,6 +402,19 @@
 	height: 100%;
 }
 
+/* The bar draws its own hover and focus state; the field inside it is only
+   text. Obsidian paints every text input on hover —
+
+     input[type='text']:not(:disabled):hover { background-color: … }
+
+   at specificity (0,3,1), which outranks the (0,3,0) rule above and lights a
+   grey slab across the bar's interior, carrying the input's own --input-radius
+   rather than the bar's 14px. Adding :hover here is (0,4,0): it wins on class
+   count, so the field stays transparent without an !important. */
+.hearth-view .hearth-search-bar .hearth-search-input:hover {
+	background: transparent;
+}
+
 .hearth-newnote {
 	display: flex;
 	align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -598,11 +598,13 @@
 	flex-wrap: wrap;
 	justify-content: flex-start;
 	--n: 1;
-	/* max(…, 1) keeps the single-chip case from dividing by zero. */
-	column-gap: clamp(8px, calc((100% - var(--n) * 38px) / max(var(--n) - 1, 1)), 48px);
-	/* A percentage row-gap would resolve against the container's indefinite
-	 * height and can collapse to 0, so wrapped rows get a fixed gap. */
-	row-gap: 8px;
+	/* Row gap first, then column gap. A percentage row-gap would resolve against
+	 * the container's indefinite height and can collapse to 0, so wrapped rows
+	 * get a fixed one; max(…, 1) keeps the single-chip case from dividing by
+	 * zero. Written as the `gap` shorthand rather than a `column-gap` longhand:
+	 * the two are equivalent on a flex container, but `column-gap` reads to
+	 * linters as the multi-column property of the same name. */
+	gap: 8px clamp(8px, calc((100% - var(--n) * 38px) / max(var(--n) - 1, 1)), 48px);
 	width: 100%;
 }
 
@@ -657,15 +659,22 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	/* "safe" keeps a card too short for its contents overflowing downwards only,
-	 * instead of centring the overflow and pushing the bar up out of the card.
-	 * Ignored by engines that don't know it, which leaves plain centring. */
-	justify-content: safe center;
 	gap: 8px;
 	width: 100%;
 	height: 100%;
 	flex: 1 1 auto;
 	min-width: 0;
+}
+
+/* "safe" keeps a card too short for its contents overflowing downwards only,
+   instead of centring the overflow and pushing the bar up out of the card.
+   Behind @supports rather than a second justify-content declaration in the rule
+   above, so engines that don't know the keyword keep plain centring without the
+   two declarations reading as a duplicate. */
+@supports (justify-content: safe center) {
+	.hearth-searchbar-card {
+		justify-content: safe center;
+	}
 }
 
 .hearth-card.is-searchbar-card .hearth-card-body {


### PR DESCRIPTION
## What does this PR do?

Clears the findings from the 2.1.0 plugin review (commit 2eb666b), plus one user-reported rendering bug found along the way.

### Search bar hover (user-reported, unrelated to the review)

Hovering the search bar lit a grey slab across its interior, carrying the input's own `--input-radius` instead of the bar's 14px — a rounded rectangle inset inside the bar's rounded rectangle. It comes from Obsidian's own stylesheet:

```css
@media (hover: hover) {
  input[type='text']:not(:disabled):hover {
    background-color: var(--background-modifier-form-field-hover);
    …
  }
}
```

That selector is specificity (0,3,1) and outranks the (0,3,0) rule that keeps the field transparent, so the background reappeared on hover only. A `:hover` variant of our own selector is (0,4,0) and wins on class count, no `!important` needed. Verified in Chromium against Obsidian 1.13.7's real `app.css`: the input's computed background stays `rgba(0,0,0,0)` idle, hovered, focused and focused+hovered, and the accent border on `:focus-within` is untouched.

### Source code (review findings)

- **`setDynamicTooltip` is deprecated** — dropped all 33 calls. Obsidian draws a slider's value inline itself as of 1.13, which is why the API was deprecated; the call is a no-op there. Three stale comments that described the removed calls were updated or dropped with them.
- **Dead symbols the linter found** — removed `Notice`, `GeoResult` and `searchPlaces` (weather card), `priorityLevel` (tasks card), `CONTRACT_VERSION` (Operon mutations) and `OperonTaxonomy` (Operon reads). The last three weren't in the review but are the same class of finding and were sitting in `npm run lint`.

### CSS lint (review findings)

- **`multicolumn` partially supported** — `.hearth-filters` now uses the `gap` shorthand instead of a `column-gap` longhand. The two are identical on a flex container, but the longhand shares its name with the multi-column property, which is what the linter was reading it as.
- **Duplicate `justify-content`** — `.hearth-searchbar-card`'s `justify-content: safe center` moves behind `@supports`, so the fallback to plain centring for engines that don't know the keyword survives without two declarations in one rule.

### Left alone deliberately

- `use24Hour` and `commandId` are our own `@deprecated` migration shims, documented in place with the release they can be removed in. The warnings are the JSDoc doing its job.
- `setWarning` — `setDestructive()` is `@since 1.13.0` and our declared `minAppVersion` is 1.8.7, so we stay on the supported API surface. Already commented at the call site.
- The `!important` rules are motion kill switches (`prefers-reduced-motion`, the performance tiers) and theme-override guards, each commented where it sits. Specificity can't replace an override that has to beat theme CSS of unknown load order.
- `display: contents` on `.hearth-kanban-card-block` is a plain wrapper div whose children need to stay flex items of the card. The partial-support caveat is about list/table semantics, which don't apply here.
- Vault enumeration is inherent to what the plugin is — search, recent files and the task cards all need the file list.

### ⚠️ minAppVersion: open question

Removing `setDynamicTooltip()` is a real regression below Obsidian 1.13 — those builds don't draw the value inline, so sliders show no value while dragging. Some context gathered on how big that group is:

- The cutoff is confirmed as **1.13.0/1.13.1**: `setDisplayFormat` and the `@deprecated` tag both first appear in the `obsidian@1.13.1` typings, and are absent from 1.13.0, 1.12.3 and 1.11.4.
- **1.13 only reached the public channel on 2026-07-30** (from the history of `desktop-releases.json`). Before that it sat on 1.12.7 from 2026-03-23 — over four months — with 1.13.0 Catalyst-only from 2026-05-28.
- Our own issue reports, which carry a structured "Obsidian version" field: **12 of 15 were below 1.13 before Jul 30; 0 of 9 after it.** Small and self-selected, and all 24 are Desktop — no mobile reports at all.

Bumping `minAppVersion` to 1.13.0 would freeze every pre-1.13 user on Hearth 2.1.0 permanently via `versions.json` — no bug fixes, not just no features. That looks like the more expensive side of the trade while 1.13 is under a month old publicly, so this PR leaves `minAppVersion` at 1.8.7. Worth revisiting once 1.13 has saturated.

## Related issue

None — follow-up on the 2.1.0 plugin review, plus a user-reported hover bug.

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

`npm run typecheck`, `npm run build` and `npm test` (980 passed, 1 skipped) are all green. `npm run lint` is down from 13 warnings to 7, all of them the intentional shims listed above. The hover fix was verified in a headless Chromium against Obsidian's real `app.css`, but not yet in a live vault.