### PR TITLE
Stop the settings-modal tab strip painting a slab behind the tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,15 +171,18 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   the field's own corner radius, not the bar's — appeared inset inside the bar.
   The bar keeps drawing its own hover and focus affordance; only the stray
   rectangle is gone.
-- **The tab strip in a card's or a board's settings takes the colour of the
-  dialog it sits in.** The strip is pinned to the top of the dialog so the tabs
-  stay reachable while a long tab scrolls past, which means it has to paint over
-  whatever passes underneath — and it painted with the *note* background. On
-  every theme that gives its dialogs a colour of their own, the tabs ended up on
-  a pale slab in the wrong shade. Hearth now measures the colour the dialog is
-  actually painted with as it opens — however the theme sets it — and where
-  there is nothing to measure it falls back to Obsidian's own modal colour
-  before the note background.
+- **No more pale slab behind the tabs in a card's or a board's settings.** The
+  tab strip was pinned to the top of the dialog so the tabs stay reachable while
+  a long tab scrolls past, and a pinned strip has to paint over whatever passes
+  underneath it. It painted with the *note* background — a colour plenty of
+  themes reserve for notes alone — so on those themes the tabs sat on a
+  rectangle in the wrong shade. Hearth now measures the colour the dialog is
+  actually painted with as it opens, however the theme sets it, and pins the
+  strip only when there is a colour it can match exactly. A dialog wearing no
+  such colour — a glass or translucent theme, where painting even the dialog's
+  own colour a second time would double the tint — keeps a strip that simply
+  scrolls with the rest of the dialog. The tabs go by as you scroll on those
+  themes; nothing is ever painted in the wrong shade on any of them.
 - **The setup wizard no longer changes your vault-wide settings.** Running setup
   — or re-running it later from **Settings → Hearth → About → Build a
   dashboard** — used to write its answers straight into the global settings: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,15 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   the field's own corner radius, not the bar's — appeared inset inside the bar.
   The bar keeps drawing its own hover and focus affordance; only the stray
   rectangle is gone.
+- **The tab strip in a card's or a board's settings takes the colour of the
+  dialog it sits in.** The strip is pinned to the top of the dialog so the tabs
+  stay reachable while a long tab scrolls past, which means it has to paint over
+  whatever passes underneath — and it painted with the *note* background. On
+  every theme that gives its dialogs a colour of their own, the tabs ended up on
+  a pale slab in the wrong shade. Hearth now measures the colour the dialog is
+  actually painted with as it opens — however the theme sets it — and where
+  there is nothing to measure it falls back to Obsidian's own modal colour
+  before the note background.
 - **The setup wizard no longer changes your vault-wide settings.** Running setup
   — or re-running it later from **Settings → Hearth → About → Build a
   dashboard** — used to write its answers straight into the global settings: the

--- a/src/tabbedmodal.ts
+++ b/src/tabbedmodal.ts
@@ -61,6 +61,8 @@ export abstract class HearthTabbedModal extends Modal {
 		contentEl.empty();
 		contentEl.addClass("hearth-tabbed-modal");
 
+		this.hearthSyncModalSurface();
+
 		const tabs = this.hearthTabs();
 		const active = this.hearthActiveTab(tabs);
 
@@ -80,6 +82,40 @@ export abstract class HearthTabbedModal extends Modal {
 
 		if (this.hearthRenderFooter) {
 			this.hearthRenderFooter(contentEl.createDiv("hearth-modal-footer"));
+		}
+	}
+
+	/**
+	 * Publish the modal's own background colour as `--hearth-modal-surface`, for
+	 * the sticky ribbon to paint itself with.
+	 *
+	 * The ribbon has to hide the rows scrolling beneath it, and any hard-coded
+	 * colour is a guess about the theme: with `--background-primary` (the note
+	 * background) the strip showed up as a slab in a different shade to the
+	 * modal on every theme that styles the two differently. Measuring beats
+	 * guessing — a theme can dress its modals through `--modal-background`, a
+	 * rule on `.modal`, or one on `.modal-content`, and all three end up in the
+	 * computed colour of some element between the content and the frame.
+	 *
+	 * Walks content → frame and takes the first background solid enough to cover
+	 * what slides under it; faint tints layered over the frame are skipped so
+	 * the strip doesn't take a 3%-white wash for the whole surface. Nothing
+	 * usable (a gradient, a translucent frame) leaves the property unset, and
+	 * the stylesheet's fallback chain takes over.
+	 */
+	private hearthSyncModalSurface(): void {
+		const { contentEl } = this;
+		contentEl.style.removeProperty("--hearth-modal-surface");
+		const frame = this.modalEl ?? contentEl;
+		let el: HTMLElement | null = contentEl;
+		while (el) {
+			const color = window.getComputedStyle(el).backgroundColor;
+			if (isOpaqueSurfaceColor(color)) {
+				contentEl.style.setProperty("--hearth-modal-surface", color);
+				return;
+			}
+			if (el === frame) return;
+			el = el.parentElement;
 		}
 	}
 
@@ -127,4 +163,29 @@ export abstract class HearthTabbedModal extends Modal {
 			text: t().settings.sectionErrorHint,
 		});
 	}
