### PR TITLE
fix(cards): reset a card's body and overlays before every redraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,19 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **A card that redraws itself is properly reset first.** Cards redraw
+  constantly — when a file they show is edited, when the vault changes at all,
+  when an embed card's view switcher is clicked — and each redraw emptied the
+  card's body without undoing two things the previous one had left outside it.
+  The floating **open button** (Daily note, Embed, Slideshow) lives on the card
+  rather than in its body, so it survived, and a fresh one was stacked on top
+  every time; being 70% opaque and pixel-aligned, the pile read as a single
+  button quietly darkening as you worked. And the marks a render leaves on the
+  body — which say whether it drew a picture, a Live Preview editor or plain
+  text, and control the card's padding — stayed behind too, so an embed card
+  switched from its picture view to a note kept the picture's edge-to-edge
+  padding and drew the note flush against the card's sides. A redraw now starts
+  from exactly the state the first one did.
 - **Hovering the search bar no longer lights a grey slab inside it.** Obsidian
   paints every text input on hover, and that rule outranked the one that makes
   Hearth's search field transparent, so a second rounded rectangle — carrying

--- a/src/cardbodies.ts
+++ b/src/cardbodies.ts
@@ -75,12 +75,20 @@ export function emptyState(body: HTMLElement, icon: string, text: string): void 
 }
 
 
