### PR TITLE
fix(gallery): stop the publish snapshot writing its redaction into the vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,6 +329,20 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ### Fixed
 
+- **Publishing a board no longer edits the notes it photographs.** The picture
+  taken at publish blanked the board by writing block characters over the page
+  itself and putting the text back afterwards — which is harmless for something
+  merely rendered, and was not harmless for the three cards whose page *is* your
+  data. A live-preview note card hosts Obsidian's own editor, which read the
+  blocks back as typing and saved them, so publishing a board rewrote the note
+  on it and the restore came too late to help; the raw-edit note card and the
+  text card could do the same through a save landing in the second the shutter
+  was open. Those regions are now blanked by *style* — hidden, drawn in nothing,
+  and blurred — so nothing readable is in the frame and nothing is written to
+  the vault to get it there. **If you published a board carrying a live note
+  card before this, check that note**: Obsidian's own File recovery holds a
+  snapshot from before the damage.
+
 - **A card hidden from the narrow board can be brought back from a phone.**
   Hiding a card for the stacked layout took it off the board — including off the
   board its own settings are reached from — so the switch could only be turned

--- a/src/gallery/snapshot.ts
+++ b/src/gallery/snapshot.ts
@@ -121,10 +121,12 @@ const REDACTED_CLASS = "hearth-snapshot-bar";
  * CodeMirror had already moved on from, so the file kept the blocks. The same
  * is true of any other editable surface a hosted view mounts.
  *
- * So these are blanked by *style* instead: the class below paints no glyphs and
- * blurs whatever is left, and the walk skips everything inside them. Nothing
- * readable is in the frame either way; the difference is that the vault is not
- * written to in order to take a photograph.
+ * So these are blanked by *style* instead: {@link BLANKED_CLASS} hides what is
+ * inside them and paints no glyphs, and the walk skips everything within.
+ * Nothing readable is in the frame either way; the difference is that the vault
+ * is not written to in order to take a photograph. A form field's value is
+ * treated the same way and for the same reason — see the field pass in
+ * `redact`.
  */
 const EDITABLE_INSIDE = '[contenteditable]:not([contenteditable="false"])';
 
@@ -138,8 +140,9 @@ const EDITABLE_INSIDE = '[contenteditable]:not([contenteditable="false"])';
  */
 const EDITABLE_HOST = ".cm-editor";
 