+}
+
+/**
+ * Is this computed `background-color` solid enough to sit a sticky bar on?
+ *
+ * `getComputedStyle` hands back `rgb()`/`rgba()` in either the legacy comma
+ * form or the modern `rgb(r g b / a)` one, so both separators are treated the
+ * same and the alpha is simply the fourth component when there is one.
+ * Anything else — `transparent`, a colour space this doesn't recognise, an
+ * element painted by a gradient — reads as "no surface here" and the walk
+ * carries on outwards.
+ *
+ * The 0.9 floor keeps the near-solid, so a theme that rounds its modal fill to
+ * 0.98 still counts, while rejecting the decorative washes themes lay over a
+ * frame: such a colour on its own says nothing about what shows through it.
+ */
+export function isOpaqueSurfaceColor(color: string): boolean {
+	const body = /^rgba?\(([^)]*)\)$/.exec(color.trim())?.[1];
+	if (body === undefined) return false;
+	const args = body.split(/[\s,/]+/).filter((arg) => arg.length > 0);
+	if (args.length < 3) return false;
+	if (args.length < 4) return true;
+	const raw = args[3];
+	const alpha = raw.endsWith("%") ? Number(raw.slice(0, -1)) / 100 : Number(raw);
+	return Number.isFinite(alpha) && alpha >= 0.9;
 }