+/** The floating overlay a card's action buttons live in. Named here because
+ * two things need to agree on it: what {@link cardOverlayButton} creates, and
+ * what {@link resetCardBody} clears away before the next draw. */
+const CARD_OVERLAY_CLASS = "hearth-card-actions-overlay";
+
 /**
  * A small action button floated over the card — the "open this file" affordance
  * the daily, embed and slideshow cards each offer. It is attached to the card
  * *element* rather than the body, so it takes no part in the body's scroll or
  * flow, and falls back to the body when the card element can't be found (the
  * card settings preview has no `.hearth-card` ancestor).
+ *
+ * Because it sits outside the body, emptying the body doesn't remove it — the
+ * redraw does, through {@link resetCardBody}.
  */
 export function cardOverlayButton(
 	body: HTMLElement,
@@ -89,7 +97,7 @@ export function cardOverlayButton(
 	onClick: (evt: MouseEvent) => void,
 ): HTMLButtonElement {
 	const cardEl = body.closest(".hearth-card");
-	const overlay = (cardEl ?? body).createDiv("hearth-card-actions-overlay");
+	const overlay = (cardEl ?? body).createDiv(CARD_OVERLAY_CLASS);
 	const button = overlay.createEl("button", {
 		cls: "hearth-open-btn",
 		attr: { "aria-label": label },
@@ -97,6 +105,44 @@ export function cardOverlayButton(
 	setIcon(button, icon);
 	button.addEventListener("click", onClick);
 	return button;
+}
+
+
+/**
+ * Put a card's body back to the state its first draw started from, so every
+ * redraw begins from the same place that one did.
+ *
+ * `body.empty()` alone isn't enough, and neither gap shows up until a card is
+ * redrawn — which cards do constantly: on a watched file changing, on any vault
+ * event, or on the embed card's view switcher.
+ *
+ * - **Classes.** A render marks the body with what it drew (`is-embed-host`,
+ *   `is-jot-host`, `hearth-card-body-image`, `hearth-card-body-live`,
+ *   `hearth-slideshow-host` …) and several of those zero the body's padding.
+ *   `empty()` takes away children, not classes, so the marks accumulated: an
+ *   embed card switched from its picture view to a note kept
+ *   `hearth-card-body-image` and drew the note flush against the card's edges.
+ *   Restoring the mount-time list (the body's own class, plus `has-bg`) rather
+ *   than naming the render-added ones means a kind can mark the body however it
+ *   likes without this having to know.
+ * - **Overlays.** {@link cardOverlayButton} deliberately floats its button on
+ *   the card *element*, outside the body's scroll and flow — so emptying the
+ *   body left it behind and every redraw stacked another copy on top. Pixel
+ *   aligned and 0.7 opaque, they never looked like duplicates; they looked like
+ *   one button quietly darkening as the vault changed, over a growing pile of
+ *   dead click handlers.
+ */
+export function resetCardBody(body: HTMLElement, baseClasses: string): void {
+	body.empty();
+	if (body.className !== baseClasses) body.className = baseClasses;
+	const cardEl = body.closest(".hearth-card");
+	if (!cardEl) return;
+	// Direct children only, and read into an array first: a "leaf" card hosts
+	// another plugin's view, whose contents are none of Hearth's business, and
+	// removing while iterating a live HTMLCollection skips elements.
+	for (const child of Array.from(cardEl.children)) {
+		if (child.classList.contains(CARD_OVERLAY_CLASS)) child.remove();
+	}
 }
 
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -4,7 +4,7 @@ import {
 	setIcon,
 	type TAbstractFile,
 } from "obsidian";
-import { emptyState } from "./cardbodies";
+import { emptyState, resetCardBody } from "./cardbodies";
 import { deferRedrawWhileTyping } from "./cardfocus";
 import { gateCardMotionOnVisibility } from "./motion";
 import { confirmAction } from "./ui";
@@ -242,11 +242,15 @@ function mountCardBody(
 ): () => void {
 	const def = cardDefinition(card);
 	let child: Component | null = null;
+	// The classes the body carries before any card has drawn into it — its own,
+	// plus `has-bg`. A render adds its own marks on top and `empty()` leaves
+	// them there, so each draw restores this snapshot (see `resetCardBody`).
+	const baseClasses = body.className;
 	const draw = () => {
 		if (child) parent.removeChild(child);
 		child = new Component();
 		parent.addChild(child);
-		body.empty();
+		resetCardBody(body, baseClasses);
 		try {
 			def.render(view, card, body, child);
 		} catch (err) {
@@ -260,7 +264,9 @@ function mountCardBody(
 			// to the one card and say so on its face, with the real error on the
 			// console for a bug report.
 			console.error(`Hearth: the ${card.kind} card failed to render`, err);
-			body.empty();
+			// Clear whatever the half-finished render left behind — its marks on
+			// the body included — so the failure notice draws in a plain card.
+			resetCardBody(body, baseClasses);
 			emptyState(body, "alert-triangle", t().cards.empty.renderFailed);
 		}
 	};


### PR DESCRIPTION
## What does this PR do?

A card redraw emptied the body and nothing else, so two things a previous render had left **outside** the body survived it. Cards redraw constantly — a watched file changing, any vault event, the embed card's view switcher — so both compound quietly with use.

**1. The floating open button stacks.** `cardOverlayButton` attaches its overlay to the card *element* rather than the body — deliberately, so it takes no part in the body's scroll or flow — which also means `body.empty()` never removed it. Nothing else did either (`hearth-card-actions-overlay` appears exactly once in `src/`, at the point it's created). Every redraw added another copy on top of the last.

They are pixel-aligned (`position: absolute; top: 6px; right: 6px`) and `.hearth-open-btn` is `opacity: 0.7` over a solid `--background-secondary`, so a pile never looks like duplicates: two composite to 0.91, three to 0.97. The button appears to darken towards looking permanently hovered, over a growing pile of dead click handlers. Affects the **Daily note**, **Embed** and **Slideshow** cards (each has the button behind a setting).

Easiest repro: an Embed card with a second view and **Open button** on — click the switcher a few times and watch the button darken. Or leave a read-only Daily note card on the board and edit today's note in another pane; each save adds one.

**2. Render marks on the body stay behind.** A render marks the body with what it drew — `is-embed-host`, `is-jot-host`, `hearth-card-body-image`, `hearth-card-body-live`, `hearth-slideshow-host` — and `empty()` removes children, not classes. Several of those marks zero the body's padding (`.hearth-card > .hearth-card-body.hearth-card-body-image { padding: 0 }`), so an Embed card switched from its picture view to a note keeps `hearth-card-body-image` and draws the note flush against the card's edges.

### The fix

`resetCardBody()` in `cardbodies.ts` does what a redraw needs: empty the body, restore the class list the body had at mount (its own, plus `has-bg`), and remove the overlays from the card element. `mountCardBody`'s `draw()` calls it in place of `body.empty()` — one call site, since `def.render` is dispatched from exactly one place.

Classes are restored from a **snapshot** rather than by naming the render-added ones, so a card kind can mark the body however it likes without this having to know. It also makes the change conservative: every draw now starts from exactly the state the first draw started from — the state each kind is already known to render correctly from — so the only behaviour that changes is the divergence.

Two things it deliberately leaves alone: `.hearth-embed-switch` (the embed switcher, mounted once per card by `mountExtras`, not per draw) and anything inside a hosted plugin view — only direct children of the card element carrying the overlay class are removed.

The failure path calls it too, so a half-finished render's marks don't stay on the card the "couldn't render" notice is drawn in.

## Related issue

None — found while working on #116 (the new Periodic note card uses the same overlay helper and inherits the fix). Not filed separately since the fix is here.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

**No unit test:** this is DOM work, and the test environment is `node` with no Obsidian API mocks — the rule the rest of the rendering code follows. `npm run build`, `npm test` (1028 passing) and `npm run lint` (7 warnings, unchanged from baseline) are clean, but the visual result is the one thing I can't check from here. The two repros above are the quickest way to see both halves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuxhxZNopZGQgUULefp4JM)_