### PR TITLE
chore: cut 3.1.0-beta.7

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "3.1.0-beta.6",
+	"version": "3.1.0-beta.7",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",


### PR DESCRIPTION
Cuts the next beta snapshot off `main`.

- `manifest-beta.json` → `3.1.0-beta.7` (version-only; `manifest.json` stays `3.0.0`)
- Picks up the gallery work merged since `3.1.0-beta.6` (#303): republished pictures refresh, publishing waits on the author's read of the redacted snapshot, and "Update" reopens an existing listing seeded with what was published last.
- `CHANGELOG.md` already describes these under `## [3.1.0]`; no changelog change needed.
- `node scripts/verify-manifests.mjs` passes.

Once this is on `main` the `3.1.0-beta.7` tag is cut from it and the release workflow publishes the pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RRBKf86aGS97oML6GmM1X

---
_Generated by [Claude Code](https://claude.ai/code/session_017RRBKf86aGS97oML6GmM1X)_