### PR TITLE
chore: cut 2.2.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,12 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **Hovering the search bar no longer lights a grey slab inside it.** Obsidian
+  paints every text input on hover, and that rule outranked the one that makes
+  Hearth's search field transparent, so a second rounded rectangle — carrying
+  the field's own corner radius, not the bar's — appeared inset inside the bar.
+  The bar keeps drawing its own hover and focus affordance; only the stray
+  rectangle is gone.
 - **The setup wizard no longer changes your vault-wide settings.** Running setup
   — or re-running it later from **Settings → Hearth → About → Build a
   dashboard** — used to write its answers straight into the global settings: the
@@ -192,6 +198,12 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   `prefers-reduced-motion` is now honoured board-wide rather than by the three
   features that had their own rules for it. Card blur defaults to 0 for new
   vaults; existing vaults keep the value they have (#223).
+
+- **Deprecated Obsidian APIs cleared out of the settings UI.** Hearth no longer
+  calls `setDynamicTooltip()` on its sliders: Obsidian draws a slider's value
+  inline itself as of 1.13, where the call did nothing. On Obsidian 1.8.7–1.12.x
+  — still Hearth's declared minimum — a slider now shows no number while you
+  drag it; the value it lands on is the one the setting keeps, as before.
 
 - **"What's new" reads as a list of headlines, not a wall of text.** The dialog
   after an update — and **View changelog** in Settings → About — now shows one

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "2.2.0-beta.1",
+	"version": "2.2.0-beta.2",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
## What does this PR do?

Cuts `2.2.0-beta.2` — a snapshot of `main` at b15ef50, released as a
pre-release (`prerelease: true`, all release guards green):
https://github.com/ondreu/Hearth/releases/tag/2.2.0-beta.2

- `manifest-beta.json` → `2.2.0-beta.2`. `manifest.json` stays `2.1.0`, so the
  community store is untouched; this soaks with BRAT only.
- `CHANGELOG.md` gains the two user-visible bits of #244, which landed without
  an entry:
  - **Fixed** — hovering the search bar no longer lights a grey slab inside it.
  - **Changed** — the deprecated `setDynamicTooltip()` calls are gone, so on
    Obsidian 1.8.7–1.12.x a slider no longer shows its value while dragging.

The tag was minted by `release.yml` via `workflow_dispatch` (tag pushes are
blocked by the web sandbox's egress proxy), which is the same path every recent
release used.

## Related issue

n/a — release chore. Documents #244.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [x] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault — nothing to test; version/changelog only

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdrS4dcnMD7eoAzZ5dHozn)_