### PR TITLE
feat(sync): pick up settings changes without restarting Obsidian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,23 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   of Obsidian — and a Hearth tab you *replace* by opening a note in it takes its
   place with it, so opening Hearth fresh afterwards still starts at the top.
 
+- **Sync arrives without a restart.** Edit a dashboard on the desktop, walk over
+  to the laptop, and the board you get is the one that machine read when
+  Obsidian started — the synced version only appeared after quitting and
+  reopening the app. Hearth now watches its own settings file and adopts another
+  device's changes as they land, boards, cards and card contents alike.
+
+  It also closes the worse half of that problem. The window holding the stale
+  copy used to write it straight back on its next save, so the edit you made on
+  the other machine could be *undone* by moving a card here. That copy is now
+  brought up to date instead, in place, so what gets saved is the synced state.
+
+  Deliberately careful about it: a file caught half-written by a sync client is
+  ignored rather than acted on, settings identical to the ones already loaded
+  re-render nothing, and a board you are in the middle of arranging is left
+  alone until you are done. Off is available — Settings → Behaviour → **Pick up
+  synced changes** — but on is the honest default.
+
 ### Fixed
 
 - **Frosted glass no longer smears across the gaps between cards.** With the

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,11 @@ export default tseslint.config(
 			// them read repository files (test/cardrequest.test.ts checks the
 			// picker's prefilled issue URL against the real issue-form template).
 			"obsidianmd/no-nodejs-modules": "off",
+			// The rule is right about the plugin: the config folder is read from
+			// Vault#configDir, never assumed. A test of the code that builds a
+			// path *out of* that value has to write a folder name down somewhere,
+			// and test/settingssync.test.ts covers a renamed one explicitly.
+			"obsidianmd/hardcoded-config-path": "off",
 		},
 	},
 );

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1011,6 +1011,11 @@ export const en = {
 				"Keep an open home view current as the vault changes — Recent, Bookmarks " +
 				"and saved-query cards update without reopening the tab. Switching back to " +
 				"the Hearth tab always refreshes it regardless of this setting.",
+			liveSettingsSync: "Pick up synced changes",
+			liveSettingsSyncDesc:
+				"Apply dashboard changes made on another device as soon as sync brings " +
+				"them in, instead of at the next Obsidian restart. Leave this on unless " +
+				"a board reloading mid-session gets in your way.",
 			mobileSearchOnly: "Mobile mode (search only)",
 			mobileSearchOnlyDesc:
 				"On phones and tablets, hide the dashboard and show only the search " +

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -933,6 +933,10 @@ export const zh: Translations = {
 			liveRefreshDesc:
 				"仓库变化时保持已打开的主页视图为最新 — 最近、书签和已保存查询卡片" +
 				"无需重新打开标签页即会更新。无论此设置如何，切回 Hearth 标签页时总会刷新。",
+			liveSettingsSync: "接收同步的更改",
+			liveSettingsSyncDesc:
+				"同步送达其他设备上所做的面板更改后立即应用，而不必等到下次重启 " +
+				"Obsidian。除非面板在使用过程中重新加载会造成困扰，否则请保持开启。",
 			mobileSearchOnly: "移动模式（仅搜索）",
 			mobileSearchOnlyDesc:
 				"在手机和平板上隐藏面板，仅显示搜索框。对桌面端无影响。",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { addIcon, debounce, Platform, Plugin, setIcon, WorkspaceLeaf, Notice } from "obsidian";
 import { HomeView, VIEW_TYPE_HOME } from "./view";
-import { DEFAULT_SETTINGS, fillMissingDefaults, HomeSettings, migrateSettings, timersAllowed } from "./types";
+import { HomeSettings, hydrateSettings, timersAllowed } from "./types";
 import { HomeSettingTab } from "./settings";
 import {
 	HEARTH_ICON_ID,
@@ -18,6 +18,13 @@ import { maybeRunSetup, openSetupWizard } from "./onboarding";
 import { clearContentSearchCache } from "./query";
 import { recordRecentFile, renameRecentFile } from "./recentfiles";
 import { forgetTaxonomy, OperonSession } from "./operon";
+import {
+	adoptSettings,
+	isPluginDataPath,
+	looksLikeSavedSettings,
+	pluginDataPath,
+	sameSettings,
+} from "./settingssync";
 
 /** Core "Audio recorder" plugin id, used by the "Record voice" mobile action. */
 const AUDIO_RECORDER_PLUGIN_ID = "audio-recorder";
@@ -67,6 +74,19 @@ export default class HearthPlugin extends Plugin {
 	 * resetTimer=true so a burst of writes (a sync, a bulk edit) coalesces into a
 	 * single re-render ~600ms after the last change. */
 	private liveRefreshDebounced = debounce(() => this.runLiveRefresh(), 600, true);
+
+	/** Vault-relative path of Hearth's own `data.json`, resolved once at load. */
+	private dataPath = "";
+
+	/** The exact text last written to (or read from) `data.json`, so a change on
+	 * disk can be dismissed with a string compare before anything is parsed. */
+	private lastSeenSettingsJson: string | null = null;
+
+	/** Debounced adoption of settings written by something other than this
+	 * window. resetTimer=true so a sync landing a config folder file by file
+	 * settles into one check, and so a check deferred while a board is being
+	 * arranged re-arms itself rather than stacking up. */
+	private externalSettingsDebounced = debounce(() => void this.adoptExternalSettings(), 400, true);
 
 	async onload() {
 		// Pick the locale from Obsidian's UI language before anything renders or
@@ -156,6 +176,18 @@ export default class HearthPlugin extends Plugin {
 		this.registerEvent(this.app.vault.on("rename", onVaultChange));
 		this.registerEvent(this.app.vault.on("modify", onVaultChange));
 
+		// Settings another device synced in. `data.json` lives in the config
+		// folder, which the create/modify/delete events above never report — they
+		// only cover vault files. The adapter's `raw` event does cover it, and is
+		// how a config file changing underneath Obsidian is noticed at all (the
+		// same event core Obsidian uses to pick up an edited CSS snippet).
+		this.dataPath = pluginDataPath(this.app.vault.configDir, this.manifest);
+		this.registerEvent(
+			this.app.vault.on("raw", (path) => {
+				if (isPluginDataPath(this.dataPath, path)) this.externalSettingsDebounced();
+			}),
+		);
+
 		// Hearth's own recent-file history (#228). Obsidian's getLastOpenFiles()
 		// stops at ten entries, so a Recent files card asking for more has to be
 		// told about opens as they happen; a rename is followed so a moved file
@@ -178,7 +210,7 @@ export default class HearthPlugin extends Plugin {
 		);
 
 		this.app.workspace.onLayoutReady(() => {
-			this.applyMobileDefaultDashboard();
+			if (this.applyMobileDefaultDashboard()) this.refreshViews();
 			if (this.settings.openOnStartup) void this.activateView();
 			// Pop the release-notes dialog after an update (but not on a fresh
 			// install). Runs once layout is ready so it doesn't fight startup.
@@ -190,6 +222,10 @@ export default class HearthPlugin extends Plugin {
 	}
 
 	onunload() {
+		// Debounced work outlives the events that scheduled it, and an unloaded
+		// plugin has no business re-rendering views or reading its own data file.
+		this.liveRefreshDebounced.cancel();
+		this.externalSettingsDebounced.cancel();
 		// Views are detached automatically by Obsidian on plugin unload.
 		// The content-search cache holds lower-cased note bodies, though, so
 		// drop it rather than leave a copy of the vault behind after unload.
@@ -227,14 +263,14 @@ export default class HearthPlugin extends Plugin {
 	 * a phone/tablet opens on the board tuned for a small screen (#120). Applied
 	 * in memory only, without saving: `activeDashboardId` is a single field shared
 	 * with desktop through synced settings, so persisting the mobile choice would
-	 * drag the desktop's active board along with it on the next sync. Any already
-	 * open home view is re-rendered to reflect the switch. */
-	private applyMobileDefaultDashboard() {
-		if (!Platform.isMobile) return;
+	 * drag the desktop's active board along with it on the next sync. Returns
+	 * true when the board changed, so the caller can re-render open home views. */
+	private applyMobileDefaultDashboard(): boolean {
+		if (!Platform.isMobile) return false;
 		const mobile = this.settings.dashboards.find((d) => d.mobileDefault);
-		if (!mobile || this.settings.activeDashboardId === mobile.id) return;
+		if (!mobile || this.settings.activeDashboardId === mobile.id) return false;
 		this.settings.activeDashboardId = mobile.id;
-		this.refreshViews();
+		return true;
 	}
 
 	/** Switch the active dashboard and refresh any open home views. */
@@ -375,19 +411,28 @@ export default class HearthPlugin extends Plugin {
 		// that merely lacks a newly-added field (like lastSeenVersion) still has
 		// its other settings here, so it is correctly treated as an upgrade.
 		this.isFirstRun = Object.keys(raw).length === 0;
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, raw);
-		// Backfill nested config defaults too, not just top-level keys, so an
-		// object persisted by an older version isn't missing a nested field.
-		fillMissingDefaults(
-			this.settings as unknown as Record<string, unknown>,
-			DEFAULT_SETTINGS as unknown as Record<string, unknown>,
-		);
-		// A one-way migration (e.g. the commandId → target fold) mutates settings
-		// in memory only; without flushing it here the legacy data would survive
-		// in storage and the migration would re-run every start, never actually
-		// retiring the deprecated field. Persist immediately when that happens.
-		const migrated = migrateSettings(this.settings, raw);
+		// Defaults (top-level and nested) plus the one-way migrations. A one-way
+		// migration (e.g. the commandId → target fold) mutates settings in memory
+		// only; without flushing it here the legacy data would survive in storage
+		// and the migration would re-run every start, never actually retiring the
+		// deprecated field. Persist immediately when that happens.
+		const { settings, migrated } = hydrateSettings(raw);
+		this.settings = settings;
 		if (migrated) await this.saveSettings();
+	}
+
+	/**
+	 * Every write to `data.json` goes through here, so this is where the copy of
+	 * it the sync watcher compares against is refreshed.
+	 *
+	 * Purely an optimisation: it lets a write this window just made be recognised
+	 * by a string compare instead of a parse and a full settings comparison.
+	 * Obsidian's exact serialisation isn't ours to depend on, so a mismatch
+	 * simply falls through to that comparison, which reaches the same answer.
+	 */
+	override async saveData(data: unknown): Promise<void> {
+		await super.saveData(data);
+		this.lastSeenSettingsJson = JSON.stringify(data, null, 2);
 	}
 
 	async saveSettings() {
@@ -438,12 +483,91 @@ export default class HearthPlugin extends Plugin {
 		if (!leaf) return;
 		const view = leaf.view;
 		if (!(view instanceof HomeView)) return;
+		// Belt and braces for the sync watcher: the `raw` event is what normally
+		// reports another device's settings landing, but a sync client Obsidian
+		// doesn't see the write from would leave the board stale until a restart —
+		// exactly the thing being fixed. Looking at the file when a Hearth tab is
+		// focused costs a string compare in the ordinary case, and means the board
+		// is current by the time it is looked at.
+		this.externalSettingsDebounced();
 		if (!this.seenActiveHomeLeaves.has(leaf)) {
 			this.seenActiveHomeLeaves.add(leaf);
 			return;
 		}
 		if (view.arrangeMode) return;
 		view.render();
+	}
+
+	/**
+	 * Adopt settings written to `data.json` by something other than this window.
+	 *
+	 * The whole point of the exercise (see `src/settingssync.ts`): a dashboard
+	 * edited on another machine arrives through sync while this one is still
+	 * holding the settings it read at startup, and until now the only way to see
+	 * it was to restart Obsidian. Worse, the first thing this window saved put
+	 * its stale copy back over the synced one.
+	 *
+	 * Deliberately conservative — it does nothing at all unless the file really
+	 * does hold a different configuration:
+	 *
+	 * - a half-written file (a sync client mid-write) fails to parse and is
+	 *   ignored; the write that completes it fires another event
+	 * - a file that doesn't carry boards is ignored, so a truncated one can never
+	 *   be hydrated into a fresh starter dashboard over the user's own
+	 * - settings identical to the ones in memory — every write this window makes
+	 *   — change nothing and re-render nothing
+	 * - a board being arranged is left alone, and the check re-arms until the
+	 *   drag is done, so a sync can't yank the grid out from under a card
+	 *
+	 * The adopted state isn't written back: it is already what is on disk, and
+	 * this window writing it again is one more chance to race the next device.
+	 * Any later save persists it in the ordinary way.
+	 */
+	private async adoptExternalSettings(): Promise<void> {
+		if (!this.settings.liveSettingsSync) return;
+		if (this.anyHomeViewArranging()) {
+			this.externalSettingsDebounced();
+			return;
+		}
+
+		let text: string;
+		try {
+			text = await this.app.vault.adapter.read(this.dataPath);
+		} catch {
+			return;
+		}
+		// Byte-identical to what this window last wrote or read: nothing to do,
+		// and nothing to parse.
+		if (text === this.lastSeenSettingsJson) return;
+		this.lastSeenSettingsJson = text;
+
+		let raw: unknown;
+		try {
+			raw = JSON.parse(text);
+		} catch {
+			// Caught mid-write. Forget the text so the completed write, which may
+			// well be a different length, is still examined.
+			this.lastSeenSettingsJson = null;
+			return;
+		}
+		if (!looksLikeSavedSettings(raw)) return;
+
+		const { settings: next } = hydrateSettings(raw);
+		if (sameSettings(this.settings, next)) return;
+
+		adoptSettings(this.settings, next);
+		// activeDashboardId is one field shared with every other device, so a
+		// synced board choice would otherwise drag a phone off its mobile board.
+		this.applyMobileDefaultDashboard();
+		this.refreshBrandIcons();
+		this.refreshViews();
+	}
+
+	/** Whether any open home view is mid-arrange, and so must not be rebuilt. */
+	private anyHomeViewArranging(): boolean {
+		return this.app.workspace
+			.getLeavesOfType(VIEW_TYPE_HOME)
+			.some((leaf) => leaf.view instanceof HomeView && leaf.view.arrangeMode);
 	}
 
 	/** Live-refresh handler behind {@link liveRefreshDebounced}. No-op unless the

--- a/src/obsidian-ext.d.ts
+++ b/src/obsidian-ext.d.ts
@@ -61,6 +61,21 @@ declare module "obsidian" {
 		on(name: "obsidian-git:loading-status", callback: () => unknown, ctx?: unknown): EventRef;
 	}
 
+	/**
+	 * The adapter-level file event. `Vault.on` declares one overload per public
+	 * event (create/modify/delete/rename), which hides the inherited
+	 * `on(name: string, …)` — so listening to `raw` needs its own overload.
+	 *
+	 * Unlike the public events, `raw` reports every path the adapter sees change,
+	 * the config folder included. That makes it the only way to notice Hearth's
+	 * own `data.json` being rewritten by sync (see `src/settingssync.ts`). It's
+	 * an internal, but a long-standing one: it is how core Obsidian picks up an
+	 * edited CSS snippet, and community plugins have listened to it for years.
+	 */
+	interface Vault {
+		on(name: "raw", callback: (path: string) => unknown, ctx?: unknown): EventRef;
+	}
+
 	/** WorkspaceLeaf's constructor isn't part of the public typings, but a
 	 * detached leaf (`new WorkspaceLeaf(app)`) is the documented-by-practice way
 	 * community plugins host a view outside the workspace layout. */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1292,6 +1292,16 @@ export class HomeSettingTab extends PluginSettingTab {
 					this.save();
 				}),
 			);
+
+		new Setting(containerEl)
+			.setName(t().settings.behaviour.liveSettingsSync)
+			.setDesc(t().settings.behaviour.liveSettingsSyncDesc)
+			.addToggle((tg) =>
+				tg.setValue(s.liveSettingsSync).onChange(async (v) => {
+					s.liveSettingsSync = v;
+					this.save();
+				}),
+			);
 	}
 
 	// ---- Opening notes ---------------------------------------------------

--- a/src/settingssync.ts
+++ b/src/settingssync.ts
@@ -1,0 +1,95 @@
+import { normalizePath } from "obsidian";
+import type { HomeSettings } from "./types";
+
+/**
+ * Picking up settings another device wrote.
+ *
+ * Hearth keeps everything — dashboards, cards, card contents — in the plugin's
+ * own `data.json`, and reads it exactly once, at load. That is fine on one
+ * machine, where this window is the only writer. It is not fine with sync: a
+ * board edited on the desktop lands on the laptop's disk while the laptop is
+ * still holding the copy it read at startup, so the change is invisible until
+ * Obsidian is restarted — and worse, the next thing the laptop saves writes its
+ * stale copy straight back over the synced one.
+ *
+ * The fix is to notice the file changing underneath us and adopt it. The pieces
+ * here are the parts of that worth testing on their own; the wiring — the
+ * `raw` vault event, the debounce, the re-render — lives in `main.ts`.
+ */
+
+/** Vault-relative path of the plugin's own `data.json`. `manifest.dir` is what
+ * Obsidian itself loads from (it accounts for a vault with a non-default config
+ * folder); the fallback only matters if that ever comes back empty. */
+export function pluginDataPath(configDir: string, manifest: { id: string; dir?: string }): string {
+	const dir = manifest.dir || `${configDir}/plugins/${manifest.id}`;
+	return normalizePath(`${dir}/data.json`);
+}
+
+/** Whether a path reported by a vault event is that `data.json`. Compared
+ * case-insensitively: the event carries the path as the filesystem spelled it,
+ * and Windows and macOS are both happy to spell it differently. */
+export function isPluginDataPath(dataPath: string, changed: string): boolean {
+	return normalizePath(changed).toLowerCase() === dataPath.toLowerCase();
+}
+
+/**
+ * Whether parsed JSON looks like a settings file Hearth actually saved, rather
+ * than something it must not act on.
+ *
+ * This is the guard against the dangerous case. A sync client writes a file
+ * before it is complete, and a truncated or empty `data.json` parses perfectly
+ * well as `{}` — which the migration would then hydrate into a brand-new
+ * starter dashboard, silently replacing the user's boards in memory and, on the
+ * next save, on disk. So nothing is adopted unless the file carries boards
+ * (or the pre-3.0 single-board `cards` array a very old peer might still send).
+ */
+export function looksLikeSavedSettings(raw: unknown): raw is Record<string, unknown> {
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return false;
+	const o = raw as Record<string, unknown>;
+	const dashboards = o.dashboards;
+	if (Array.isArray(dashboards) && dashboards.length > 0) return true;
+	return Array.isArray(o.cards);
+}
+
+/** Key-order-independent serialisation, so settings that differ only in the
+ * order two versions of Hearth happened to write their keys don't read as a
+ * change. Only the shapes `data.json` can hold — JSON — are handled. */
+function stableJson(value: unknown): string {
+	if (value === undefined) return "null";
+	if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+	if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+	const o = value as Record<string, unknown>;
+	const body = Object.keys(o)
+		.sort()
+		.filter((k) => o[k] !== undefined)
+		.map((k) => `${JSON.stringify(k)}:${stableJson(o[k])}`)
+		.join(",");
+	return `{${body}}`;
+}
+
+/** Whether two settings objects are the same configuration. Used to tell a
+ * write this window just made (identical, ignore it) from another device's
+ * (different, adopt it). */
+export function sameSettings(a: HomeSettings, b: HomeSettings): boolean {
+	return stableJson(a) === stableJson(b);
+}
+
+/**
+ * Take on `next`'s values **in place**, so every reference already handed out
+ * stays live.
+ *
+ * Cards, the settings tab and the dashboard editor all capture
+ * `plugin.settings` and hold it for as long as they exist; replacing the object
+ * would leave every one of them writing into a copy nothing reads — and the
+ * first such write would put the stale copy back on disk. Mutating the object
+ * they already hold means the adoption reaches them all, and their next save
+ * persists the synced state rather than fighting it.
+ */
+export function adoptSettings(current: HomeSettings, next: HomeSettings): void {
+	const c = current as unknown as Record<string, unknown>;
+	const n = next as unknown as Record<string, unknown>;
+	// Keys the incoming settings no longer carry (a field a migration retired)
+	// have to go, or they would outlive it here and be written back.
+	for (const key of Object.keys(c)) if (!(key in n)) delete c[key];
+	Object.assign(c, n);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2068,6 +2068,13 @@ export interface HomeSettings {
 	 * board is being arranged. Off by default; a home view already refreshes
 	 * whenever the user switches back to its tab regardless of this setting. */
 	liveRefresh: boolean;
+	/** Adopt settings written to Hearth's `data.json` by something other than
+	 * this window — Obsidian Sync landing another device's dashboards, a git
+	 * pull, an external editor — as they arrive, instead of only at the next
+	 * Obsidian restart. On by default: without it this window keeps showing the
+	 * copy it read at startup and writes that stale copy back on its next save.
+	 * See `src/settingssync.ts`. */
+	liveSettingsSync: boolean;
 	/** On mobile, show only the search field and hide the dashboard. Has no
 	 * effect on desktop, where the full dashboard is always shown. */
 	mobileSearchOnly: boolean;
@@ -2300,6 +2307,7 @@ export const DEFAULT_SETTINGS: HomeSettings = {
 	replaceNewTabs: true,
 	focusSearchOnOpen: false,
 	liveRefresh: false,
+	liveSettingsSync: true,
 	mobileSearchOnly: false,
 	showMobileActionBar: true,
 	// Backfilled by migrateSettings so a fresh install gets the defaults below
@@ -2900,6 +2908,30 @@ export function effectiveBackground(s: HomeSettings): ResolvedBackground {
 export function bannerActive(s: HomeSettings): boolean {
 	const bg = effectiveBackground(s);
 	return bg.layout === "banner" && bg.kind !== "none";
+}
+
+/**
+ * Turn the raw contents of `data.json` into usable settings: defaults for
+ * everything it doesn't carry (top-level and nested), then the one-way
+ * migrations.
+ *
+ * Shared by the load at startup and by the adoption of settings another device
+ * synced in (`src/settingssync.ts`), so a board arriving mid-session is
+ * hydrated exactly the way a restart would have hydrated it.
+ *
+ * `migrated` is true when a destructive migration ran and its result therefore
+ * needs flushing back to storage — see {@link migrateSettings}.
+ */
+export function hydrateSettings(raw: Record<string, unknown>): {
+	settings: HomeSettings;
+	migrated: boolean;
+} {
+	const settings = Object.assign({}, DEFAULT_SETTINGS, raw) as HomeSettings;
+	fillMissingDefaults(
+		settings as unknown as Record<string, unknown>,
+		DEFAULT_SETTINGS as unknown as Record<string, unknown>,
+	);
+	return { settings, migrated: migrateSettings(settings, raw) };
 }
 
 /**

--- a/test/settingssync.test.ts
+++ b/test/settingssync.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+	adoptSettings,
+	isPluginDataPath,
+	looksLikeSavedSettings,
+	pluginDataPath,
+	sameSettings,
+} from "../src/settingssync";
+import { DEFAULT_SETTINGS, HomeSettings } from "../src/types";
+
+/**
+ * Picking up settings another device synced in.
+ *
+ * These cover the decisions the watcher makes before it touches anything: which
+ * file it is looking at, whether what it read is safe to act on, whether it is
+ * actually different from what is already loaded, and what adopting it does to
+ * the settings object every card is holding. The wiring around them — the vault
+ * event, the debounce, the re-render — is Obsidian API and stays untested, per
+ * the no-mocks rule.
+ */
+
+const manifest = { id: "hearth", dir: ".obsidian/plugins/hearth" };
+
+/** Settings as they would be after loading, with one recognisable board. */
+function settings(name = "Work"): HomeSettings {
+	const s: HomeSettings = structuredClone(DEFAULT_SETTINGS);
+	s.dashboards = [{ id: "d1", name, cards: [] }];
+	s.activeDashboardId = "d1";
+	return s;
+}
+
+describe("pluginDataPath", () => {
+	it("uses the directory Obsidian actually loaded the plugin from", () => {
+		expect(pluginDataPath(".obsidian", manifest)).toBe(".obsidian/plugins/hearth/data.json");
+	});
+
+	it("follows a vault with a renamed config folder", () => {
+		expect(pluginDataPath(".config", { id: "hearth", dir: ".config/plugins/hearth" })).toBe(
+			".config/plugins/hearth/data.json",
+		);
+	});
+
+	it("falls back to the conventional location when the manifest has no dir", () => {
+		expect(pluginDataPath(".obsidian", { id: "hearth" })).toBe(
+			".obsidian/plugins/hearth/data.json",
+		);
+	});
+});
+
+describe("isPluginDataPath", () => {
+	const path = pluginDataPath(".obsidian", manifest);
+
+	it("recognises its own data file", () => {
+		expect(isPluginDataPath(path, ".obsidian/plugins/hearth/data.json")).toBe(true);
+	});
+
+	it("ignores every other file the vault reports", () => {
+		expect(isPluginDataPath(path, ".obsidian/plugins/dataview/data.json")).toBe(false);
+		expect(isPluginDataPath(path, ".obsidian/workspace.json")).toBe(false);
+		expect(isPluginDataPath(path, "notes/data.json")).toBe(false);
+		expect(isPluginDataPath(path, ".obsidian/plugins/hearth/main.js")).toBe(false);
+	});
+
+	it("matches however the filesystem spelled the path", () => {
+		// Windows separators, and the case-insensitive volumes on Windows and
+		// macOS — the event carries the path as the OS reported it.
+		expect(isPluginDataPath(path, ".obsidian\\plugins\\hearth\\data.json")).toBe(true);
+		expect(isPluginDataPath(path, ".Obsidian/Plugins/Hearth/data.json")).toBe(true);
+	});
+});
+
+describe("looksLikeSavedSettings", () => {
+	it("accepts a file carrying boards", () => {
+		expect(looksLikeSavedSettings({ dashboards: [{ id: "d1", name: "Home", cards: [] }] })).toBe(
+			true,
+		);
+	});
+
+	it("accepts a pre-3.0 single-board file", () => {
+		expect(looksLikeSavedSettings({ cards: [] })).toBe(true);
+	});
+
+	it("refuses a file with no boards in it", () => {
+		// The dangerous case: a sync client writing the file, caught before it is
+		// complete. `{}` parses fine and would hydrate into a brand-new starter
+		// dashboard — replacing the user's boards in memory, and on disk at the
+		// next save.
+		expect(looksLikeSavedSettings({})).toBe(false);
+		expect(looksLikeSavedSettings({ dashboards: [] })).toBe(false);
+		expect(looksLikeSavedSettings({ liveRefresh: true })).toBe(false);
+	});
+
+	it("refuses anything that isn't a settings object", () => {
+		expect(looksLikeSavedSettings(null)).toBe(false);
+		expect(looksLikeSavedSettings("{}")).toBe(false);
+		expect(looksLikeSavedSettings([])).toBe(false);
+		expect(looksLikeSavedSettings(42)).toBe(false);
+	});
+});
+
+describe("sameSettings", () => {
+	it("reads identical settings as unchanged", () => {
+		expect(sameSettings(settings(), settings())).toBe(true);
+	});
+
+	it("ignores the order two versions happened to write their keys in", () => {
+		const a = settings();
+		// Same configuration, rebuilt with the keys in reverse — what a peer
+		// running a different Hearth version can easily send.
+		const reversed = Object.fromEntries(
+			Object.entries(a as unknown as Record<string, unknown>).reverse(),
+		) as unknown as HomeSettings;
+		expect(sameSettings(a, reversed)).toBe(true);
+	});
+
+	it("sees a board renamed on another device", () => {
+		expect(sameSettings(settings("Work"), settings("Home"))).toBe(false);
+	});
+
+	it("sees a card added, and does not confuse it with a reorder", () => {
+		const a = settings();
+		const b = settings();
+		b.dashboards[0].cards = [{ id: "c1", kind: "clock" as const, x: 0, y: 0, w: 2, h: 2 }];
+		expect(sameSettings(a, b)).toBe(false);
+
+		const first = settings();
+		first.dashboards[0].cards = [
+			{ id: "c1", kind: "clock" as const, x: 0, y: 0, w: 2, h: 2 },
+			{ id: "c2", kind: "search" as const, x: 2, y: 0, w: 2, h: 2 },
+		];
+		const swapped = settings();
+		swapped.dashboards[0].cards = [...first.dashboards[0].cards].reverse();
+		expect(sameSettings(first, swapped)).toBe(false);
+	});
+
+	it("treats a key set to undefined as absent, the way JSON does", () => {
+		const a = settings();
+		const b = settings() as unknown as Record<string, unknown>;
+		b.somethingUnset = undefined;
+		expect(sameSettings(a, b as unknown as HomeSettings)).toBe(true);
+	});
+});
+
+describe("adoptSettings", () => {
+	it("updates the object every card is already holding", () => {
+		const current = settings("Work");
+		const held = current;
+		adoptSettings(current, settings("Home"));
+		// Same object, new contents: a card that captured `plugin.settings` sees
+		// the synced board, and its next save writes that rather than the stale one.
+		expect(held).toBe(current);
+		expect(held.dashboards[0].name).toBe("Home");
+	});
+
+	it("takes on values the incoming settings changed", () => {
+		const current = settings();
+		const next = settings();
+		next.liveRefresh = !current.liveRefresh;
+		next.rowHeight = 120;
+		adoptSettings(current, next);
+		expect(current.liveRefresh).toBe(next.liveRefresh);
+		expect(current.rowHeight).toBe(120);
+	});
+
+	it("drops a field the incoming settings no longer carry", () => {
+		// A field retired by a migration must not survive here, or this window
+		// would write it straight back.
+		const current = settings() as unknown as Record<string, unknown>;
+		current.legacyField = "gone";
+		adoptSettings(current as unknown as HomeSettings, settings());
+		expect("legacyField" in current).toBe(false);
+	});
+
+	it("leaves the two objects independent afterwards", () => {
+		const current = settings();
+		const next = settings("Home");
+		adoptSettings(current, next);
+		expect(sameSettings(current, next)).toBe(true);
+	});
+});

--- a/test/support/obsidian-shim.ts
+++ b/test/support/obsidian-shim.ts
@@ -74,6 +74,17 @@ export class Keymap {
 export class SliderComponent {}
 export class TextComponent {}
 
+// Real behaviour, not a placeholder: this is a pure string function (collapse
+// separators, trim the ends, NFC), and the sync watcher's path matching is
+// tested against it rather than against a guess at what it does.
+export function normalizePath(path: string): string {
+	const cleaned = path
+		.replace(/([\\/])+/g, "/")
+		.replace(/(^\/+|\/+$)/g, "")
+		.normalize("NFC");
+	return cleaned === "" ? "/" : cleaned;
+}
+
 export function setIcon(): void {}
 export function addIcon(): void {}
 // lucide.ts imports this for its icon-registry lookup (fileicons.ts and the


### PR DESCRIPTION
## What does this PR do?

Hearth reads its `data.json` exactly once, in `onload()`, and holds that object for the session. With sync that causes two problems on the second machine:

1. **The change is invisible.** Sync lands the new `data.json` on disk; the in-memory copy is untouched. Nothing short of restarting Obsidian re-reads it — the reported symptom (open Obsidian, let it sync, restart Obsidian to see the board).
2. **The worse half.** The window holding the stale copy writes it straight back on its next save — moving a card, editing a text card, switching board. An edit made on the other machine can be silently *undone* by touching the board here.

This watches the settings file and adopts another device's changes as they land: boards, cards and card contents alike.

**Detection.** `data.json` lives in the config folder, which the `create`/`modify`/`delete` vault events never report — they only cover vault files. The adapter's `raw` event does cover it (the same event core Obsidian uses to pick up an edited CSS snippet); typed in `obsidian-ext.d.ts` alongside the other internals, debounced 400 ms. Plus a fallback check whenever a Hearth tab is focused, for a sync client whose write Obsidian never reports — that costs a string compare in the ordinary case.

**Adoption is in place.** Values are copied *onto* the existing settings object rather than replacing it. Every card, editor and settings row captured `plugin.settings` and holds it; replacing the object would leave them all writing into a copy nothing reads — which is problem 2 again in a new shape. Mutating what they already hold means the adoption reaches them, and their next save persists the synced state rather than fighting it.

**Guards**, because the failure modes here are destructive:

- A file caught half-written by a sync client fails to parse and is ignored; the write that completes it fires another event.
- **A file carrying no boards is refused outright.** This is the one that matters most: a truncated `data.json` parses perfectly well as `{}`, and `migrateSettings` would hydrate that into a brand-new starter dashboard — replacing the user's boards in memory and, at the next save, on disk.
- Settings identical to the ones in memory change nothing and re-render nothing, so every write this window makes is a no-op.
- A board mid-arrange is left alone, and the check re-arms until the drag is done.
- The adopted state is not written back — it is already what is on disk, and writing it again is one more chance to race the next device.

`loadSettings` and the watcher now share one `hydrateSettings()`, so a board arriving mid-session is hydrated exactly the way a restart would have hydrated it.

Off switch: Settings → Behaviour → **Pick up synced changes**, on by default (`liveSettingsSync`). Strings added to `en` and `zh`.

Two caveats, inherent rather than oversights: if the Hearth settings pane is open when a change lands its rendered controls stay stale until reopened (re-rendering it under the user's fingers seemed worse); and two devices editing while both run is still last-writer-wins at the file level — this closes the restart gap, not the general merge problem.

## Related issue

None — reported directly.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault

`npm run build`, `npm test` (1253 passing) and `npm run lint` (0 errors; the 7 warnings are pre-existing) all pass on this branch, rebased onto `3c3c3eb`. 19 new tests in `test/settingssync.test.ts` cover the path matching, the "is this safe to act on" guard, the key-order-independent comparison and the in-place adoption. The vault event, the debounce and the re-render are Obsidian API and stay untested, per the no-mocks rule — **so the one thing left is a real two-machine vault**, which I can't run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYaQqfHMN9GwcBGUbMPtHK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYaQqfHMN9GwcBGUbMPtHK)_