-/** Class an editable region carries while the shutter is open. `styles.css`
- * paints its text away and blurs the rest. */
+/** Class a region carries while the shutter is open, instead of having its text
+ * replaced: an editor, or a field holding a value. `styles.css` hides what is
+ * inside it, paints its text away and blurs the rest. */
 const BLANKED_CLASS = "hearth-snapshot-blank";
 
 /**
@@ -271,7 +274,6 @@ interface Redaction {
 function redact(root: HTMLElement): Redaction {
 	const originals: [Text, string][] = [];
 	const wrapped: HTMLElement[] = [];
-	const fields: [HTMLInputElement | HTMLTextAreaElement, string][] = [];
 	const blanked: HTMLElement[] = [];
 
 	const pass = (): void => {
@@ -322,22 +324,28 @@ function redact(root: HTMLElement): Redaction {
 
 			// **A form field's value is not a text node**, so the walk above
 			// never sees it — and a calculator card renders its last sum into an
-			// `<input>`, a search card its query. Those are the author's own
-			// working state, which the publish path removes from the *package*;
-			// a picture that still showed them would put back exactly what the
-			// strip took out. Placeholders stay: they are part of the board's
-			// look and travel in the package anyway.
+			// `<input>`, a search card its query, and the raw-edit note card the
+			// whole note. Those are the author's own working state, which the
+			// publish path removes from the *package*; a picture that still
+			// showed them would put back exactly what the strip took out.
+			//
+			// Blanked by style rather than by writing over `value`, for the
+			// reason the editors are: a field's value can be what the card saves
+			// to the vault. `renderEditableEmbed`'s textarea *is* the note, and
+			// its debounced `flush()` writes whatever `value` holds at the
+			// moment it fires — so a save landing inside the second the shutter
+			// is open would write the blocks to the file. Nothing readable is
+			// painted either way; this way there is no window in which the
+			// author's own data has been replaced.
+			//
+			// Placeholders stay: they are part of the board's look and travel in
+			// the package anyway.
 			for (const field of Array.from(
 				body.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>("input, textarea"),
 			)) {
-				if (!field.value || field.dataset.hearthRedacted === "1") continue;
-				// A field a hosted view owns is blanked with the rest of it; a
-				// value written behind that view's back is the same mistake as
-				// rewriting an editor's text.
-				if (field.closest(`.${BLANKED_CLASS}`)) continue;
-				fields.push([field, field.value]);
-				field.dataset.hearthRedacted = "1";
-				field.value = redactedText(field.value);
+				if (!field.value || field.classList.contains(BLANKED_CLASS)) continue;
+				field.classList.add(BLANKED_CLASS);
+				blanked.push(field);
 			}
 		}
 	};
@@ -353,10 +361,6 @@ function redact(root: HTMLElement): Redaction {
 				if (text && span.parentNode) span.parentNode.replaceChild(text, span);
 			}
 			for (const [node, value] of originals) node.data = value;
-			for (const [field, value] of fields) {
-				field.value = value;
-				delete field.dataset.hearthRedacted;
-			}
 			for (const region of blanked) region.classList.remove(BLANKED_CLASS);
 			root.removeClass("hearth-snapshot-redacted");
 		},

--- a/src/gallery/snapshot.ts
+++ b/src/gallery/snapshot.ts
@@ -14,7 +14,10 @@
  *   This is a redaction rather than an obscuring: the characters are not in the
  *   DOM at the moment it is painted, so there is nothing in the image to
  *   recover. What survives is the layout, the card shapes, the colours, the
- *   icons and the wallpaper — which is what a look is.
+ *   icons and the wallpaper — which is what a look is. The one exception is an
+ *   editor hosted inside a card, whose DOM *is* a note and cannot be written to
+ *   without editing it: that is blanked by style instead — see
+ *   {@link EDITABLE_INSIDE}.
  * - **The author sees it before it goes.** The share dialog shows the captured
  *   image and will not upload one that hasn't been looked at. A promise about
  *   what a picture contains is worth much less than the picture.
@@ -104,6 +107,40 @@ const OPEN_KINDS = new Set(["clock"]);
 
 /** Class the wrapper carries, so `styles.css` can draw the bars. */
 const REDACTED_CLASS = "hearth-snapshot-bar";
