### PR TITLE
fix(privacy): cover a URL background and title icon with "Disable external calls" (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,6 +308,23 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **"Disable external calls" now also covers a background image and a title icon
+  given as a web address.** The switch promises to block every outbound request
+  Hearth makes, and every card kept that promise — but a wallpaper whose kind is
+  "Image URL", the bundled default wallpaper (which is served from GitHub rather
+  than from the plugin folder), and a title icon pointed at an `https://` address
+  were all set straight onto the page and fetched regardless. That was a footnote
+  while those strings were ones you typed yourself; with boards now shared and
+  installed from a gallery they are strings a stranger chose, and a board can be
+  authored so that merely opening it reports your IP to a host of the author's
+  choosing. All three are now blocked while the switch is on, and a blocked
+  wallpaper falls back to no picture — a bannered board loses the strip rather
+  than reserving an empty one — while a blocked icon falls back to the Hearth
+  crystal. Nothing is rewritten: turn the switch off and the wallpaper and the
+  icon come back. **If you have deliberately set a URL wallpaper or icon and have
+  the switch on, that picture will disappear on upgrade** — either point it at a
+  vault attachment, or turn the switch off.
+
 - **A full settings backup no longer forgets eleven settings.** Export every
   Hearth setting, restore it into a fresh vault, and eleven of them came back at
   their defaults instead of yours: the theme-colour target, the mobile

--- a/README.md
+++ b/README.md
@@ -238,8 +238,9 @@ from you.
 
 Everything is **live**: embeds and editable notes follow vault events without
 losing your cursor, data cards redraw on vault and metadata changes, and web
-cards refresh on a timer. Every card that reaches the network respects
-**Settings → Behaviour → Disable external calls**.
+cards refresh on a timer. Everything that reaches the network respects
+**Settings → Behaviour → Disable external calls** — every card, and a background
+image or title icon given as a web address.
 
 ## Integrations
 
@@ -288,6 +289,7 @@ network → Disable external calls**.
 | RSS / Atom feeds | RSS cards | None |
 | ICS / webcal feeds | Mini calendar subscriptions (Google, iCloud, Fastmail, Nextcloud…) | The feed URL |
 | DuckDuckGo | The search bar's optional web-search button | None |
+| Whatever host you name | A background image or title icon given as a web address; the bundled default wallpaper is one of these, served from `raw.githubusercontent.com` | None |
 
 ### Operon
 

--- a/docs/dashboard-package.md
+++ b/docs/dashboard-package.md
@@ -434,11 +434,13 @@ and `residualPaths()` could not recognise it either.
 A board can name things on the web — an embedded page, an RSS feed, a wallpaper
 given as a URL. Those are `publicUrl` and travel by design, because they are
 what the board *is*. But a board opened from a stranger will fetch them, and
-Hearth's **Disable external calls** setting does not currently cover a
-background image or a title icon given by URL (it covers live-content cards and
-the currency fetch — see its own documentation). Hearth's import dialog says how
-many remote things a package loads; a gallery should surface the same, and may
-want to strip or proxy `publicUrl` itself.
+what stops that is the reader's own **Disable external calls** setting: since
+#281 it covers a background image and a title icon given by URL as well as the
+live-content cards and the currency fetch, so a beacon wallpaper on an imported
+board is not fetched by a vault that has the switch on. With the switch off — the
+default — every `publicUrl` on the board is still fetched the moment it opens.
+Hearth's import dialog says how many remote things a package loads; a gallery
+should surface the same, and may want to strip or proxy `publicUrl` itself.
 
 ### The upload pipeline
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -9,6 +9,7 @@ import {
 import type { HomeView } from "./view";
 import {
 	type BackgroundConfig,
+	backgroundPaintable,
 	effectiveBackground,
 	effectiveFullWidth,
 	effectiveMaxWidth,
@@ -44,7 +45,9 @@ export function applyBackground(
 	component: Component,
 ): void {
 	const bg = effectiveBackground(view.plugin.settings);
-	if (!paintable(bg)) return;
+	// Nothing to paint: no background, a kind with no value, or a picture from
+	// the web that "Disable external calls" won't let Hearth fetch (#281).
+	if (!backgroundPaintable(bg, view.plugin.settings.disableExternalCalls)) return;
 
 	paintBackground(view, root.createDiv("hearth-bg"), bg, component);
 }
@@ -69,7 +72,7 @@ export function renderBanner(
 ): HTMLElement | null {
 	const bg = effectiveBackground(view.plugin.settings);
 	if (bg.layout !== "banner") return null;
-	if (!paintable(bg)) return null;
+	if (!backgroundPaintable(bg, view.plugin.settings.disableExternalCalls)) return null;
 
 	const banner = parent.createDiv("hearth-banner");
 	banner.style.height = `${bg.bannerHeight}px`;
@@ -90,13 +93,6 @@ export function renderBanner(
 
 	paintBackground(view, layer, bg, component);
 	return banner;
-}
-
-/** Whether a background config has anything to paint. "default" ships its own
- * image so it needs no value; every other kind but "none" needs one. */
-function paintable(bg: BackgroundConfig): boolean {
-	if (bg.kind === "none") return false;
-	return bg.kind === "default" || !!bg.value;
 }
 
 /**
@@ -124,11 +120,17 @@ function paintBackground(
 		return;
 	}
 
+	// A picture from the web is an outbound request whoever it was configured by,
+	// so "Disable external calls" blocks both remote kinds — the bundled default
+	// included, which is served from GitHub rather than from the plugin folder.
+	// `paintable` normally means we are never called for one; this is the check
+	// at the point the request would actually be made.
+	const blocked = view.plugin.settings.disableExternalCalls;
 	let url: string | null = null;
 	if (bg.kind === "default") {
-		url = DEFAULT_BG_URL;
+		url = blocked ? null : DEFAULT_BG_URL;
 	} else if (bg.kind === "url") {
-		url = bg.value;
+		url = blocked ? null : bg.value;
 	} else if (bg.kind === "image") {
 		const file = view.app.vault.getAbstractFileByPath(bg.value);
 		if (file instanceof TFile) url = view.app.vault.getResourcePath(file);

--- a/src/dashboards.ts
+++ b/src/dashboards.ts
@@ -3,6 +3,7 @@ import type { HomeView } from "./view";
 import {
 	type BackgroundConfig,
 	type BackgroundKind,
+	backgroundIsRemote,
 	type BackgroundLayout,
 	BANNER_HEIGHT_MAX,
 	BANNER_HEIGHT_MIN,
@@ -1038,7 +1039,13 @@ class DashboardSettingsModal extends HearthTabbedModal {
 				}),
 			);
 		if (overriding) {
-			addTitleIconPicker(row, this.view.app, current, (v) => set(v));
+			addTitleIconPicker(
+				row,
+				this.view.app,
+				current,
+				(v) => set(v),
+				this.view.plugin.settings.disableExternalCalls,
+			);
 		}
 	}
 
@@ -1359,6 +1366,21 @@ class DashboardSettingsModal extends HearthTabbedModal {
 					this.render();
 				});
 			});
+
+		// A wallpaper fetched from the web is one "Disable external calls" blocks
+		// (#281), so the board says so too — resolving the kind rather than testing
+		// the override, since a board showing the vault's URL wallpaper loses it
+		// just the same.
+		const shownKind = bg?.kind ?? this.view.plugin.settings.backgroundKind;
+		if (backgroundIsRemote(shownKind) && this.view.plugin.settings.disableExternalCalls) {
+			const note = new Setting(containerEl).setDesc(
+				t().settings.background.externalCallsDisabled,
+			);
+			note.settingEl.addClass("hearth-setting-note");
+			const icon = createSpan("hearth-setting-note-icon");
+			setIcon(icon, "wifi-off");
+			note.descEl.prepend(icon);
+		}
 
 		// How the board wears its backdrop is settable whether or not the board
 		// overrides *what* that backdrop is — the two are separate overrides, so

--- a/src/header.ts
+++ b/src/header.ts
@@ -60,9 +60,13 @@ export function renderHeader(view: HomeView, container: HTMLElement, component: 
 		}
 
 		// One setting decides the mark: a Lucide icon, an emoji or short text, a
-		// picture from the vault or the web, or — when it is empty, and when a
-		// picture it names has gone missing — the Hearth crystal (#252).
-		renderTitleIcon(view.app, titleRow, effectiveTitleIcon(s), hearthIconIdFor(target));
+		// picture from the vault or the web, or — when it is empty, when a picture
+		// it names has gone missing, and when a web picture is one "Disable
+		// external calls" won't fetch — the Hearth crystal (#252, #281).
+		renderTitleIcon(view.app, titleRow, effectiveTitleIcon(s), {
+			fallbackIconId: hearthIconIdFor(target),
+			externalCallsDisabled: s.disableExternalCalls,
+		});
 		titleRow.createSpan({ cls: "hearth-title-text", text: effectiveTitle(s) });
 	}
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -992,6 +992,10 @@ export const en = {
 			valueColorDesc: "A CSS color, e.g. #1e1e2e or rgb(30,30,46).",
 			valueImageDesc: "A vault image path, e.g. Attachments/bg.png.",
 			valueUrlDesc: "A direct image URL.",
+			externalCallsDisabled:
+				"Not shown while \u201cDisable external calls\u201d is on in Behaviour: " +
+				"this background is fetched from the web. Pick a vault image instead, " +
+				"or turn the setting off.",
 			opacity: "Opacity",
 			opacityDesc:
 				"How much the background shows through. Lower is more subtle.",
@@ -1090,7 +1094,9 @@ export const en = {
 			disableExternalCalls: "Disable external calls",
 			disableExternalCallsDesc:
 				"Block all outbound network requests Hearth makes, including Jira, " +
-				"external calendars, RSS feeds, and the calculator's currency-rate lookup.",
+				"external calendars, RSS feeds, the calculator's currency-rate lookup, " +
+				"and background images and title icons given as a web address — those " +
+				"fall back to no picture and the Hearth crystal.",
 			openIn: "Open notes in",
 			openInDesc:
 				"Where a note goes when you open one from Hearth. \"Current tab\" replaces " +

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -916,6 +916,9 @@ export const zh: Translations = {
 			valueColorDesc: "一个 CSS 颜色值，例如 #1e1e2e 或 rgb(30,30,46)。",
 			valueImageDesc: "仓库内的图片路径，例如 Attachments/bg.png。",
 			valueUrlDesc: "图片的直链 URL。",
+			externalCallsDisabled:
+				"“行为”中的“禁用对外调用”已开启，因此不会显示：该背景需要从网络获取。" +
+				"请改用仓库内的图片，或关闭该设置。",
 			opacity: "不透明度",
 			opacityDesc: "背景透出的程度。数值越低越含蓄。",
 			blur: "模糊",
@@ -999,8 +1002,9 @@ export const zh: Translations = {
 			mobileTierMatch: "与桌面一致",
 			disableExternalCalls: "禁用对外调用",
 			disableExternalCallsDesc:
-				"阻止 Hearth 发出的所有对外网络请求，包括 Jira、外部日历、RSS 源" +
-				"以及计算器的汇率查询。",
+				"阻止 Hearth 发出的所有对外网络请求，包括 Jira、外部日历、RSS 源、" +
+				"计算器的汇率查询，以及以网址给出的背景图片和标题图标——它们会" +
+				"分别回退为不显示图片和 Hearth 水晶。",
 			openIn: "笔记打开位置",
 			openInDesc:
 				"从 Hearth 打开笔记时它去哪里。“当前标签页”会替换主页视图，" +

--- a/src/onboarding/wizard.ts
+++ b/src/onboarding/wizard.ts
@@ -361,6 +361,7 @@ export class SetupWizardModal extends Modal {
 			(v) => {
 				a.titleIcon = v;
 			},
+			this.plugin.settings.disableExternalCalls,
 		);
 
 		new Setting(body)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,7 +8,7 @@ import { addIconPicker } from "./lucide";
 import { CommandPickerModal, FilePickerModal, FolderPickerModal } from "./pickers";
 import { addTitleIconPicker } from "./titleicon";
 import { configuredPlaces, renderSkySource } from "./placepicker";
-import { activeDashboard, BANNER_HEIGHT_MAX, BANNER_HEIGHT_MIN, type BackgroundKind, type BackgroundLayout, CARD_BORDER_WIDTH_MAX, clampBannerHeight, CONTENT_WIDTH_MAX, CONTENT_WIDTH_MIN, CONTENT_WIDTH_STEP, DEFAULT_SETTINGS, defaultMobileActionButtons, frostAllowed, type HomeSettings, LOW_POWER_BACKGROUND, lowPowerActive, type MobileActionButton, motionAllowed, OPEN_IN_MODES, OPEN_SOURCES, type OpenIn, type OpenInRule, type OpenOutsideRule, PERFORMANCE_TIERS, type PerformanceTier, performanceTier, skyDensity, timersAllowed } from "./types";
+import { activeDashboard, BANNER_HEIGHT_MAX, BANNER_HEIGHT_MIN, type BackgroundKind, backgroundIsRemote, type BackgroundLayout, CARD_BORDER_WIDTH_MAX, clampBannerHeight, CONTENT_WIDTH_MAX, CONTENT_WIDTH_MIN, CONTENT_WIDTH_STEP, DEFAULT_SETTINGS, defaultMobileActionButtons, frostAllowed, type HomeSettings, LOW_POWER_BACKGROUND, lowPowerActive, type MobileActionButton, motionAllowed, OPEN_IN_MODES, OPEN_SOURCES, type OpenIn, type OpenInRule, type OpenOutsideRule, PERFORMANCE_TIERS, type PerformanceTier, performanceTier, skyDensity, timersAllowed } from "./types";
 import {
 	exportLayout,
 	exportSettings,
@@ -666,6 +666,7 @@ export class HomeSettingTab extends PluginSettingTab {
 				s.titleIcon = v;
 				void this.save();
 			},
+			s.disableExternalCalls,
 		);
 
 		addIconPicker(
@@ -1046,6 +1047,19 @@ export class HomeSettingTab extends PluginSettingTab {
 
 	// ---- Background -----------------------------------------------------
 
+	/** The note that says a web wallpaper is not being fetched, shown only when
+	 * the chosen kind actually is one and the switch actually is on. */
+	private remoteBackgroundNote(containerEl: HTMLElement, kind: BackgroundKind): void {
+		if (!backgroundIsRemote(kind) || !this.plugin.settings.disableExternalCalls) return;
+		const note = new Setting(containerEl).setDesc(
+			t().settings.background.externalCallsDisabled,
+		);
+		note.settingEl.addClass("hearth-setting-note");
+		const icon = createSpan("hearth-setting-note-icon");
+		setIcon(icon, "wifi-off");
+		note.descEl.prepend(icon);
+	}
+
 	private backgroundSection(containerEl: HTMLElement): void {
 		const s = this.plugin.settings;
 
@@ -1077,6 +1091,11 @@ export class HomeSettingTab extends PluginSettingTab {
 					this.rerender();
 				});
 			});
+
+		// A wallpaper fetched from the web is one the kill switch blocks (#281),
+		// and a background that quietly doesn't appear is worse than one that says
+		// why — so the note sits with the dropdown that chose it.
+		this.remoteBackgroundNote(containerEl, s.backgroundKind);
 
 		// The weather sky stores a place rather than a typed-in value, so it gets
 		// the shared place picker instead of the text field below.

--- a/src/titleicon.ts
+++ b/src/titleicon.ts
@@ -17,7 +17,8 @@ import { t } from "./i18n";
  *
  *   - empty            → the Hearth crystal (or whatever the caller passes as
  *                        the fallback icon)
- *   - `https://…`      → a picture fetched from the web
+ *   - `https://…`      → a picture fetched from the web (unless the vault has
+ *                        turned external calls off, which draws the fallback)
  *   - `Assets/me.png`  → a picture from the vault
  *   - `flame`          → a Lucide icon
  *   - anything else    → the text itself, emoji included
@@ -96,23 +97,49 @@ export function titleIconFile(app: App, value: string): TFile | null {
 	return file && isImageFile(file) ? file : null;
 }
 
+/** How a title icon is drawn. */
+export interface TitleIconOptions {
+	/** What an empty value — and a picture that has gone missing — falls back to.
+	 * The header passes the Hearth crystal in the variant the board's
+	 * theme-colour setting asks for. */
+	fallbackIconId?: string;
+	/** The vault's **Disable external calls** setting. A `https://` icon is a
+	 * request to a host somebody chose — and on an imported board, somebody
+	 * else — so when the switch is on it is not fetched and the fallback mark is
+	 * drawn instead. A vault picture is unaffected. */
+	externalCallsDisabled?: boolean;
+}
+
+/**
+ * Whether a classified title icon names a picture Hearth must not fetch.
+ *
+ * Only the `url` kind reaches the network: a vault picture is served by
+ * Obsidian, and an icon, an emoji or a word is drawn locally. Pure and tested
+ * so the one rule the kill switch turns on lives in a single place (#281).
+ */
+export function titleIconBlocked(icon: TitleIcon, externalCallsDisabled: boolean): boolean {
+	return externalCallsDisabled && icon.kind === "url";
+}
+
 /**
  * Draw a title icon into `parent` and return the element it created.
- *
- * `fallbackIconId` is what an empty value — and a picture that has gone missing
- * — falls back to; the header passes the Hearth crystal in the variant the
- * board's theme-colour setting asks for.
  */
 export function renderTitleIcon(
 	app: App,
 	parent: HTMLElement,
 	raw: string | undefined,
-	fallbackIconId: string = HEARTH_ICON_ID,
+	options: TitleIconOptions = {},
 ): HTMLElement {
+	const fallbackIconId = options.fallbackIconId ?? HEARTH_ICON_ID;
 	const icon = titleIconOf(raw);
 	if (icon.kind === "url" || icon.kind === "image") {
-		const file = icon.kind === "image" ? titleIconFile(app, icon.value) : null;
-		const src = icon.kind === "url" ? icon.value : file && app.vault.getResourcePath(file);
+		let src: string | null = null;
+		if (icon.kind === "url") {
+			if (!titleIconBlocked(icon, options.externalCallsDisabled === true)) src = icon.value;
+		} else {
+			const file = titleIconFile(app, icon.value);
+			if (file) src = app.vault.getResourcePath(file);
+		}
 		if (src) {
 			const el = parent.createSpan({ cls: "hearth-logo hearth-logo-image" });
 			// Decorative: the title text beside it already names the board.
@@ -141,13 +168,16 @@ export function renderTitleIcon(
  * something anyone types from memory; emoji, text and web URLs are pasted, so
  * the input takes those. The preview is the only feedback that says which of
  * the five readings a value got — type `flame` and the flame appears, type
- * `flames` and the word does.
+ * `flames` and the word does. It honours `externalCallsDisabled` too, so the
+ * preview shows what the header will actually draw rather than making the one
+ * request the setting is there to prevent.
  */
 export function addTitleIconPicker(
 	setting: Setting,
 	app: App,
 	value: string,
 	onChange: (value: string) => void,
+	externalCallsDisabled = false,
 ): Setting {
 	const preview = setting.controlEl.createSpan({ cls: "hearth-icon-preview" });
 	let text: TextComponent | undefined;
@@ -155,7 +185,7 @@ export function addTitleIconPicker(
 	const apply = (next: string) => {
 		const trimmed = next.trim();
 		preview.empty();
-		renderTitleIcon(app, preview, trimmed);
+		renderTitleIcon(app, preview, trimmed, { externalCallsDisabled });
 		preview.toggleClass("is-empty", trimmed === "");
 		onChange(trimmed);
 	};
@@ -197,7 +227,7 @@ export function addTitleIconPicker(
 			.onClick(() => set("")),
 	);
 
-	renderTitleIcon(app, preview, value);
+	renderTitleIcon(app, preview, value, { externalCallsDisabled });
 	preview.toggleClass("is-empty", value.trim() === "");
 	return setting;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3112,14 +3112,42 @@ export function effectiveBackground(s: HomeSettings): ResolvedBackground {
 	};
 }
 
+/** Whether a background kind is fetched from the web. "weather" is not in the
+ * list: a live sky asks for a forecast, but the fetch is gated on its own and
+ * what it draws is drawn locally either way (see background.ts), so it still
+ * paints something. */
+export function backgroundIsRemote(kind: BackgroundKind): boolean {
+	return kind === "url" || kind === "default";
+}
+
+/**
+ * Whether a resolved background has anything to paint.
+ *
+ * "default" ships its own image so it needs no value; every other kind but
+ * "none" needs one. `externalCallsDisabled` — the vault's **Disable external
+ * calls** setting — takes the two remote kinds out: a wallpaper the switch will
+ * not let Hearth fetch is a wallpaper that isn't there, and saying so here is
+ * what keeps the banner strip from being reserved for a picture that never
+ * arrives.
+ */
+export function backgroundPaintable(
+	bg: BackgroundConfig,
+	externalCallsDisabled: boolean,
+): boolean {
+	if (bg.kind === "none") return false;
+	if (externalCallsDisabled && backgroundIsRemote(bg.kind)) return false;
+	return bg.kind === "default" || !!bg.value;
+}
+
 /** Whether the active board paints its backdrop as a banner rather than as a
- * full-view wallpaper. A "none" background has nothing to put in a banner, so
- * it reports false and the board is drawn without one. Low power mode does not
- * change the answer — it swaps what fills the banner, not whether there is one
- * (see {@link effectiveBackground}). */
+ * full-view wallpaper. A background with nothing to paint — "none", a kind with
+ * no value, or a remote picture the kill switch blocks — has nothing to put in a
+ * banner, so it reports false and the board is drawn without one. Low power mode
+ * does not change the answer — it swaps what fills the banner, not whether there
+ * is one (see {@link effectiveBackground}). */
 export function bannerActive(s: HomeSettings): boolean {
 	const bg = effectiveBackground(s);
-	return bg.layout === "banner" && bg.kind !== "none";
+	return bg.layout === "banner" && backgroundPaintable(bg, s.disableExternalCalls);
 }
 
 /**

--- a/test/externalcalls.test.ts
+++ b/test/externalcalls.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { classifyTitleIcon, titleIconBlocked } from "../src/titleicon";
+import {
+	backgroundIsRemote,
+	backgroundPaintable,
+	bannerActive,
+	DEFAULT_SETTINGS,
+	effectiveBackground,
+	type HomeSettings,
+} from "../src/types";
+
+/**
+ * **Disable external calls** is a kill switch, so what it does not cover is a
+ * hole rather than a rough edge (#281). Every card that fetches checks it; the
+ * two things that didn't were a background image and a title icon given as a
+ * web address — the two strings an *imported* board gets to choose (#282), and
+ * so the two a stranger's board could point at a host of their own to learn
+ * that the board had been opened, and by which IP.
+ *
+ * Both are now gated, which means a URL wallpaper and a URL icon disappear
+ * while the switch is on: that is the promise the switch makes, and these tests
+ * are what keeps it. The pure predicates are tested here rather than the
+ * painting, because the painting is DOM (there is no jsdom in this suite) and
+ * because both renderers ask exactly these questions.
+ */
+
+function settings(): HomeSettings {
+	const s: HomeSettings = structuredClone(DEFAULT_SETTINGS);
+	s.dashboards = [{ id: "d1", name: "Dashboard 1", cards: [] }];
+	s.activeDashboardId = "d1";
+	return s;
+}
+
+const classify = (raw: string) => classifyTitleIcon(raw, () => false);
+
+describe("backgroundIsRemote", () => {
+	it("names the two kinds that are fetched over the network", () => {
+		expect(backgroundIsRemote("url")).toBe(true);
+		// The bundled default is not bundled: it is served from GitHub.
+		expect(backgroundIsRemote("default")).toBe(true);
+	});
+
+	it("leaves the local kinds alone", () => {
+		expect(backgroundIsRemote("none")).toBe(false);
+		expect(backgroundIsRemote("color")).toBe(false);
+		expect(backgroundIsRemote("image")).toBe(false);
+		// A live sky asks for a forecast, but that fetch is gated on its own and
+		// the sky is drawn either way — so it still paints something.
+		expect(backgroundIsRemote("weather")).toBe(false);
+	});
+});
+
+describe("backgroundPaintable", () => {
+	const bg = (kind: HomeSettings["backgroundKind"], value = "") => ({
+		kind,
+		value,
+		opacity: 1,
+		blur: 0,
+	});
+
+	it("has nothing to paint without a background", () => {
+		expect(backgroundPaintable(bg("none"), false)).toBe(false);
+	});
+
+	it("needs a value for every kind but the default", () => {
+		expect(backgroundPaintable(bg("default"), false)).toBe(true);
+		expect(backgroundPaintable(bg("url"), false)).toBe(false);
+		expect(backgroundPaintable(bg("url", "https://example.com/bg.png"), false)).toBe(true);
+		expect(backgroundPaintable(bg("color", "#123456"), false)).toBe(true);
+	});
+
+	it("drops the remote kinds once external calls are off", () => {
+		expect(backgroundPaintable(bg("url", "https://example.com/bg.png"), true)).toBe(false);
+		expect(backgroundPaintable(bg("default"), true)).toBe(false);
+	});
+
+	it("keeps the local kinds when external calls are off", () => {
+		expect(backgroundPaintable(bg("color", "#123456"), true)).toBe(true);
+		expect(backgroundPaintable(bg("image", "Assets/wall.png"), true)).toBe(true);
+		expect(backgroundPaintable(bg("weather", "50.1,14.4,Prague"), true)).toBe(true);
+	});
+});
+
+describe("bannerActive with external calls off", () => {
+	it("reserves no strip for a picture that will not be fetched", () => {
+		const s = settings();
+		s.backgroundKind = "url";
+		s.backgroundValue = "https://attacker.example/bg.png?u=1";
+		s.backgroundLayout = "banner";
+		expect(bannerActive(s)).toBe(true);
+
+		s.disableExternalCalls = true;
+		expect(bannerActive(s)).toBe(false);
+		// The setting is untouched: turn the switch off again and the banner is
+		// back, wallpaper and all.
+		expect(effectiveBackground(s).value).toBe("https://attacker.example/bg.png?u=1");
+	});
+
+	it("leaves a vault picture's banner standing", () => {
+		const s = settings();
+		s.backgroundKind = "image";
+		s.backgroundValue = "Assets/wall.png";
+		s.backgroundLayout = "banner";
+		s.disableExternalCalls = true;
+		expect(bannerActive(s)).toBe(true);
+	});
+});
+
+describe("titleIconBlocked", () => {
+	it("blocks a web address, and only while the switch is on", () => {
+		const icon = classify("https://attacker.example/i.png?u=1");
+		expect(icon.kind).toBe("url");
+		expect(titleIconBlocked(icon, true)).toBe(true);
+		expect(titleIconBlocked(icon, false)).toBe(false);
+	});
+
+	it("never blocks a mark that is drawn locally", () => {
+		for (const raw of ["Assets/me.png", "🔥", "AB", "data:image/png;base64,AAAA"]) {
+			expect(titleIconBlocked(classify(raw), true)).toBe(false);
+		}
+		expect(titleIconBlocked(classify(""), true)).toBe(false);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Takes **option (1)** from #281: the two remaining network-touching features are
gated by **Settings → Behaviour → Disable external calls**, and the setting says
so.

Three requests went out regardless of the switch:

- a background whose kind is `url` — `background.ts` set `backgroundImage:
  url("…")` with no check;
- the **`default`** background, which is served from `raw.githubusercontent.com`
  rather than from the plugin folder, so a vault on the default wallpaper reached
  GitHub on every render;
- a title icon given as an `https://` address — `titleicon.ts` set `img.src`
  with no check.

Every card already checked. What makes these worth closing now is sharing (#282):
once a board is installed from a gallery, `background.value` and
`header.titleIcon` are strings **a stranger chose**, so a board can be authored
to beacon — opening it reports the importing user's IP and reading pattern to a
host of the author's choosing, including for the reader who turned the switch on
precisely to stop that.

**How it's done**

- `backgroundIsRemote` / `backgroundPaintable` in `types.ts` are now the single
  place that decides whether a background paints. `bannerActive` shares that
  predicate, so a blocked wallpaper drops the banner strip instead of reserving
  an empty one — which also fixes the same mismatch for a kind that simply has
  no value yet.
- `paintBackground` still re-checks at the point the request would be made.
- `titleIconBlocked` is the equivalent for the icon. A blocked icon falls back to
  the Hearth crystal, exactly as an empty value and a missing picture already do.
  `renderTitleIcon` takes an options object (fallback icon + flag), and the
  previews in the settings tab, a board's own settings and the onboarding wizard
  pass the flag too — a preview must not make the request the setting exists to
  prevent.
- Both background screens show a note beside the dropdown when the chosen kind is
  one the switch blocks, so the wallpaper does not just quietly fail to appear.
  The setting's own description (en + zh) now names remote backgrounds and icons.
- `docs/dashboard-package.md` no longer records the gap as open; README's
  external-services table gains the row for "whatever host you name".

**The visible behaviour change**, called out in the CHANGELOG: a user who has
deliberately set a URL wallpaper or icon *and* has the switch on loses that
picture on upgrade. Nothing is rewritten — the value is untouched, exports still
carry it, and turning the switch off brings it straight back.

New pure predicates are tested in `test/externalcalls.test.ts` (10 tests); the
painting itself is DOM, and this suite has no jsdom.

**One thing I noticed and did not touch:** a board's background dropdown offers
an `hdefault` ("Hearth default") option whose key is stored verbatim as the
`BackgroundKind`, and nothing in `src/` maps it back to `default` — so that
option paints nothing at all. Unrelated to this issue and it fetches nothing, so
it's left as it is, but it looks like a real bug worth its own issue.

## Related issue

Closes #281

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [x] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (`npm run lint`, `npm run typecheck` and
      `npm test` — 1426 passing — too)
- [ ] I've tested this in an actual vault — not possible from this environment;
      the pure predicates are covered by tests and the render paths are the two
      call sites shown in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM8FWiMn3ku8mchgCUYZPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM8FWiMn3ku8mchgCUYZPS)_