### PR TITLE
Show hidden cards while arranging a stacked board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,6 +329,17 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **A card hidden from the narrow board can be brought back from a phone.**
+  Hiding a card for the stacked layout took it off the board — including off the
+  board its own settings are reached from — so the switch could only be turned
+  back off from a desktop or by forcing the wide layout. Arranging a stacked
+  board now shows the hidden cards too, greyed out and dashed, each with an eye
+  button in its header that puts it back. They are never built while they sit
+  there (hiding a card is usually because it is expensive or needs width), they
+  keep their place in the stack so unhiding returns a card where it was left,
+  and outside arrange mode nothing changes: hidden stays hidden, and the
+  free-form board on a desktop is untouched.
+
 - **"Disable external calls" now also covers a background image and a title icon
   given as a web address.** The switch promises to block every outbound request
   Hearth makes, and every card kept that promise — but a wallpaper whose kind is

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -125,22 +125,36 @@ export function renderDashboard(
 		elements: new Map(),
 	};
 
-	for (const card of stacked ? stackedCards(cards) : cards) {
+	// While arranging a stacked board the hidden cards are shown too, greyed out
+	// and inert, because hiding one is otherwise a one-way door: the only control
+	// that brings it back lives on the board it was just taken off, so a card
+	// hidden on a phone could only be restored from a desktop. Outside arrange
+	// mode the rendered board is unchanged — hidden stays hidden.
+	const arrangingStack = stacked && view.arrangeMode;
+	for (const card of stacked
+		? stackedCards(cards, { includeHidden: arrangingStack })
+		: cards) {
 		// A card asked to collapse gets a title row and nothing else until someone
 		// taps it — which is the whole point of the option: an expensive card
 		// costs one row on a phone instead of a screenful, and its body is never
 		// built at all unless it is opened. Only in the stacked layout, where
 		// vertical space is the scarce thing.
 		const collapsed = stacked && card.mobile?.collapsed === true;
+		// A card only on screen because the board is being arranged: shown as a
+		// greyed header with its kind for a label, and never built. Hiding a card
+		// is most often exactly because it is expensive or needs width, and
+		// arranging it back into view must not be the thing that runs it.
+		const hidden = arrangingStack && card.mobile?.hidden === true;
 
 		const el = grid.createDiv("hearth-card");
+		el.toggleClass("is-mobile-hidden", hidden);
 		gridLayout.elements.set(card, el);
 		// Stacked cards are in normal flow: full width from CSS, and only as tall
 		// as the stacked layout says — bar a collapsed one, which is as tall as
 		// its own header until it is opened. Everywhere else they are placed
 		// absolutely from their stored geometry.
 		if (!stacked) applyCardPosition(el, card);
-		else if (!collapsed) el.style.height = `${stackedHeight(card)}px`;
+		else if (!collapsed && !hidden) el.style.height = `${stackedHeight(card)}px`;
 
 		if (card.pinned) el.addClass("is-pinned");
 		// The card's kind, on the element. Only a couple of kinds contribute a
@@ -196,6 +210,14 @@ export function renderDashboard(
 
 		const body = el.createDiv("hearth-card-body");
 		if (card.background) body.addClass("has-bg");
+
+		// A hidden card names its kind and stops there: nothing is mounted, so
+		// there is no title on an untitled card and no content to recognise it by.
+		if (hidden) {
+			body.addClass("is-hidden-note");
+			body.createSpan({ text: t().editors.kinds[card.kind] });
+			continue;
+		}
 
 		// One mount for both paths, so a card expanded on a phone is built exactly
 		// as it would have been had it never been collapsed — its header extras
@@ -525,7 +547,10 @@ function renderCardControls(
 	// `mobile.order`, the same field the card's own Mobile settings expose.
 	if (stack) {
 		const move = (delta: -1 | 1) => {
-			if (!moveStacked(stack, card, delta)) return;
+			// The arrange stack is the one with the hidden cards in it, so the
+			// renumbering has to count them too — otherwise moving a card past a
+			// hidden one on screen would leave it where it started.
+			if (!moveStacked(stack, card, delta, { includeHidden: true })) return;
 			persistAndRender(view);
 		};
 		for (const [delta, icon, label] of [
@@ -540,6 +565,27 @@ function renderCardControls(
 			btn.addEventListener("pointerdown", (e) => e.stopPropagation());
 			btn.addEventListener("click", () => move(delta));
 		}
+
+		// The way back from a hidden card. `mobile.hidden` is also a toggle in the
+		// card's own settings, but that is a desktop-shaped answer to a phone-shaped
+		// problem: on the board where the card is hidden it isn't rendered, so its
+		// settings can't be reached from it. Arranging shows it greyed out with
+		// this button on it, so hiding is reversible from the phone that did it.
+		const hidden = card.mobile?.hidden === true;
+		const vis = actions.createEl("button", {
+			cls: "hearth-card-action",
+			attr: {
+				"aria-label": hidden ? t().dashboard.showOnNarrow : t().dashboard.hideOnNarrow,
+				"aria-pressed": String(hidden),
+				type: "button",
+			},
+		});
+		setIcon(vis, hidden ? "eye-off" : "eye");
+		vis.addEventListener("pointerdown", (e) => e.stopPropagation());
+		vis.addEventListener("click", () => {
+			card.mobile = { ...card.mobile, hidden: !hidden };
+			persistAndRender(view);
+		});
 	}
 
 	const settingsBtn = actions.createEl("button", {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -490,6 +490,8 @@ export const en = {
 		phonePreviewOff: "Leave phone preview",
 		moveCardUp: "Move card up",
 		moveCardDown: "Move card down",
+		hideOnNarrow: "Hide on a narrow board",
+		showOnNarrow: "Show on a narrow board",
 	},
 
 	// ---- Dashboard switcher & per-dashboard settings -------------------

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -457,6 +457,8 @@ export const zh: Translations = {
 		phonePreviewOff: "退出手机预览",
 		moveCardUp: "上移卡片",
 		moveCardDown: "下移卡片",
+		hideOnNarrow: "在窄屏布局中隐藏",
+		showOnNarrow: "在窄屏布局中显示",
 	},
 
 	// ---- Dashboard switcher & per-dashboard settings -------------------

--- a/src/narrow.ts
+++ b/src/narrow.ts
@@ -102,9 +102,18 @@ function readingOrder(cards: DashboardCard[]): DashboardCard[] {
  * isn't — the two share one number line, so `order: 0` pulls a card to the top
  * and a large `order` pushes it to the bottom without having to number every
  * other card. Ties keep reading order.
+ *
+ * `includeHidden` keeps the hidden ones in the list, in the place they would
+ * hold if they were shown. That is what arranging a stacked board asks for: a
+ * card hidden from a phone can only be brought back from a control that is
+ * itself on the phone, so the arrange view has to be able to show what the
+ * rendered board deliberately does not. Nothing outside arrange mode passes it.
  */
-export function stackedCards(cards: DashboardCard[]): DashboardCard[] {
-	return readingOrder(cards.filter((card) => !card.mobile?.hidden))
+export function stackedCards(
+	cards: DashboardCard[],
+	opts: { includeHidden?: boolean } = {},
+): DashboardCard[] {
+	return readingOrder(cards.filter((card) => opts.includeHidden || !card.mobile?.hidden))
 		.map((card, index) => ({
 			card,
 			index,
@@ -162,14 +171,19 @@ export function observeNarrowWidth(
  * order someone arranged the thing that holds.
  *
  * Hidden cards are left out and left alone: they are not in the stack, so they
- * have no position in it to renumber.
+ * have no position in it to renumber. `includeHidden` — what arrange mode
+ * passes, where the hidden cards are on screen and movable — puts them back in
+ * the same one line, so a card moved past a hidden one keeps the place it was
+ * dragged to and the hidden card comes back where it was left rather than
+ * wherever the desktop geometry would re-derive it.
  */
 export function moveStacked(
 	cards: DashboardCard[],
 	card: DashboardCard,
 	delta: -1 | 1,
+	opts: { includeHidden?: boolean } = {},
 ): boolean {
-	const order = stackedCards(cards);
+	const order = stackedCards(cards, opts);
 	const from = order.indexOf(card);
 	const to = from + delta;
 	if (from < 0 || to < 0 || to >= order.length) return false;

--- a/styles.css
+++ b/styles.css
@@ -6292,6 +6292,27 @@
 	display: none;
 }
 
+/* A card hidden from the narrow board, shown only while that board is being
+   arranged (see renderDashboard). It is greyed and dashed rather than absent so
+   the way back from hiding a card is on the phone that hid it; its body is
+   never built, so all there is to lay out is the header and a kind label. */
+.hearth-grid.is-stacked .hearth-card.is-mobile-hidden {
+	height: auto;
+	opacity: 0.55;
+	border-style: dashed;
+	box-shadow: none;
+}
+
+.hearth-card.is-mobile-hidden .hearth-card-body.is-hidden-note {
+	display: flex;
+	align-items: center;
+	min-height: 0;
+	padding: 6px 12px 10px;
+	color: var(--text-faint);
+	font-size: 0.85rem;
+	font-style: italic;
+}
+
 /* The whole header is the tap target outside arrange mode, where it holds no
    controls of its own. */
 .hearth-card-head.is-collapsible {

--- a/test/narrow.test.ts
+++ b/test/narrow.test.ts
@@ -90,6 +90,21 @@ describe("stackedCards", () => {
 		expect(ids(stackedCards(cards))).toEqual(["shown", "also-shown"]);
 	});
 
+	it("keeps hidden cards in place when asked for them", () => {
+		// What arranging a stacked board shows: the hidden card is on screen, in
+		// the position it would hold if it were shown, so it can be brought back.
+		const cards = [
+			card("shown", { fy: 0 }),
+			card("gone", { fy: 100, mobile: { hidden: true } }),
+			card("also-shown", { fy: 200 }),
+		];
+		expect(ids(stackedCards(cards, { includeHidden: true }))).toEqual([
+			"shown",
+			"gone",
+			"also-shown",
+		]);
+	});
+
 	it("places an explicit order on the same number line as the derived one", () => {
 		// The clock is last on the board and asks to come first; everything else
 		// keeps its reading-order position around it.
@@ -177,6 +192,26 @@ describe("moveStacked", () => {
 		expect(moveStacked(cards, cards[2], -1)).toBe(true);
 		expect(ids(stackedCards(cards))).toEqual(["c", "a"]);
 		expect(cards[1].mobile).toEqual({ hidden: true });
+	});
+
+	it("counts hidden cards when arranging with them on screen", () => {
+		const cards = [
+			card("a", { fy: 0 }),
+			card("hidden", { fy: 100, mobile: { hidden: true } }),
+			card("c", { fy: 200 }),
+		];
+		expect(moveStacked(cards, cards[2], -1, { includeHidden: true })).toBe(true);
+		// The move is one place on the stack the arranger can see, so `c` lands
+		// above the hidden card rather than jumping the whole way to the top.
+		expect(ids(stackedCards(cards, { includeHidden: true }))).toEqual([
+			"a",
+			"c",
+			"hidden",
+		]);
+		// Hidden or not, the whole stack is numbered — so unhiding the card later
+		// brings it back where it was left.
+		expect(cards.map((c) => c.mobile?.order)).toEqual([0, 2, 1]);
+		expect(cards[1].mobile?.hidden).toBe(true);
 	});
 
 	it("keeps a card's other mobile options while reordering", () => {


### PR DESCRIPTION
## What does this PR do?

Makes hiding a card for the narrow layout reversible from the device that hid it.

Today `mobile.hidden` takes a card off the stacked board — including off the only board its own settings can be opened from — so on a phone the switch is one-way: the card is gone, and the control that would bring it back went with it. The only ways out are a desktop or forcing the wide layout.

Now, **while arranging a stacked board**, the hidden cards are listed too, in the place they would hold if they were shown, greyed out and dashed, each with an eye button in its header that puts it back.

- Hidden cards are never mounted while they sit there — hiding a card is usually because it is expensive or needs width, and arranging it should not be the thing that runs it. A hidden card renders as its arrange header plus its card kind for a label (an untitled card would otherwise be a blank bar).
- Reordering while arranging renumbers the whole stack, hidden cards included, so unhiding a card returns it where it was left instead of wherever the desktop geometry re-derives it.
- Outside arrange mode nothing changes: hidden stays hidden. The free-form desktop board is untouched — `stackedCards`/`moveStacked` still exclude hidden cards by default, and neither writes to `fx/fy/fw/fh`.

Implementation: `stackedCards` and `moveStacked` take an `includeHidden` option (default off, so every existing caller and behaviour is unchanged); `renderDashboard` passes it only when the board is both stacked and being arranged; `renderCardControls` gains the eye/eye-off toggle beside the existing move buttons; new `.is-mobile-hidden` styling; new `dashboard.hideOnNarrow` / `dashboard.showOnNarrow` strings in `en` and `zh`.

## Related issue

None — small, self-contained fix to an existing control.

## Type of change

- [x] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally (`npm test` — 1451 passed; `npm run lint` — 0 errors, only pre-existing warnings)
- [ ] I've tested this in an actual vault — **not done**: verified by the unit tests for the ordering logic and by typecheck/build only; the rendering path was not exercised in Obsidian from this environment. Worth a look on a phone (or via the Arrange phone preview) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPEw822ipKgzUu2kU28j2g

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPEw822ipKgzUu2kU28j2g)_