+
+/**
+ * Regions the redaction must not touch the *text* of, because their DOM is a
+ * document rather than a rendering of one.
+ *
+ * A live-preview note card hosts Obsidian's own Markdown editor (see
+ * `leafview.ts`), and a CodeMirror editor watches its contenteditable for
+ * changes: anything written into that DOM is read back as the user having
+ * typed it, folded into the editor's state and saved to the vault. Replacing
+ * its text nodes with blocks therefore did not redact a picture — it rewrote
+ * the note, and the `restore()` afterwards put the characters back in a DOM
+ * CodeMirror had already moved on from, so the file kept the blocks. The same
+ * is true of any other editable surface a hosted view mounts.
+ *
+ * So these are blanked by *style* instead: the class below paints no glyphs and
+ * blurs whatever is left, and the walk skips everything inside them. Nothing
+ * readable is in the frame either way; the difference is that the vault is not
+ * written to in order to take a photograph.
+ */
+const EDITABLE_INSIDE = '[contenteditable]:not([contenteditable="false"])';
+
+/**
+ * What is blanked instead of an editable region's text.
+ *
+ * The whole editor rather than the contenteditable alone, when there is one:
+ * CodeMirror paints gutters, the active-line highlight and its own widgets
+ * around the editable element, and half a blanked editor reads worse than a
+ * blank one.
+ */
+const EDITABLE_HOST = ".cm-editor";
+
+/** Class an editable region carries while the shutter is open. `styles.css`
+ * paints its text away and blurs the rest. */
+const BLANKED_CLASS = "hearth-snapshot-blank";
 
 /**
  * Parts of a card that stay readable, because they are the card's own
@@ -235,6 +272,7 @@ function redact(root: HTMLElement): Redaction {
 	const originals: [Text, string][] = [];
 	const wrapped: HTMLElement[] = [];
 	const fields: [HTMLInputElement | HTMLTextAreaElement, string][] = [];
+	const blanked: HTMLElement[] = [];
 
 	const pass = (): void => {
 		// **Only the insides of cards.** The board's chrome — the vault name,
@@ -245,6 +283,16 @@ function redact(root: HTMLElement): Redaction {
 		for (const body of Array.from(root.querySelectorAll<HTMLElement>(REDACT_INSIDE))) {
 			if (isOpenCard(body)) continue;
 
+			// **An editor is blanked, never rewritten.** Its text nodes belong to
+			// a document CodeMirror is watching, so touching them edits the
+			// user's note — see EDITABLE_INSIDE.
+			for (const editable of Array.from(body.querySelectorAll<HTMLElement>(EDITABLE_INSIDE))) {
+				const region = editable.closest<HTMLElement>(EDITABLE_HOST) ?? editable;
+				if (region.classList.contains(BLANKED_CLASS)) continue;
+				region.classList.add(BLANKED_CLASS);
+				blanked.push(region);
+			}
+
 			const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT);
 			const texts: Text[] = [];
 			for (let node = walker.nextNode(); node; node = walker.nextNode()) {
@@ -254,6 +302,8 @@ function redact(root: HTMLElement): Redaction {
 				if (text.parentElement?.classList.contains(REDACTED_CLASS)) continue;
 				// A date, a weekday, a month name: the card's own furniture.
 				if (text.parentElement?.closest(KEEP_INSIDE)) continue;
+				// Inside an editor, which is blanked by style above.
+				if (text.parentElement?.closest(EDITABLE_INSIDE)) continue;
 				texts.push(text);
 			}
 			for (const text of texts) {
@@ -281,6 +331,10 @@ function redact(root: HTMLElement): Redaction {
 				body.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>("input, textarea"),
 			)) {
 				if (!field.value || field.dataset.hearthRedacted === "1") continue;
+				// A field a hosted view owns is blanked with the rest of it; a
+				// value written behind that view's back is the same mistake as
+				// rewriting an editor's text.
+				if (field.closest(`.${BLANKED_CLASS}`)) continue;
 				fields.push([field, field.value]);
 				field.dataset.hearthRedacted = "1";
 				field.value = redactedText(field.value);
@@ -303,6 +357,7 @@ function redact(root: HTMLElement): Redaction {
 				field.value = value;
 				delete field.dataset.hearthRedacted;
 			}
+			for (const region of blanked) region.classList.remove(BLANKED_CLASS);
 			root.removeClass("hearth-snapshot-redacted");
 		},
 	};

--- a/styles.css
+++ b/styles.css
@@ -13060,6 +13060,29 @@ body.hearth-snapshot-capturing .hearth-view {
 	filter: blur(10px) !important;
 }
 
+/* An editor hosted inside a card — a live-preview note — is blanked rather than
+   rewritten. Its DOM is the note: CodeMirror reads anything written into it back
+   as typing and saves it, so replacing its text with blocks edited the vault to
+   take a photograph. Nothing readable is painted here either — the glyphs are
+   drawn in nothing and what is left (a pseudo-element's content, an inline
+   picture, a widget) goes through the blur — the difference is that the file is
+   left alone. See src/gallery/snapshot.ts. */
+.hearth-snapshot-redacted .hearth-snapshot-blank,
+.hearth-snapshot-redacted .hearth-snapshot-blank * {
+	color: transparent !important;
+	-webkit-text-fill-color: transparent !important;
+	text-shadow: none !important;
+	caret-color: transparent !important;
+}
+
+.hearth-snapshot-redacted .hearth-snapshot-blank {
+	filter: blur(10px) !important;
+	/* So the region still reads as "text lives here" rather than as an empty
+	   card, the same soft ink the bars use. */
+	background-color: var(--text-normal);
+	opacity: 0.14;
+}
+
 /* A canvas is blurred a little less than a picture, because the graph view's
    *shape* is worth publishing and a heavy blur turns it to fog. Not much less:
    nothing inside a canvas is text to the redactor — it is pixels — so this blur

--- a/styles.css
+++ b/styles.css
@@ -13060,13 +13060,22 @@ body.hearth-snapshot-capturing .hearth-view {
 	filter: blur(10px) !important;
 }
 
-/* An editor hosted inside a card — a live-preview note — is blanked rather than
-   rewritten. Its DOM is the note: CodeMirror reads anything written into it back
-   as typing and saves it, so replacing its text with blocks edited the vault to
-   take a photograph. Nothing readable is painted here either — the glyphs are
-   drawn in nothing and what is left (a pseudo-element's content, an inline
-   picture, a widget) goes through the blur — the difference is that the file is
-   left alone. See src/gallery/snapshot.ts. */
+/* What is blanked rather than rewritten: a hosted editor (a live-preview note
+   card) and every form field holding a value (a calculator's sum, a search
+   query, the raw-edit note card's textarea, which *is* the note).
+
+   The DOM of those is the user's data, not a rendering of it — CodeMirror reads
+   anything written into its contenteditable back as typing and saves it, and a
+   card's own save writes whatever its textarea holds at that moment. Replacing
+   their text with blocks edited the vault in order to take a photograph. So
+   they are made to paint nothing instead: children are hidden (layout kept, so
+   the card keeps its shape), text is drawn in nothing, and the region goes
+   through a blur as a backstop against anything a theme un-hides. See
+   src/gallery/snapshot.ts. */
+.hearth-snapshot-redacted .hearth-snapshot-blank > * {
+	visibility: hidden !important;
+}
+
 .hearth-snapshot-redacted .hearth-snapshot-blank,
 .hearth-snapshot-redacted .hearth-snapshot-blank * {
 	color: transparent !important;
@@ -13076,11 +13085,11 @@ body.hearth-snapshot-capturing .hearth-view {
 }
 
 .hearth-snapshot-redacted .hearth-snapshot-blank {
-	filter: blur(10px) !important;
-	/* So the region still reads as "text lives here" rather than as an empty
-	   card, the same soft ink the bars use. */
+	filter: blur(8px) !important;
+	/* So the region still reads as "content lives here" rather than as an empty
+	   card — the same soft ink the bars are drawn in. */
 	background-color: var(--text-normal);
-	opacity: 0.14;
+	opacity: 0.16;
 }
 
 /* A canvas is blurred a little less than a picture, because the graph view's


### PR DESCRIPTION
## What does this PR do?

The snapshot taken before a board is published redacted the board by **writing over the live DOM** — replacing every text node under a card body with `█`, and every form field's `value` with the same — then restoring both in a `finally`. For anything that is merely a rendering, that is fine. For the three places where a card's DOM *is* the user's data, it edited the vault in order to take a photograph:

- **The live-preview note card** (`renderLivePreviewEmbed` → `createEditorLeaf`) hosts Obsidian's own Markdown editor. CodeMirror watches its contenteditable: the blocks were read back as typing, folded into the editor state and saved. The restore afterwards put the characters back into a DOM CodeMirror had already re-rendered from its own (now corrupted) state, so the file kept the blocks. This is the reported corruption.
- **The raw-edit note card** (`renderEditableEmbed`) keeps the whole note in a `<textarea>` and its debounced `flush()` writes whatever `value` holds when it fires — so a save landing inside the second the shutter is open wrote blocks to the note.
- **The text / jot-down card** (`cards/text.ts`) does the same into `card.text` and `saveData(settings)`.

Both mechanisms are now closed by never writing to either:

- The text-node walk skips anything inside a `[contenteditable]`, and the enclosing `.cm-editor` is blanked by style instead.
- Fields holding a value are blanked by style too, rather than having `value` replaced.
- The blanking class hides the region's children (keeping the card's shape), paints its text in nothing, and puts a blur over the region as a backstop against a theme rule that outranks the colour.

Nothing readable is in the frame either way. The difference is that publishing no longer touches the vault.

**A note on the guarantee.** For these regions the redaction is now a property of how the page is *painted*, not of the DOM — weaker than the module's original rule, and the module header says so rather than overclaiming. The remaining safeguard is the one the design already had: the dialog shows the captured image and will not upload one the author hasn't looked at.

The rest of the publish path was audited for the same class of bug and is clean: `captureDashboard` deep-clones the board on both the `flatten` and `flatten: false` paths, `withPinnedCards` / `foldFavorites` / `foldTaskFields` all clone what they fold in, and `scrubCard` is copy-on-write — so `stripReferences`, which mutates its package in place by design, never reaches live settings.

## Related issue

None — reported directly, with a corrupted note as evidence.

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] `npm run build` passes locally (plus eslint and the full vitest suite, 1451 passing)
- [ ] I've tested this in an actual vault — **not done here**, and worth doing: the suite is `environment: "node"` with no jsdom, so none of this DOM path has automated coverage. Publishing a board carrying a live-preview note card and a jot card is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177mUy37G8SqPX5xnbWk3EF

---
_Generated by [Claude Code](https://claude.ai/code/session_0177mUy37G8SqPX5xnbWk3EF)_