### PR TITLE
chore: clear what the plugin review flagged, cut 3.1.0-beta.8

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "hearth",
 	"name": "Hearth",
-	"version": "3.1.0-beta.7",
+	"version": "3.1.0-beta.8",
 	"minAppVersion": "1.8.7",
 	"description": "A beautiful, customizable home screen for your vault — search, dashboard, and launcher in one.",
 	"author": "ondreu",

--- a/server/src/entries.ts
+++ b/server/src/entries.ts
@@ -66,6 +66,19 @@ const SUMMARY_COLUMNS = `
 	(e.snapshot IS NOT NULL) AS has_snapshot
 `;
 
+/** The default order: score over age. A board with ten votes today outranks one
+ * with twelve from last month, and one with two hundred still holds its place
+ * for a while. `+ 1` so a board with no votes yet has an age-ordered position
+ * rather than a flat zero, and `+ 2` hours so the first minutes aren't a divide
+ * by ~0. Named rather than only living in the map below, so the fallback in
+ * `listEntries` is the string itself rather than a lookup the types have to be
+ * told cannot miss. */
+const TRENDING_ORDER = `
+		((e.upvotes - e.downvotes) + 1.0) /
+		POWER((julianday('now') - julianday(e.published_at)) * 24.0 + 2.0, 1.5) DESC,
+		e.id DESC
+	`;
+
 /** How each sort orders the listing. Fixed strings chosen by a closed set —
  * nothing from a query string ever reaches the SQL, and a `Map` rather than an
  * object so nothing from one can reach `Object.prototype` either. */
