### PR TITLE
Bump version to 3.1.0-beta.3

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "3.1.0-beta.1",
+	"version": "3.1.0-beta.3",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
## What does this PR do?

Updates the plugin version from `3.1.0-beta.1` to `3.1.0-beta.3` in the manifest.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault

https://claude.ai/code/session_014e3dJwtaEAC3ggqJGaF1wY