### PR TITLE
chore: cut 3.1.0-beta.5

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "3.1.0-beta.4",
+	"version": "3.1.0-beta.5",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
## What does this PR do?

Cuts `3.1.0-beta.5` from `main`: bumps `manifest-beta.json` only. `manifest.json` (the store-facing stable manifest) is untouched.

The beta line's content since beta.4 is the publish-snapshot fix in [#299](https://github.com/ondreu/Hearth/pull/299) — the snapshot no longer writes its redaction into the page, so publishing a board can no longer edit the notes it photographs. Its changelog entry is already in the `[3.1.0]` section.

`node scripts/verify-manifests.mjs` passes: stable 3.0.0 in versions.json; beta 3.1.0-beta.5 is a pre-release ahead of stable and matches on all other fields.

## Related issue

None.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

Release chore — none of the above.

## Checklist

- [x] `npm run build` passes locally
- [ ] I've tested this in an actual vault — version-only bump; the code it tags is what #299 shipped, which has not been exercised in a vault yet. That is what the beta soak is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177mUy37G8SqPX5xnbWk3EF

---
_Generated by [Claude Code](https://claude.ai/code/session_0177mUy37G8SqPX5xnbWk3EF)_