### PR TITLE
chore: cut 3.0.0-beta.2

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "3.0.0-beta.1",
+	"version": "3.0.0-beta.2",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
## What does this PR do?

Opens the 3.0.0 line's second soak build: `manifest-beta.json` → `3.0.0-beta.2`. `manifest.json` is untouched — stable stays 2.2.0, as it must until this beta has soaked and is promoted.

What beta.2 carries over beta.1:

- **The phone layout** — a board narrower than 600px stacks into one readable column (#205, #262).
- **Half-cell launchpad buttons** — "Fill the card" put its buttons on a grid of whole cells, which took away the half-width and half-height buttons the fixed style's fine grid always allowed. The filled grid is now drawn at half-cell resolution, pixel-identical for every button that doesn't use it (#264).

The `## [3.0.0]` changelog section already describes exactly this build; no changelog change is needed in this commit.

## Related issue

None — release chore.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

Release chore (none of the above).

## Checklist

- [x] `npm run build` passes locally (plus `npm run lint`, the full suite, and `npm run verify:manifests`: "beta 3.0.0-beta.2 is a pre-release ahead of stable and matches on all other fields")
- [ ] I've tested this in an actual vault

Version bump only — no `src/`, `styles.css` or `esbuild.config.mjs` change. The soak in BRAT is what tests it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdQcrGxXBUjsoYBwzJKPPM)_