### PR TITLE
chore: cut 3.0.0-beta.3

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "3.0.0-beta.2",
+	"version": "3.0.0-beta.3",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
## What does this PR do?

Bumps `manifest-beta.json` to **3.0.0-beta.3**, snapshotting `main` for BRAT testers. `manifest.json` is untouched and stays on the stable `2.2.0`, as the two-manifest split requires.

Since `3.0.0-beta.2`, `main` gained one change: the full forecast a weather card opens when it is clicked (ondreu/Hearth#266).

The `3.0.0` changelog section already covers this line and needs no edit — betas are aggregated into their release's entry rather than listed on their own.

`node scripts/verify-manifests.mjs`: *stable 2.2.0 in versions.json; beta 3.0.0-beta.3 is a pre-release ahead of stable and matches on all other fields.*

Once this is on `main`, the release is cut by dispatching `Release Obsidian plugin` with `version: 3.0.0-beta.3` — the workflow mints the tag, runs the guards, and publishes it as a pre-release.

## Related issue

None — release chore.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

Release chore: a one-line version bump, no behaviour change.

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

No vault available in this session; the diff is a single version string in `manifest-beta.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016niJs8EmoRp2bCBsLNeM9r)_