--- a/src/tabbedmodal.ts
+++ b/src/tabbedmodal.ts
@@ -61,7 +61,7 @@ export abstract class HearthTabbedModal extends Modal {
 		contentEl.empty();
 		contentEl.addClass("hearth-tabbed-modal");
 
-		this.hearthSyncModalSurface();
+		this.hearthSyncModalSurface(true);
 
 		const tabs = this.hearthTabs();
 		const active = this.hearthActiveTab(tabs);
@@ -86,37 +86,57 @@ export abstract class HearthTabbedModal extends Modal {
 	}
 
 	/**
-	 * Publish the modal's own background colour as `--hearth-modal-surface`, for
-	 * the sticky ribbon to paint itself with.
+	 * Decide whether the tab ribbon may pin itself to the top of the modal, and
+	 * on what colour.
 	 *
-	 * The ribbon has to hide the rows scrolling beneath it, and any hard-coded
-	 * colour is a guess about the theme: with `--background-primary` (the note
-	 * background) the strip showed up as a slab in a different shade to the
-	 * modal on every theme that styles the two differently. Measuring beats
-	 * guessing — a theme can dress its modals through `--modal-background`, a
-	 * rule on `.modal`, or one on `.modal-content`, and all three end up in the
-	 * computed colour of some element between the content and the frame.
+	 * Pinning means rows scroll underneath the ribbon, so a pinned ribbon has to
+	 * be filled with something — and the only fill that can't betray the theme
+	 * is the modal's own surface. Guessing at it went wrong twice over: the note
+	 * background (`--background-primary`) is a colour a theme may reserve for
+	 * notes alone, and even the modal's *declared* colour is wrong when that
+	 * colour is translucent, because painting it a second time over a surface
+	 * already wearing it doubles the tint. Either way the strip showed up as a
+	 * slab in the wrong shade behind the tabs.
 	 *
-	 * Walks content → frame and takes the first background solid enough to cover
-	 * what slides under it; faint tints layered over the frame are skipped so
-	 * the strip doesn't take a 3%-white wash for the whole surface. Nothing
-	 * usable (a gradient, a translucent frame) leaves the property unset, and
-	 * the stylesheet's fallback chain takes over.
+	 * So the ribbon only pins when there is a colour it can match exactly. This
+	 * walks content → frame and takes the first background solid enough to hide
+	 * what slides under it — which catches a theme dressing its modals through
+	 * `--modal-background`, a rule on `.modal` or one on `.modal-content` alike,
+	 * and skips the faint washes layered over a frame, whose colour says nothing
+	 * about what shows through them. Find one and the ribbon pins, painted with
+	 * that exact colour. Find none — a glass modal, a gradient, a translucent
+	 * frame — and it stays unpainted and scrolls away with the content, which
+	 * costs the tabs their pinning but can never leave a slab behind them.
+	 *
+	 * `retry` covers the modal being measured a frame too early: styles resolve
+	 * to nothing until the frame is in the document, and a theme may still be
+	 * transitioning it in. One more look on the next frame settles it, and the
+	 * ribbon is unpinned in the meantime rather than wrongly painted.
 	 */
-	private hearthSyncModalSurface(): void {
+	private hearthSyncModalSurface(retry: boolean): void {
 		const { contentEl } = this;
-		contentEl.style.removeProperty("--hearth-modal-surface");
-		const frame = this.modalEl ?? contentEl;
-		let el: HTMLElement | null = contentEl;
+		const surface = this.hearthMeasureSurface();
+		contentEl.toggleClass("hearth-surface-solid", surface !== null);
+		if (surface === null) contentEl.style.removeProperty("--hearth-modal-surface");
+		else contentEl.style.setProperty("--hearth-modal-surface", surface);
+		if (surface !== null || !retry) return;
+		window.requestAnimationFrame(() => {
+			if (contentEl.isConnected) this.hearthSyncModalSurface(false);
+		});
+	}
+
+	/** The first background between the modal's content and its frame solid
+	 * enough to sit a pinned bar on, or null if the modal wears none. */
+	private hearthMeasureSurface(): string | null {
+		const frame = this.modalEl ?? this.contentEl;
+		let el: HTMLElement | null = this.contentEl;
 		while (el) {
 			const color = window.getComputedStyle(el).backgroundColor;
-			if (isOpaqueSurfaceColor(color)) {
-				contentEl.style.setProperty("--hearth-modal-surface", color);
-				return;
-			}
-			if (el === frame) return;
+			if (isOpaqueSurfaceColor(color)) return color;
+			if (el === frame) return null;
 			el = el.parentElement;
 		}
+		return null;
 	}
 
 	/** Draw the tab ribbon. Clicking a tab persists the choice and rebuilds. */

--- a/styles.css
+++ b/styles.css
@@ -1905,6 +1905,15 @@
    look (.hearth-ribbon-tab): a row of tabs pinned to the top, one group's
    controls shown at a time, and a persistent action footer below. */
 
+/* The ribbon is sticky, so it needs an opaque fill to hide the rows sliding
+   under it — and that fill has to be the modal's own surface, not a guess.
+   --background-primary is the note background, which a theme is free to make
+   nothing like its modals; where the two differ the strip read as a pale slab
+   behind the tabs. --hearth-modal-surface carries the colour the modal
+   is actually painted with, measured at open time (HearthTabbedModal
+   .hearthSyncModalSurface); the var chain behind it covers the cases that
+   measures to nothing — a themed modal falls back to Obsidian's own modal
+   token before the note background. */
 .hearth-modal-ribbon {
 	display: flex;
 	flex-wrap: wrap;
@@ -1914,7 +1923,10 @@
 	z-index: 5;
 	padding-bottom: 10px;
 	margin-bottom: 6px;
-	background: var(--background-primary);
+	background: var(
+		--hearth-modal-surface,
+		var(--modal-background, var(--background-primary))
+	);
 	border-bottom: 1px solid var(--background-modifier-border);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1902,32 +1902,36 @@
 
 /* ---- Tabbed modals: card & dashboard settings -----------------------
    The card- and dashboard-settings modals reuse the settings pane's ribbon
-   look (.hearth-ribbon-tab): a row of tabs pinned to the top, one group's
+   look (.hearth-ribbon-tab): a row of tabs across the top, one group's
    controls shown at a time, and a persistent action footer below. */
 
-/* The ribbon is sticky, so it needs an opaque fill to hide the rows sliding
-   under it — and that fill has to be the modal's own surface, not a guess.
-   --background-primary is the note background, which a theme is free to make
-   nothing like its modals; where the two differ the strip read as a pale slab
-   behind the tabs. --hearth-modal-surface carries the colour the modal
-   is actually painted with, measured at open time (HearthTabbedModal
-   .hearthSyncModalSurface); the var chain behind it covers the cases that
-   measures to nothing — a themed modal falls back to Obsidian's own modal
-   token before the note background. */
+/* The ribbon carries no fill of its own, and scrolls with the body. Pinning it
+   to the top is the nicer behaviour, but a pinned strip has rows passing under
+   it and so must be filled — and every fill that isn't exactly the modal's own
+   surface reads as a slab behind the tabs. Both guesses at that surface were
+   wrong on somebody's theme: --background-primary is the *note* background, and
+   a theme's declared modal colour is itself translucent on a glass modal, where
+   painting it again over a surface already wearing it doubles the tint.
+
+   So pinning is opt-in, granted below only once the modal is measured to wear a
+   colour the strip can match exactly (HearthTabbedModal.hearthSyncModalSurface).
+   Unmeasurable modals — glass, gradient, translucent — keep a ribbon that is
+   merely unpinned, which is a far smaller loss than a slab in the wrong shade. */
 .hearth-modal-ribbon {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 4px;
+	padding-bottom: 10px;
+	margin-bottom: 6px;
+	background: none;
+	border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.hearth-surface-solid .hearth-modal-ribbon {
 	position: sticky;
 	top: 0;
 	z-index: 5;
-	padding-bottom: 10px;
-	margin-bottom: 6px;
-	background: var(
-		--hearth-modal-surface,
-		var(--modal-background, var(--background-primary))
-	);
-	border-bottom: 1px solid var(--background-modifier-border);
+	background: var(--hearth-modal-surface);
 }
 
 /* Give the body a floor so switching from a dense tab (tasks) to a sparse one

--- a/test/modalsurface.test.ts
+++ b/test/modalsurface.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { isOpaqueSurfaceColor } from "../src/tabbedmodal";
+
+/**
+ * The tabbed modals' sticky tab ribbon paints itself with the modal's own
+ * background so it doesn't read as a slab in a different shade on themes that
+ * style modals apart from notes. Which measured colour counts as "the surface"
+ * is the one piece of that with no DOM in it, so it is pinned here.
+ */
+describe("isOpaqueSurfaceColor", () => {
+	it("accepts a solid colour in either computed form", () => {
+		expect(isOpaqueSurfaceColor("rgb(30, 30, 30)")).toBe(true);
+		expect(isOpaqueSurfaceColor("rgb(30 30 30)")).toBe(true);
+		expect(isOpaqueSurfaceColor("rgba(30, 30, 30, 1)")).toBe(true);
+		expect(isOpaqueSurfaceColor("rgb(30 30 30 / 1)")).toBe(true);
+	});
+
+	it("accepts a fill that rounds just short of solid", () => {
+		expect(isOpaqueSurfaceColor("rgba(30, 30, 30, 0.98)")).toBe(true);
+		expect(isOpaqueSurfaceColor("rgb(30 30 30 / 95%)")).toBe(true);
+	});
+
+	it("rejects a translucent frame and the washes themes lay over one", () => {
+		expect(isOpaqueSurfaceColor("rgba(30, 30, 30, 0.7)")).toBe(false);
+		expect(isOpaqueSurfaceColor("rgba(255, 255, 255, 0.03)")).toBe(false);
+		expect(isOpaqueSurfaceColor("rgb(255 255 255 / 3%)")).toBe(false);
+	});
+
+	it("rejects the unpainted element the walk starts on", () => {
+		expect(isOpaqueSurfaceColor("rgba(0, 0, 0, 0)")).toBe(false);
+		expect(isOpaqueSurfaceColor("transparent")).toBe(false);
+		expect(isOpaqueSurfaceColor("")).toBe(false);
+	});
+
+	it("rejects anything it cannot read an alpha out of", () => {
+		expect(isOpaqueSurfaceColor("color(srgb 0.1 0.1 0.1)")).toBe(false);
+		expect(isOpaqueSurfaceColor("rgb(30, 30)")).toBe(false);
+		expect(isOpaqueSurfaceColor("rgba(30, 30, 30, none)")).toBe(false);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the pale rectangle behind the tab buttons in the **Dashboard settings** and **Card settings** dialogs on themes whose modals aren't painted like a note.

Both dialogs pinned their tab strip to the top (`.hearth-modal-ribbon`, `position: sticky`) so the tabs stay reachable while a long tab body scrolls beneath them. A pinned strip has rows passing under it and so must be filled — and it filled itself with `--background-primary`, the *note* background, which plenty of themes reserve for notes alone. Where that differs from the modal, the strip read as a slab in the wrong shade. The tab buttons themselves were never the problem; the container behind them was.

**Pinning is now opt-in, granted only when the strip can match the modal exactly.**

- `HearthTabbedModal.hearthSyncModalSurface()` walks `contentEl → modalEl` and takes the first background solid enough to hide what would slide under it. That catches a theme dressing its modals through `--modal-background`, a rule on `.modal`, or one on `.modal-content` alike. Find one, and the content element gets `.hearth-surface-solid` and the ribbon pins itself, painted with that exact colour.
- Find none — a glass, gradient or translucent modal — and the ribbon stays unfilled and scrolls with the body. That costs the tabs their pinning on those themes, which is a far smaller loss than a rectangle in the wrong shade.
- `isOpaqueSurfaceColor()` decides what counts: it reads both computed forms (`rgba(r, g, b, a)` and `rgb(r g b / a)`) and applies a 0.9 alpha floor, so a fill rounded to 0.98 still qualifies while the faint washes themes lay over a frame are skipped — such a colour on its own says nothing about what shows through it.
- The measurement retries once on the next animation frame, so a modal measured before its frame is in the document (or mid-transition) isn't left unpinned on a theme that would have qualified.

The CSS default is the safe one: with no measurement at all the ribbon is simply unpinned and unpainted, never a mismatched slab.

An earlier commit on this branch tried to keep the pinning and just paint the measured colour, with `--modal-background` as the fallback. That is still wrong on a glass modal, where the modal's own declared colour is translucent: painting it a second time over a surface already wearing it doubles the tint, and the slab stays, in a new wrong shade. The second commit is the fix; the first is kept for the reasoning trail.

## Related issue

None — a self-contained visual fix, reported with screenshots of the Dashboard settings dialog on a glass theme.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

`npm test` (1054 passed, 1 skipped), `npm run typecheck` and `npm run lint` (pre-existing warnings only) are also clean. A new `test/modalsurface.test.ts` pins `isOpaqueSurfaceColor` across both computed colour forms, near-solid fills, translucent frames, unpainted elements and unreadable values; the DOM walk itself is untested, per the repo's no-Obsidian-API-mocks rule. The vault checkbox is left unticked — this ran in a headless session, so the fix has not been seen against a live theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bWST2pJSbAQaBJfZgpBkV
