### PR TITLE
chore: cut 3.1.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 All notable changes to Hearth are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to a numeric-only versioning scheme
-(`MAJOR.MINOR.PATCH`) as required by Obsidian's plugin manifest. Beta builds
-carry a fourth `.N-beta` segment and are omitted here; each entry aggregates its
+and this project adheres to [semantic versioning](https://semver.org/)
+(`MAJOR.MINOR.PATCH`) as required by Obsidian's plugin manifest. Beta builds are
+tagged `MAJOR.MINOR.PATCH-beta.N` and are omitted here; each entry aggregates its
 preceding beta series.
 
 History begins at 1.5.0. For releases before 1.5.0, see the

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "3.1.0-beta.3",
+	"version": "3.1.0-beta.4",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
## What does this PR do?

Cuts the next beta snapshot of the 3.1.0 line from current `main`.

- `manifest-beta.json` → `3.1.0-beta.4` (BRAT only; `manifest.json` stays at the stable `3.0.0`, untouched).
- `CHANGELOG.md` preamble corrected: it claimed betas "carry a fourth `.N-beta` segment", which is invalid semver, is rejected by Obsidian, and does not match the release workflow's tag trigger. Betas are `MAJOR.MINOR.PATCH-beta.N`. Also links semver rather than describing the scheme as "numeric-only", which the pre-release tags contradict.

The `## [3.1.0]` section already describes everything this build contains — the dashboard gallery, plugin view dashboards, the signed anonymous handle, the web search engine picker, the "Disable external calls" URL-background/icon fix, the chained switch-then-open fix and the hidden-cards-while-arranging fix — so no entries needed adding. No `src/`, `styles.css` or `esbuild.config.mjs` changes: this is a version/label commit only.

`node scripts/verify-manifests.mjs` passes: beta `3.1.0-beta.4` is a pre-release ahead of stable `3.0.0` and matches it on every other field.

## Related issue

None — release chore.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

Release chore (none of the above).

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault — no runtime code changes to test; the beta build itself is what goes to BRAT testers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dQoRyD7gRwVJySFGXLoNw

---
_Generated by [Claude Code](https://claude.ai/code/session_014dQoRyD7gRwVJySFGXLoNw)_