@@ -73,15 +86,7 @@ const ORDER_BY = new Map<string, string>(Object.entries({
 	new: "e.published_at DESC, e.id DESC",
 	top: "(e.upvotes - e.downvotes) DESC, e.downloads DESC, e.id DESC",
 	downloads: "e.downloads DESC, (e.upvotes - e.downvotes) DESC, e.id DESC",
-	// Score over age: a board with ten votes today outranks one with twelve from
-	// last month, and one with two hundred still holds its place for a while.
-	// `+ 1` so a board with no votes yet has an age-ordered position rather than
-	// a flat zero, and `+ 2` hours so the first minutes aren't a divide by ~0.
-	trending: `
-		((e.upvotes - e.downvotes) + 1.0) /
-		POWER((julianday('now') - julianday(e.published_at)) * 24.0 + 2.0, 1.5) DESC,
-		e.id DESC
-	`,
+	trending: TRENDING_ORDER,
 }));
 
 export interface ListParams {
@@ -138,7 +143,7 @@ export function listEntries(db: Db, params: ListParams): unknown {
 	// A Map, not an object: `?sort=toString` would otherwise resolve through
 	// `Object.prototype` and interpolate a function into the SQL, which SQLite
 	// answers with an error and the caller with a 500.
-	const order = ORDER_BY.get(params.sort ?? "") ?? (ORDER_BY.get("trending") as string);
+	const order = ORDER_BY.get(params.sort ?? "") ?? TRENDING_ORDER;
 	const rows = db
 		.prepare(
 			`SELECT ${SUMMARY_COLUMNS} FROM entries e WHERE ${clause}
@@ -157,7 +162,7 @@ export function listEntries(db: Db, params: ListParams): unknown {
 export function entryDetail(db: Db, id: string, viewer: string | null): unknown {
 	const row = db
 		.prepare(`SELECT ${SUMMARY_COLUMNS} FROM entries e WHERE e.id = ? AND e.status = 'live'`)
-		.get(id) as unknown as EntryRow | undefined;
+		.get(id) as EntryRow | undefined;
 	if (!row) throw notFound();
 	// `source_id` is the author's own id for the board — the `meta.id` their
 	// vault stamped into the package — and it is sent back only to them. It is

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -51,7 +51,7 @@ export interface RequestContext {
 	ip: string;
 }
 
-export type Handler = (ctx: RequestContext) => Promise<unknown> | unknown;
+export type Handler = (ctx: RequestContext) => unknown;
 
 /** `METHOD /v1/path/:x` → handler. `:x` matches one segment. */
 export interface Route {

--- a/src/gallery/snapshot.ts
+++ b/src/gallery/snapshot.ts
@@ -368,7 +368,8 @@ function paintLines(region: HTMLElement): HTMLElement | null {
 			bar.style.height = `${rect.height}px`;
 			if (++drawn >= MAX_BARS) break;
 		}
-		range.detach();
+		// No `range.detach()`: it is a no-op in every current engine and is
+		// deprecated. The range is a local that goes with the iteration.
 	}
 
 	if (drawn === 0) {
@@ -449,8 +450,7 @@ function redact(root: HTMLElement): Redaction {
 				// drawn: a soft rounded bar in the theme's own ink reads as
 				// "text lives here", where a row of hard glyphs reads as a
 				// rendering fault.
-				const span = text.ownerDocument.createElement("span");
-				span.className = REDACTED_CLASS;
+				const span = text.ownerDocument.createSpan({ cls: REDACTED_CLASS });
 				text.parentNode?.insertBefore(span, text);
 				span.appendChild(text);
 				wrapped.push(span);
@@ -752,7 +752,7 @@ async function stitch(
 	const height = Math.round(last.y * ratio) + last.image.getSize().height;
 
 	const scale = Math.min(1, MAX_WIDTH / first.width);
-	const canvas = document.createElement("canvas");
+	const canvas = createEl("canvas");
 	canvas.width = Math.max(1, Math.round(first.width * scale));
 	canvas.height = Math.max(1, Math.round(height * scale));
 	const ctx = canvas.getContext("2d");

--- a/styles.css
+++ b/styles.css
@@ -12136,8 +12136,9 @@ body.hearth-dv-resizing {
 
 .hearth-gallery-author.is-clickable {
 	cursor: pointer;
-	text-decoration-line: underline;
-	text-decoration-style: dotted;
+	/* A dotted rule rather than `text-decoration-style`, whose longhands
+	   Obsidian's supported engine only partially covers. Same look. */
+	border-bottom: 1px dotted currentColor;
 }
 
 .hearth-gallery-author.is-clickable:hover {


### PR DESCRIPTION
Acts on the community review of `7f10c0a`, then opens the next beta snapshot.

### Fixed (none of it behavioural)

- `document.createElement` → Obsidian's `createSpan` / `createEl` in `src/gallery/snapshot.ts` (the redaction wrapper, and the stitching canvas).
- Dropped `range.detach()` — a no-op in every current engine and deprecated.
- `.hearth-gallery-author.is-clickable` draws its dotted underline with `border-bottom` rather than `text-decoration-line`/`-style`, whose longhands Obsidian's supported engine only partly covers. Same look.
- `server/src/entries.ts`: the trending order is a named `TRENDING_ORDER` constant, so the fallback in `listEntries` is the string itself rather than a lookup the types had to be told cannot miss; `entryDetail`'s row cast no longer detours through `unknown`.
- `server/src/http.ts`: `Handler` was `Promise<unknown> | unknown`, which is `unknown`.

### Left alone, deliberately

- The `node:` imports, `setInterval` and console output under `server/` are a Node server, not plugin code — no `Platform.isDesktop`, no `window`, and none of it is in the plugin bundle.
- The `!important` rules listed are the snapshot redaction's, and each carries a comment on why it has to outrank a theme. Weakening them risks somebody's notes landing in a published picture.
- The remaining deprecation notices are Hearth's own `@deprecated` tags on `use24Hour` and `commandId` (migration paths that must outlive what they migrate from) and `setWarning`, whose replacement `setDestructive` is `@since 1.13.0` against a declared `minAppVersion` of 1.8.7.

### Release

- `manifest-beta.json` → `3.1.0-beta.8`; `manifest.json` stays `3.0.0`.
- `node scripts/verify-manifests.mjs` passes.

### Verification

`npm run typecheck`, `npm run lint`, `npm run build`, `npm test` (1470 passed, 1 skipped) and the server's `typecheck` all clean. The gallery smoke suite was run against a fresh server before and after these edits: 51 checks pass either way, including "a sort key that isn't one falls back rather than erroring", and its crash point is identical on the unmodified base (the suite trips this sandbox's auth rate limiter partway through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RRBKf86aGS97oML6GmM1X

---
_Generated by [Claude Code](https://claude.ai/code/session_017RRBKf86aGS97oML6GmM1X)_