### PR TITLE
chore: cut 2.2.0-beta.3

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "2.2.0-beta.2",
+	"version": "2.2.0-beta.3",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
## What does this PR do?

Cuts `2.2.0-beta.3` — a snapshot of `main` at e5e4e50 — and lands the beta
manifest bump so `manifest-beta.json` on `main` matches the tag BRAT serves.

`manifest-beta.json` `2.2.0-beta.2` → `2.2.0-beta.3`. Nothing else changes:
`manifest.json` stays `2.1.0`, so the community store is untouched and stable
users see nothing.

What this beta adds over `2.2.0-beta.2`:

- Simplified Chinese locale and Chinese README (ondreu/Hearth#246)
- Slideshow daily advance, manual mode and position memory (ondreu/Hearth#253, closes ondreu/Hearth#249)

`CHANGELOG.md`'s `[2.2.0]` section already describes exactly this build, so it
needed no edit.

The release is already published as a pre-release, cut by the
`Release Obsidian plugin` workflow via `workflow_dispatch` (tag pushes are
blocked by the sandbox egress proxy): https://github.com/ondreu/Hearth/releases/tag/2.2.0-beta.3

This soaks with BRAT testers; promotion to stable is a separate, later job.

## Related issue

n/a — release chore.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

Release chore — version bump only.

## Checklist

- [x] `npm run typecheck` passes locally; the release workflow's own
      `Install & build` step and all four release guards (tag↔manifest, beta
      parity, plain-`x.y.z` store manifest, build output) passed on this commit
- [x] `node scripts/verify-manifests.mjs` passes
- [x] I've tested this in an actual vault — this is what the beta soak is for

---
_Generated by [Claude Code](https://claude.ai/code/session_01McofmzxxmFexHZcXJBN8Sa)_