### PR TITLE
feat(icons): use Iconize pack icons on command and launchpad tiles

### DIFF
--- a/src/cards/commands.ts
+++ b/src/cards/commands.ts
@@ -3,7 +3,7 @@ import { applyTileSize, emptyState, makeTileDraggable, makeTileResizable, markOv
 import { moveItem } from "../editors";
 import { t } from "../i18n";
 import { CommandPickerModal } from "../pickers";
-import { addIconHelp, applyTileVisual } from "../widgeticon";
+import { addTileIconField, applyTileVisual } from "../widgeticon";
 import { type CommandItem, type DashboardCard } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -101,17 +101,10 @@ export function commandsEditor(ctx: CardEditorContext, containerEl: HTMLElement)
 		const row = new Setting(containerEl)
 			.setClass("hearth-link-setting")
 			.setName(cmd.name || cmd.id);
-		row.addText((txt) => {
-			txt
-				.setPlaceholder(t().editors.commands.iconOptionalPlaceholder)
-				.setValue(cmd.icon ?? "")
-				.onChange((v) => {
-					cmd.icon = v || undefined;
-					ctx.opts.save();
-				});
-			setTooltip(txt.inputEl, t().editors.iconHelp);
+		addTileIconField(row, ctx.app, cmd.icon ?? "", (v) => {
+			cmd.icon = v || undefined;
+			ctx.opts.save();
 		});
-		addIconHelp(row.controlEl);
 		row.addText((txt) => {
 			txt
 				.setPlaceholder(t().editors.commands.sizePlaceholder)

--- a/src/cards/links.ts
+++ b/src/cards/links.ts
@@ -1,10 +1,10 @@
-import { setTooltip, Setting, TFile } from "obsidian";
+import { Setting, TFile } from "obsidian";
 import { applyTileSize, emptyState, makeTileDraggable, makeTileResizable, markOverlappingTiles } from "../cardbodies";
 import { moveItem } from "../editors";
 import { t } from "../i18n";
 import { openFile, openLink as openLinkTarget } from "../opener";
 import { CommandPickerModal } from "../pickers";
-import { addIconHelp, applyTileVisual } from "../widgeticon";
+import { addTileIconField, applyTileVisual } from "../widgeticon";
 import { type DashboardCard, type LinkItem } from "../types";
 import { makeClickable } from "../ui";
 import { type HomeView } from "../view";
@@ -103,17 +103,10 @@ export function linksEditor(ctx: CardEditorContext, containerEl: HTMLElement): v
 					ctx.opts.save();
 				}),
 		);
-		row.addText((txt) => {
-			txt
-				.setPlaceholder(t().editors.links.iconPlaceholder)
-				.setValue(link.icon)
-				.onChange((v) => {
-					link.icon = v;
-					ctx.opts.save();
-				});
-			setTooltip(txt.inputEl, t().editors.iconHelp);
+		addTileIconField(row, ctx.app, link.icon, (v) => {
+			link.icon = v;
+			ctx.opts.save();
 		});
-		addIconHelp(row.controlEl);
 		row.addDropdown((d) => {
 			(Object.keys(t().editors.linkTypes) as LinkItem["type"][]).forEach(
 				(k) => {

--- a/src/cards/templater.ts
+++ b/src/cards/templater.ts
@@ -27,7 +27,7 @@ import {
 import { type DashboardCard, type TemplaterItem } from "../types";
 import { makeClickable, promptForText } from "../ui";
 import { type HomeView } from "../view";
-import { addIconHelp, applyTileVisual } from "../widgeticon";
+import { addTileIconField, applyTileVisual } from "../widgeticon";
 import { type CardDefinition, type CardEditorContext } from "./definition";
 
 
@@ -266,17 +266,10 @@ export function templaterEditor(ctx: CardEditorContext, containerEl: HTMLElement
 				}),
 		);
 
-		row.addText((txt) => {
-			txt
-				.setPlaceholder(t().pickers.iconPlaceholder)
-				.setValue(item.icon)
-				.onChange((v) => {
-					item.icon = v;
-					ctx.opts.save();
-				});
-			setTooltip(txt.inputEl, t().editors.iconHelp);
+		addTileIconField(row, ctx.app, item.icon, (v) => {
+			item.icon = v;
+			ctx.opts.save();
 		});
-		addIconHelp(row.controlEl);
 
 		// A template is addressed by vault path, which is exactly the kind of
 		// thing a fuzzy picker is for. Scoped to Templater's own template folder

--- a/src/iconizeicons.ts
+++ b/src/iconizeicons.ts
@@ -1,0 +1,142 @@
+import { FuzzySuggestModal, type App, type FuzzyMatch } from "obsidian";
+import { applyFileIcon, ICONIZE_PLUGIN_ID, normalizeStoredIcon } from "./fileicons";
+import { knownIconIds, resolveIconId } from "./lucide";
+import { t } from "./i18n";
+
+/** One icon from an Iconize pack, ready to store on a tile (`LiFileText`, …). */
+export interface IconizeIconEntry {
+	name: string;
+	label: string;
+}
+
+/** The bit of Iconize's public API Hearth needs for tile icons. */
+interface IconizeApi {
+	getIconByName?: (iconNameWithPrefix: string) => unknown;
+	setIconForNode?: (iconName: string, node: HTMLElement, color?: string) => void;
+	getAllIconPacks?: () => IconizeIconPack[];
+	getIconsFromIconPack?: (packName: string) => IconizeIconPack | undefined;
+}
+
+interface IconizeIconPack {
+	name: string;
+	prefix: string;
+	icons?: { name: string; prefix: string }[];
+}
+
+export function iconizeEnabled(app: App): boolean {
+	try {
+		return app.plugins.enabledPlugins.has(ICONIZE_PLUGIN_ID);
+	} catch {
+		return false;
+	}
+}
+
+function iconizeApi(app: App): IconizeApi | null {
+	if (!iconizeEnabled(app)) return null;
+	const plugin = app.plugins.plugins[ICONIZE_PLUGIN_ID] as { api?: IconizeApi } | undefined;
+	return plugin?.api ?? null;
+}
+
+/** Every Iconize icon name Hearth can render, for the tile-icon picker. */
+export function iconizeIconEntries(app: App): IconizeIconEntry[] {
+	const api = iconizeApi(app);
+	if (!api?.getAllIconPacks) return [];
+	const out: IconizeIconEntry[] = [];
+	try {
+		for (const pack of api.getAllIconPacks()) {
+			const loaded = api.getIconsFromIconPack?.(pack.name) ?? pack;
+			for (const icon of loaded.icons ?? []) {
+				const name = `${icon.prefix}${icon.name}`;
+				out.push({ name, label: `${pack.name} / ${icon.name}` });
+			}
+		}
+	} catch {
+		return [];
+	}
+	return out.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+/** Draw an Iconize pack icon into `el`. Returns false when Iconize is off or the
+ * name isn't one of its loaded icons. */
+export function renderIconizeIcon(app: App, el: HTMLElement, raw: string): boolean {
+	const name = raw.trim();
+	if (!name) return false;
+	const api = iconizeApi(app);
+	if (!api?.getIconByName) return false;
+	try {
+		const icon = api.getIconByName(name);
+		if (!icon) return false;
+		el.empty();
+		if (api.setIconForNode) {
+			api.setIconForNode(name, el);
+			return true;
+		}
+		const svg = (icon as { svgElement?: string }).svgElement;
+		if (typeof svg === "string" && svg) {
+			el.innerHTML = svg;
+			return true;
+		}
+	} catch {
+		// Iconize's API is best-effort; a broken read costs the custom icon, not
+		// the tile.
+	}
+	return false;
+}
+
+/**
+ * Draw a stored tile icon: Lucide id, emoji, Iconize pack name, or nothing.
+ * Vault image paths are handled by {@link applyTileVisual} before this runs.
+ */
+export function applyTileIcon(app: App, el: HTMLElement, raw: string | undefined): boolean {
+	const value = raw?.trim();
+	if (!value) return false;
+	try {
+		const known = knownIconIds();
+		const resolved = normalizeStoredIcon(value, (id) => known.has(id));
+		if (resolved) {
+			applyFileIcon(el, resolved);
+			return true;
+		}
+		const lucide = resolveIconId(value);
+		if (lucide) {
+			applyFileIcon(el, { kind: "lucide", id: lucide });
+			return true;
+		}
+		return renderIconizeIcon(app, el, value);
+	} catch {
+		return false;
+	}
+}
+
+/** Fuzzy picker over Iconize's loaded icon packs. Only offered when Iconize is
+ * enabled — Lucide icons stay on the existing Lucide picker. */
+export class IconizeIconPickerModal extends FuzzySuggestModal<IconizeIconEntry> {
+	constructor(
+		app: App,
+		private readonly onChoose: (name: string) => void,
+	) {
+		super(app);
+		this.setPlaceholder(t().pickers.iconize);
+	}
+
+	getItems(): IconizeIconEntry[] {
+		return iconizeIconEntries(this.app);
+	}
+
+	getItemText(entry: IconizeIconEntry): string {
+		return entry.label;
+	}
+
+	renderSuggestion(match: FuzzyMatch<IconizeIconEntry>, el: HTMLElement): void {
+		el.addClass("hearth-icon-suggestion");
+		const slot = el.createSpan("hearth-icon-suggestion-icon hearth-link-icon");
+		if (!renderIconizeIcon(this.app, slot, match.item.name)) {
+			slot.addClass("is-empty");
+		}
+		el.createSpan({ cls: "hearth-icon-suggestion-name", text: match.item.label });
+	}
+
+	onChooseItem(entry: IconizeIconEntry): void {
+		this.onChoose(entry.name);
+	}
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -457,6 +457,8 @@ export const en = {
 		icon: "Search Lucide icons…",
 		iconPlaceholder: "Lucide icon id",
 		iconBrowse: "Browse Lucide icons",
+		iconize: "Search Iconize icons…",
+		iconizeBrowse: "Browse Iconize icons",
 		iconClear: "Clear icon",
 	},
 
@@ -1130,7 +1132,8 @@ export const en = {
 					name: "Iconize",
 					desc:
 						"The same for Iconize (formerly Obsidian Icon Folder), including icons " +
-						"set through a frontmatter property.",
+						"set through a frontmatter property. Iconize pack icons can also be " +
+						"used on command, launchpad and templater tiles.",
 				},
 				excalidraw: {
 					name: "Excalidraw",
@@ -1402,8 +1405,10 @@ export const en = {
 		/** Shown as the tooltip on tile icon fields (launchpad, commands). */
 		iconHelp:
 			"Enter a Lucide icon id (e.g. “home”, “star”, “calendar”) — browse them at " +
-			"lucide.dev/icons. You can also enter a vault image path (e.g. " +
-			"Attachments/icon.png) to use your own picture as the icon.",
+			"lucide.dev/icons. When Iconize is enabled, you can also pick one of its " +
+			"icon-pack icons (e.g. “FaBook”), or type an Iconize name directly. You " +
+			"can also enter a vault image path (e.g. Attachments/icon.png) to use your " +
+			"own picture as the icon.",
 		/** Tabs across the top of the card settings modal. */
 		tabs: {
 			content: "Content",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -423,6 +423,8 @@ export const zh: Translations = {
 		icon: "搜索 Lucide 图标…",
 		iconPlaceholder: "Lucide 图标 id",
 		iconBrowse: "浏览 Lucide 图标",
+		iconize: "搜索 Iconize 图标…",
+		iconizeBrowse: "浏览 Iconize 图标",
 		iconClear: "清除图标",
 	},
 

--- a/src/widgeticon.ts
+++ b/src/widgeticon.ts
@@ -1,6 +1,8 @@
-import { setIcon, setTooltip, TFile } from "obsidian";
+import { setIcon, setTooltip, TextComponent, type App, type Setting, TFile } from "obsidian";
 import type { HomeView } from "./view";
 import { isImageFile } from "./filetypes";
+import { applyTileIcon, iconizeEnabled, IconizeIconPickerModal } from "./iconizeicons";
+import { LucideIconPickerModal } from "./lucide";
 import { t } from "./i18n";
 
 /**
@@ -24,8 +26,8 @@ export function resolveIconImage(view: HomeView, icon: string | undefined): TFil
  *   (object-fit: cover) with the label overlaid on top (#119). The caller adds
  *   the label afterwards; the `hearth-tile-has-image` class makes CSS position
  *   the image behind it and give the label a legibility scrim.
- * - Otherwise the usual centered Lucide icon slot is used (falling back to
- *   `fallback` when the string is empty).
+ * - Otherwise a centered icon slot is used: Lucide, emoji, Iconize pack icon,
+ *   or `fallback` when the string is empty or unrecognised.
  */
 export function applyTileVisual(
 	view: HomeView,
@@ -40,16 +42,80 @@ export function applyTileVisual(
 		img.src = view.app.vault.getResourcePath(image);
 		return;
 	}
-	setIcon(tile.createDiv("hearth-link-icon"), icon?.trim() || fallback);
+	const slot = tile.createDiv("hearth-link-icon");
+	if (!applyTileIcon(view.app, slot, icon)) {
+		setIcon(slot, fallback);
+	}
 }
 
 /**
  * Append a small "?" help badge to an icon field's control row, carrying the
  * shared icon help as its tooltip so users can discover that the field accepts
- * a Lucide id or a vault image path without having to hover the input (#119).
+ * a Lucide id, an Iconize icon, or a vault image path (#119).
  */
 export function addIconHelp(controlEl: HTMLElement): void {
 	const help = controlEl.createSpan({ cls: "hearth-icon-help", text: "?" });
 	setTooltip(help, t().editors.iconHelp);
 	help.setAttribute("aria-label", t().editors.iconHelp);
+}
+
+/**
+ * Icon field for command / launchpad / templater tiles: text input, live
+ * preview, Lucide browse, and — when Iconize is enabled — an Iconize browse
+ * button for downloaded icon packs.
+ */
+export function addTileIconField(
+	row: Setting,
+	app: App,
+	value: string,
+	onChange: (value: string) => void,
+): void {
+	const preview = row.controlEl.createSpan({
+		cls: "hearth-icon-preview hearth-link-icon",
+	});
+	let text: TextComponent | undefined;
+
+	const apply = (next: string) => {
+		const trimmed = next.trim();
+		preview.empty();
+		preview.toggleClass("is-empty", !applyTileIcon(app, preview, trimmed));
+		onChange(trimmed);
+	};
+
+	row.addText((tx) => {
+		text = tx;
+		tx.setPlaceholder(t().pickers.iconPlaceholder)
+			.setValue(value)
+			.onChange((v) => apply(v));
+		setTooltip(tx.inputEl, t().editors.iconHelp);
+	});
+
+	row.addExtraButton((b) =>
+		b
+			.setIcon("search")
+			.setTooltip(t().pickers.iconBrowse)
+			.onClick(() => {
+				new LucideIconPickerModal(app, (name) => {
+					text?.setValue(name);
+					apply(name);
+				}).open();
+			}),
+	);
+
+	if (iconizeEnabled(app)) {
+		row.addExtraButton((b) =>
+			b
+				.setIcon("shapes")
+				.setTooltip(t().pickers.iconizeBrowse)
+				.onClick(() => {
+					new IconizeIconPickerModal(app, (name) => {
+						text?.setValue(name);
+						apply(name);
+					}).open();
+				}),
+		);
+	}
+
+	addIconHelp(row.controlEl);
+	preview.toggleClass("is-empty", !applyTileIcon(app, preview, value));
 }

--- a/styles.css
+++ b/styles.css
@@ -2580,6 +2580,13 @@
 	height: 24px;
 }
 
+/* Iconize pack icons inject raw SVG rather than Obsidian's .svg-icon wrapper. */
+.hearth-link-icon svg {
+	width: 24px;
+	height: 24px;
+	flex-shrink: 0;
+}
+
 /* A vault image used as a tile icon (#119): the image covers the whole tile and
  * the label is overlaid on top of it. */
 .hearth-link-tile.hearth-tile-has-image {


### PR DESCRIPTION
## Summary
- When **Iconize** is enabled, command / launchpad / templater tile icons can use icons from Iconize's loaded packs (Font Awesome, Remix, custom packs, etc.), not just Lucide ids and vault images.
- Uses Iconize's public `api.getIconByName` / `api.setIconForNode` for rendering, and adds a **Browse Iconize icons** picker next to the existing Lucide browse button in tile icon fields.
- Lucide ids, emoji, and Iconize `Li*` names continue to work as before; non-Lucide pack icons (e.g. `FaBook`) render through Iconize.

## Test plan
- [ ] With Iconize enabled: edit a Commands card → icon field shows Lucide + Iconize browse buttons
- [ ] Pick a non-Lucide Iconize icon → tile renders it on the dashboard
- [ ] With Iconize disabled: only Lucide browse appears; existing Lucide/image icons unchanged
- [ ] `npm test` / `npm run build`


Made with [Cursor](https://cursor.com)