### PR TITLE
docs: add a complete Hearth user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Think of it as a new-tab dashboard, start page and command launcher in one.
 [Settings & shortcuts](#settings--shortcuts) · [Development](#development) ·
 [Contributing](#contributing)
 
+> **Looking for more detail?** The [Hearth User Guide](docs/user-guide/) is a
+> full, chapter-by-chapter manual: every card, every setting, every integration,
+> plus troubleshooting and a glossary. This README is the tour; the guide is the
+> reference.
+
 ## Quick start
 
 1. Install **Hearth** from Obsidian's community plugin browser — or drop

--- a/docs/user-guide/01-introduction.md
+++ b/docs/user-guide/01-introduction.md
@@ -1,0 +1,118 @@
+# 1. Introduction: what Hearth is
+
+**Hearth** is a community plugin for [Obsidian](https://obsidian.md). It adds a
+view called **Home** that acts as the front page of your vault. Instead of
+opening Obsidian to whatever note you had open last, or to an empty pane, you
+open it to a screen you designed: a search field, and a board of live panels
+showing your notes, your tasks, your calendar, your repository status, the
+weather, and anything else you decide belongs there.
+
+If you have used a browser's new-tab page, a phone's home screen, or a
+dashboarding tool such as Grafana or Notion's gallery view, the idea will be
+familiar. Hearth is all three of those things pointed at one Obsidian vault.
+
+Hearth works on desktop (Windows, macOS, Linux) and on mobile (iOS, Android).
+A small number of features are desktop-only, and this guide says so wherever
+that is the case.
+
+## The three things Hearth does
+
+### 1. It searches
+
+The Home view carries a keyboard-first search field that searches file names,
+file paths, tags, frontmatter properties and — optionally — the text inside your
+notes. A leading `>` turns the same field into a command launcher that can run
+any command in Obsidian's command palette. Below the field sit filter chips for
+the kinds of file your vault actually contains, so you can narrow a search to
+images, canvases, PDFs or notes with one click.
+
+Search is covered in [chapter 4](04-search.md).
+
+### 2. It displays
+
+Below the search field is the **dashboard**: a free-form board of **cards**.
+Hearth ships with more than thirty-five kinds of card. A card can embed a note
+and let you edit it in place, list your tasks as a to-do list or a drag-and-drop
+Kanban board, show a month calendar with your daily notes marked on it, draw a
+year of vault activity as a heatmap, run a Dataview query, render a web page in
+an iframe, show your Git repository's status with working commit and sync
+buttons, paint the sky as it currently looks over a place you pick, or host
+another plugin's entire side panel.
+
+Cards are covered in chapters [7](07-cards-notes-and-files.md) through
+[10](10-cards-integrations.md).
+
+### 3. It launches
+
+Hearth's **Links / launchpad** and **Commands** cards turn any note, folder,
+URL or Obsidian command into a button on a grid. The **New note from template**
+card turns each of your Templater templates into a button that creates a note
+in a folder and under a filename pattern you choose. On mobile there is a
+dedicated action bar of buttons under the search field. The result is a
+launcher: the twenty things you do most often, one tap each.
+
+## Design principles worth knowing before you start
+
+Understanding these five ideas will save you a lot of hunting.
+
+**Cards are configured on the board, not in the settings window.** The plugin
+settings page holds vault-wide defaults. Everything about an individual card —
+what it shows, how big it is, what colour it is — is edited by pressing
+**Arrange** in the Home view and then opening that card's own settings. The
+settings page says so explicitly under *Settings → Hearth → Dashboard → Cards*.
+
+**Almost everything cascades in three levels.** A visual property such as card
+opacity has a vault-wide default, an optional per-dashboard override, and an
+optional per-card override. The most specific level that has an opinion wins.
+Where a control can defer, it offers an explicit *Use global default* choice
+rather than a blank, so you can always tell whether a board is following the
+vault or overriding it.
+
+**Nothing reaches the network unless a card asks it to.** Hearth has no
+telemetry, no account and no phone-home. The only outbound requests it makes are
+the ones a card you added needs — a weather forecast, an RSS feed, a calendar
+subscription, a Jira query, an image whose address you typed. A single switch,
+*Settings → Hearth → Behaviour → Disable external calls*, silences all of them
+at once. See [chapter 17](17-privacy-and-network.md).
+
+**Hearth works through other plugins rather than around them.** Where Hearth
+integrates with another plugin, it uses that plugin's own machinery. Git commits
+go through the Git plugin's task queue, so your remote, credentials and
+commit-message template apply unchanged. Kanban writes are made in the Kanban
+plugin's own format, so the note stays editable in Kanban. Periodic notes are
+resolved and created by Periodic Notes itself. Templater does the templating.
+This means Hearth does not become a second, disagreeing source of truth.
+
+**Your layout is never rewritten behind your back.** When the board is too
+narrow for its free-form layout — on a phone, or in a narrow split pane on the
+desktop — Hearth reflows it into a single column for display only. The stored
+layout is untouched and returns at full width.
+
+## What Hearth is not
+
+- It is not a note editor. It embeds Obsidian's editor where editing makes sense
+  (an embedded note card can be edited in place, in raw Markdown or in Live
+  Preview), but Hearth does not implement editing of its own.
+- It is not a task manager. Its Tasks card reads and writes Markdown checkboxes,
+  TaskNotes task notes and Kanban board notes; the rules about what a task *is*
+  stay with those systems.
+- It is not a sync service. Everything Hearth stores lives in your vault's
+  plugin data, and travels with whatever sync you already use.
+- It is not a theme. Hearth draws its own surfaces and honours your theme's
+  colours; it does not restyle the rest of Obsidian.
+
+## A note on how Hearth is built
+
+Hearth's README states plainly that the plugin was created using AI. Every pull
+request is tested in a testing vault by a human before merging, and every
+release is beta tested in a testing vault by a human before being promoted to
+stable. Hearth is MIT-licensed, and the full source is in the repository.
+
+## Where to go next
+
+If Hearth is not installed yet, or you have just installed it and the setup
+wizard is offering to build you a dashboard, read
+[chapter 2, Installing Hearth and your first run](02-getting-started.md).
+
+If Hearth is already open in front of you and you want to know what you are
+looking at, read [chapter 3, The anatomy of the Home view](03-the-home-view.md).

--- a/docs/user-guide/02-getting-started.md
+++ b/docs/user-guide/02-getting-started.md
@@ -1,0 +1,182 @@
+# 2. Installing Hearth and your first run
+
+This chapter covers getting the Hearth plugin into an Obsidian vault, what
+happens the first time it loads, and how to use the setup wizard that builds
+your first dashboard.
+
+## Installing Hearth
+
+### From Obsidian's community plugin browser (recommended)
+
+1. In Obsidian, open **Settings → Community plugins**.
+2. If restricted mode is on, turn it off.
+3. Choose **Browse**, search for **Hearth**, and install it.
+4. Enable it.
+
+Hearth requires Obsidian **1.8.7** or newer. It is not desktop-only: it runs on
+Obsidian for iOS and Android as well.
+
+### Manually
+
+Download `main.js`, `manifest.json` and `styles.css` from a release, place all
+three in the folder `<your vault>/.obsidian/plugins/hearth/`, then enable
+**Hearth** under **Settings → Community plugins**. If Obsidian is already
+running, use the reload-plugins button or restart the app.
+
+### Beta releases
+
+Hearth publishes beta builds alongside stable ones. Betas can be installed with
+the BRAT community plugin, pointed at the `ondreu/Hearth` repository. Betas are
+tested in a real vault by a human before release but are, by definition, ahead
+of the stable line.
+
+## What happens the first time Hearth loads
+
+On a fresh install Hearth does three things:
+
+1. It registers the **Home** view, a ribbon icon (the Hearth crystal by
+   default), and a set of commands including *Open home dashboard*.
+2. It sets itself to open on startup and to replace empty new tabs. Both are
+   ordinary settings you can turn off — see [chapter 15](15-settings-reference.md).
+3. It offers to run the **setup wizard**, which builds your first dashboard
+   from a handful of questions.
+
+Vaults that had Hearth installed before the wizard existed are marked as already
+set up, so upgrading never offers to rebuild a dashboard you already have.
+
+## Opening Hearth
+
+There are four ways to open the Home view:
+
+- Click the **Hearth crystal** icon in the left ribbon.
+- Run the command **Open home dashboard** from the command palette.
+- Open a new empty tab, if *Replace new tabs* is on (it is, by default).
+- Start Obsidian, if *Open on startup* is on (it is, by default).
+
+You can bind a hotkey to *Open home dashboard*, and to several other Hearth
+commands, under **Settings → Hotkeys**. The full list of bindable commands is in
+[chapter 15](15-settings-reference.md).
+
+## The setup wizard
+
+The wizard exists so that you are not dropped onto a blank grid. It asks about
+you and about your vault, then lays out a board from the answers.
+
+You can run it at any later time from **Settings → Hearth → About → Build a
+dashboard**, or with the command **Set up Hearth**.
+
+### The six steps
+
+**Step 1 — Welcome.** Explains what the wizard will do and lists any supported
+plugins it has already detected in your vault. If it finds none, that is fine:
+Hearth works entirely on its own.
+
+**Step 2 — Your vault.** Names the board. You set the *Title* shown large across
+the top, whether the title is shown at all, the *Title icon* beside it (an
+emoji, a couple of characters, a Lucide icon id, a vault image path, or an image
+URL — leave it empty for the Hearth crystal), whether the title and/or icon
+should follow your theme's accent colour, and whether the search bar is shown.
+
+**Step 3 — Look.** Chooses a card surface and a background.
+
+The three card surfaces are *Frosted* (translucent cards over a soft blur of the
+background), *Solid* (opaque panels, easiest to read over a busy photograph) and
+*Minimal* (no card surface at all, content floating on the background).
+
+The four backgrounds are *Hearth's wallpaper* (the image that ships with the
+plugin), *Live sky* (a painted sky drawn from real weather over a place you
+pick, or one condition pinned and kept), *A flat colour* (the lightest option
+there is), and *None* (your theme's own background, untouched).
+
+You also choose whether the background sits behind everything or is worn as a
+*banner* strip across the top of the board, and whether spacing is compact.
+
+**Step 4 — What for.** Pick as many purposes as apply. Each one adds cards:
+
+| Purpose | What it adds |
+| --- | --- |
+| Daily notes & journaling | Today's note front and centre, with a calendar to move between days |
+| Tasks & to-dos | A task list, read from your checkboxes or from a task plugin |
+| Planning & calendar | A full month/week/day calendar, including any subscribed feeds |
+| Finding my notes | What you touched recently, plus a shelf of favourites |
+| Quick capture & launching | Tiles for the notes and commands you reach for constantly |
+| Vault statistics | How big the vault is and how active you have been |
+| Reading & feeds | An RSS card for the sites you follow |
+| A bit of life | Weather, and a small pet that lives on your board |
+
+A running count tells you how many cards the board is up to.
+
+**Step 5 — Integrations.** Hearth lists the supported plugins it found installed
+and enabled, each with the single thing accepting it will do:
+
+| Plugin found | What Hearth does with it |
+| --- | --- |
+| TaskNotes | Adds a Tasks card on the TaskNotes source, using TaskNotes' own field names and completed statuses |
+| Kanban | Adds a Tasks card showing your board as draggable columns |
+| Dataview | Adds a Dataview card, seeded with an editable query |
+| Datacore | Adds a Datacore card ready for a query |
+| Templater | Adds a launchpad with one button per template you already have |
+| Git | Adds a Git card with status, commit and sync |
+| Operon | Adds an Operon tasks card (desktop only; Operon still has to approve Hearth separately) |
+| Bases | Embeds a `.base` file from your vault |
+| Daily notes | Adds a card showing today's daily note, editable in place |
+| Bookmarks | Adds a card listing your bookmarks |
+
+The TaskNotes case is worth understanding. TaskNotes lets its users rename its
+frontmatter fields and define their own statuses, so there is no fixed set of
+names Hearth could assume. The wizard reads the names TaskNotes is actually
+configured with — the status field, the due field, the priority field, and which
+statuses count as done — and writes them onto the Tasks card it creates. A vault
+that renamed `due` to `deadline` therefore gets a Tasks card that works on its
+first render. The wizard shows you the values it read before it uses them.
+
+Nothing is installed, enabled or changed in the other plugin. The wizard only
+adds a card to the board it is building.
+
+**Step 6 — Finish.** Shows a preview: a scale drawing of the board, plus a list
+of every card with the reason it is there ("Daily notes is enabled", "Reading &
+feeds", "Templater templates were found"). You name the dashboard, and choose
+whether it replaces the board you are on or is added as a new one.
+
+Nothing is written to your vault until you press **Build my dashboard**.
+
+### What the wizard writes, and what it never touches
+
+This distinction matters if you already have Hearth set up the way you like it.
+
+Everything the wizard sets lands as a **per-board override on the one dashboard
+it builds**: the title, the title icon, the accent colour target, the card
+surface, the spacing, and the background. The TaskNotes field mapping lands on
+the Tasks card itself. Your vault-wide settings, and every other dashboard you
+have, come out of a setup run exactly as they went in.
+
+That is also why the wizard no longer asks about things that can only be
+vault-wide — whether Hearth opens on startup, where notes open, which search
+engine to use, whose file icons to show. Those live in **Settings → Hearth**,
+one toggle each, and apply everywhere by design.
+
+When you run the wizard again later from *Settings → Hearth → About*, it
+**always** adds a new dashboard. Every board you already have is left alone;
+nothing is replaced or removed.
+
+### If you skip the wizard
+
+Skipping is a supported choice. You get Hearth's starter dashboard, and you add
+cards yourself with **Arrange → Add card**. See
+[chapter 6](06-arranging-cards.md).
+
+## What to do immediately after setup
+
+The wizard's own closing advice is worth repeating, because it is accurate:
+the board it built is a starting point, not a preset. Hearth is built above all
+to be customised, and the wizard touches only a fraction of it.
+
+Three things to try first:
+
+1. **Press Arrange** (top-right of the board). Drag a card. Resize it from a
+   corner. Open a card's settings with its gear button. Add a card you did not
+   ask the wizard for.
+2. **Open the dashboard switcher** (top-left) and press **+** to make a second
+   board. Give it an icon. Bind *Switch to dashboard 2* to a hotkey.
+3. **Open Settings → Hearth** and read down the eight categories. There is a
+   great deal in there that the wizard never asked about.

--- a/docs/user-guide/03-the-home-view.md
+++ b/docs/user-guide/03-the-home-view.md
@@ -1,0 +1,184 @@
+# 3. The anatomy of the Home view
+
+This chapter names every part of the Hearth Home view, so that the rest of this
+guide can refer to them without ambiguity. Read it once and the vocabulary in
+the other chapters will be obvious.
+
+The Home view is an ordinary Obsidian view. It lives in a tab, it can be split
+and moved like any other tab, and Obsidian's own tab header sits above it
+carrying the Hearth crystal (or a Lucide icon of your choosing) and the view
+name, *Home*.
+
+Inside the tab, from top to bottom:
+
+## 1. The dashboard switcher (top-left)
+
+A strip of small buttons, `[1] [2] [3] … [+]`. Each button is one dashboard.
+Clicking a button switches the board. The `+` button creates a new dashboard.
+
+Each button shows the dashboard's number by default. You can give a dashboard an
+emoji or a couple of characters instead, or a Lucide icon, which takes
+precedence over the emoji. You can drag the buttons to reorder your dashboards.
+Right-clicking a button opens a menu with *Dashboard settings…*, *Duplicate*,
+*Export dashboard…*, *Import dashboard…* and *Delete*.
+
+The switcher can be set to stay always visible, or to fade in only when you move
+the pointer near it. That is *Settings → Hearth → Dashboard → Dashboard switcher
+visibility* vault-wide, and *Dashboard settings → Layout → Dashboard switcher*
+per board.
+
+Dashboards are covered in [chapter 5](05-dashboards.md).
+
+## 2. The Arrange button (top-right)
+
+The button that puts the board into **arrange mode** — Hearth's edit mode. In
+arrange mode the button becomes *Done arranging*, and a toolbar appears carrying
+*Add card*, *Dashboard settings*, a titles toggle, a card-headers toggle, and
+*Preview at phone width*.
+
+Like the switcher, the Arrange button can be always visible or revealed on
+hover, vault-wide or per board.
+
+Arrange mode is covered in [chapter 6](06-arranging-cards.md).
+
+## 3. The Gallery button (in the arrange toolbar)
+
+While the board is being arranged, a **Gallery** button sits beside *Add card*.
+It opens the **dashboard gallery**, where dashboards other people have published
+can be browsed, rated, commented on and installed in one click, and where you
+can publish your own. It is placed there deliberately: adding one card you place
+yourself, and installing a whole board somebody else has already arranged, are
+the same question at two scales.
+
+The button only appears when a gallery address is configured. Clearing that
+address under *Settings → Hearth → Backup → Dashboard gallery* turns the gallery
+off entirely, and nothing is fetched until you open it.
+
+The gallery is covered in [chapter 16](16-sharing-and-gallery.md).
+
+## 4. The title block
+
+A large heading with an optional mark beside it. The default title text is
+`Obsidian`; the default mark is the Hearth crystal.
+
+The mark accepts four different kinds of value, and works out which you meant:
+
+- a **Lucide icon id** such as `home`, `star` or `layout-dashboard` (there is a
+  search button that browses the whole Lucide set, so you do not have to
+  remember ids),
+- an **emoji** or a couple of characters,
+- the **vault path of an image**, such as `Attachments/logo.png` (there is a
+  picker button for this too),
+- the **URL of an image on the web**.
+
+The title block can be hidden entirely, aligned left, centre or right, resized,
+given a top margin, and set to draw the icon and/or the title text in your
+theme's icon colour instead of the default purple crystal and normal text. Every
+one of those is a vault-wide setting with a per-dashboard override.
+
+## 5. The search section
+
+The search field, the row of file-type filter chips beneath it, and the results
+dropdown that appears as you type. Optionally, an action button sits beside the
+field — by default *New note*, and optionally *Search online* instead.
+
+The whole section can be hidden vault-wide (*Settings → Hearth → Appearance →
+Show search section*) and each dashboard can follow that default or override it
+to show or hide the section on that board alone.
+
+Search is covered in [chapter 4](04-search.md).
+
+## 6. The dashboard
+
+The board of cards. This is the bulk of the view.
+
+### Cards
+
+A **card** is one panel on the board. Every card has:
+
+- a **kind** (the type of thing it shows — Tasks, Clock, Weather, and so on),
+- an optional **title**, shown in a header row at the top of the card; a card
+  with an empty title is drawn headerless,
+- a **position and size** on the board,
+- optional per-card style overrides (accent colour, background tint, opacity,
+  blur, border width),
+- optional per-card behaviour when the board is stacked into one column on a
+  narrow screen.
+
+Cards are live. Embedded and editable notes follow vault events without losing
+your cursor, data cards redraw when the vault or its metadata changes, and web,
+RSS, calendar-subscription and Jira cards refresh on their own timers.
+
+### The board's geometry
+
+The board is **free-form**, not a strict row-and-column grid. Cards are stored
+as a position and a size, where width is a fraction of the board's width and
+height is in pixels, and they can sit anywhere. When you drag a card it snaps
+magnetically to the edges and centres of its neighbours and of the board itself
+(the snap threshold is 8 pixels). Two cards snapped together share a border,
+which drops out so that the pair reads as one continuous tile — this is called
+**edge-merging**, and merged cards blur as one seamless sheet.
+
+Because the board is free-form there is no column count to configure. Hearth
+keeps an internal column count of 12 and a seed row height of 92 pixels, used
+only when it has to place a newly added card for you.
+
+### Fit to page
+
+By default the board is set to **fit to page**: it stays on one screen and does
+not scroll. Turning that off lets the board scroll. This is a vault-wide setting
+with a per-board override. A dashboard that hosts a plugin view always fits the
+pane, because the hosted view fills it and scrolls itself.
+
+## 7. The background
+
+Behind everything sits the background: nothing, a solid colour, an image from
+your vault, an image from a URL, Hearth's own bundled wallpaper, or a **live
+weather sky** — a painted sky that follows the real conditions and time of day
+over a place you pick, or one condition pinned and kept.
+
+The background has an opacity and a blur, and can be worn two ways: filling the
+whole view, or as a **banner** strip across the top of the board with the cards
+below it on your theme's own surface, the way a cover image sits above a note.
+
+Backgrounds are covered in [chapter 11](11-appearance.md).
+
+## Two special kinds of dashboard
+
+Almost everything above describes a **cards dashboard**, the normal kind. There
+are two variations worth knowing about now.
+
+### Plugin view dashboards
+
+A dashboard's *Dashboard type* can be set to **Plugin view**, at which point it
+stops being a grid of cards: the whole board becomes one other plugin's view —
+your RSS reader, a Kanban board, a Canvas, an outline, a specific PDF — at full
+size and fully working, with the dashboard switcher, header and background still
+around it. The board keeps its cards while it is in this mode, and switching it
+back to **Cards** brings them back untouched.
+
+See [chapter 5](05-dashboards.md).
+
+### Mobile mode (search only)
+
+An optional mode, off by default, in which Hearth on phones and tablets hides the
+dashboard entirely and shows only the search field with a row of action buttons
+beneath it. This is for people who want a launcher on their phone and a
+dashboard on their desktop. It has no effect on desktop.
+
+See [chapter 13](13-mobile.md).
+
+## Where each thing is configured
+
+This table is a map of the rest of the guide.
+
+| Part of the view | Configured from |
+| --- | --- |
+| Title, title icon, tab icon, content width | Settings → Hearth → Appearance, with per-board overrides in Dashboard settings → Header |
+| Search field, filter chips, action button | Settings → Hearth → Search, with per-board overrides in Dashboard settings → Header |
+| Background and banner | Settings → Hearth → Appearance → Background, with per-board overrides in Dashboard settings → Background |
+| Grid, spacing, card surface, chrome visibility | Settings → Hearth → Dashboard, with per-board overrides in Dashboard settings → Layout and → Style |
+| One dashboard's name, icon, type, workspace link | Right-click its switcher button → Dashboard settings… |
+| An individual card | Arrange → that card's gear button |
+| Startup, new tabs, where notes open, privacy | Settings → Hearth → Behaviour |
+| The stacked phone layout and the action bar | Settings → Hearth → Mobile, and each card's Layout tab |

--- a/docs/user-guide/04-search.md
+++ b/docs/user-guide/04-search.md
@@ -1,0 +1,204 @@
+# 4. Search: modes, filters and the action button
+
+The **search section** sits under the title in Hearth's Home view. It is
+keyboard-first: focus it, type, and results appear in a dropdown as you go.
+There is also a **Search bar** *card*, which puts the same field anywhere on the
+board — see [chapter 9](09-cards-vault-tools-and-fun.md).
+
+Everything in this chapter refers to Hearth's own search. It is a separate thing
+from Obsidian's built-in search pane, though Hearth can hand a query over to
+that pane when you want the full results.
+
+## The four search modes
+
+Hearth's search field has four modes. You do not switch between them with a
+control: the mode is decided by what you type, which is why the guide calls them
+*transparent* modes.
+
+| What you type | Mode | What it matches |
+| --- | --- | --- |
+| anything else | Fuzzy plus full text | File names, file paths, tags, frontmatter properties, and — optionally — the text inside note bodies |
+| `#something` | Tags | Vault tags, showing which tag matched |
+| `key:value` | Frontmatter | Notes whose property `key` matches `value` |
+| `>something` | Commands | Any registered Obsidian command, run by name |
+
+### Fuzzy plus full-text mode (the default)
+
+With no prefix, Hearth matches file names and paths first, and then — if *Search
+note contents* is on, which it is by default — the text inside your notes. Name
+matches always rank above body matches, so a well-scored fuzzy match on a body
+can never displace a literal match on a file name. Body matches appear after
+name matches, each with a short excerpt showing the matched text in context.
+
+At most 40 results are shown.
+
+### Tag mode
+
+A leading `#` searches your vault's tags. Each result shows which tag matched,
+so a note carrying several tags tells you why it is in the list.
+
+### Frontmatter mode
+
+Typing an identifier followed by a colon — `status:active`, `project:hearth`,
+`type:meeting` — searches frontmatter properties. Hearth recognises this shape
+because a colon is not a legal filename character, so a property query can never
+be confused with a file-name search.
+
+### Command mode
+
+A leading `>` turns the field into a command launcher. Every command registered
+in Obsidian — core, community plugin, or Hearth's own — can be found by name and
+run with Enter. This is the same set of commands as Obsidian's command palette.
+
+## Filter chips
+
+Under the search field is a row of **filter chips** for file types. They are
+**auto-detected**: a chip only appears if your vault actually contains that kind
+of file. The possible groups are Folders, Notes, Excalidraw, Canvas, Bases,
+Images, Videos, Audio, PDF, Documents, Sheets, Slides, 3D and Other.
+
+Clicking a chip lists the items of that type. Clicking it again clears the
+filter.
+
+You can hide chips you never use. Vault-wide, that is **Settings → Hearth →
+Search → Search filters**. Per dashboard, *Dashboard settings → Header → Filter
+chips* lets one board show a different set from the vault-wide choice; a board
+that has not been given its own set follows the vault, and the control tells you
+how many the vault currently hides.
+
+## Recent files
+
+Focusing the search field while it is empty lists the files you opened most
+recently through Hearth's search. This history holds the last six entries and
+lives in the vault's local storage rather than in Hearth's settings, so it never
+appears in the settings UI and is never included in an export.
+
+## Keyboard control
+
+Inside the search field:
+
+- `↑` and `↓` move the selection through the results.
+- `Enter` opens the selected result, or runs the selected command in command
+  mode.
+- `Esc` dismisses the results.
+- `Ctrl`-click (or `Cmd`-click on macOS) on a result always opens it in a new
+  tab, whatever your *Open notes in* setting says.
+
+Optionally, Hearth can place the cursor in the search field whenever a Home view
+opens, so you can start typing straight away: **Settings → Hearth → Behaviour →
+Startup & tabs → Focus search on open**. This is desktop-only.
+
+## Where a search result opens
+
+Where a clicked result goes is governed by **Settings → Hearth → Behaviour →
+Opening notes**. There is a general *Open notes in* choice (a new tab, the
+current tab replacing Hearth, a split pane, or a new window) and a per-source
+override for *Search results* specifically, which may also be set to follow the
+general choice. See [chapter 15](15-settings-reference.md).
+
+Right-clicking a result offers **Reveal in file explorer**, which uses
+Obsidian's core File explorer plugin.
+
+## The action button beside the field
+
+By default a **New note** button sits beside the search field. It has two
+possible jobs, chosen with *Search-bar button* under **Settings → Hearth →
+Search → Search bar**:
+
+- **New note** — creates a note.
+- **Search online** — sends whatever is typed in the search field to a web
+  search engine.
+
+The button can also be hidden entirely (*Show "New note" button*), and each
+dashboard can override whether the button is shown, what it does, and what its
+label says.
+
+### Configuring what "New note" makes
+
+One set of settings drives the button beside the search bar, the button on a
+Search bar card, and Hearth's *Create new note (default location)* command.
+They are under **Settings → Hearth → Search → Search bar**, in a group headed
+*The "New note" button*:
+
+| Setting | Meaning |
+| --- | --- |
+| *Button text* | The text on the button. Empty means "New note". |
+| *Template* | Make the note from a Templater template instead of a blank one. Requires the Templater community plugin. Templater does the templating, so your user scripts, `tp.system.prompt()` dialogs and cursor placement behave exactly as they do from Templater's own command. |
+| *Location* | The folder the new note goes in, created if it does not exist. "Default location" means wherever Obsidian puts new notes. |
+| *Filename* | The name, without the extension. Supports `{{date}}`, `{{date:FMT}}`, `{{time}}`, `{{time:FMT}}` and `{{prompt}}`. `{{prompt}}` asks you for the name on each click. Empty means "Untitled". |
+
+If the button is set to use a Templater template but Templater is not enabled,
+Hearth makes a blank note and tells you why.
+
+### Searching the web
+
+When the button is set to *Search online*, pressing it opens your chosen engine
+with the current contents of the search field.
+
+The engine the button itself uses is *Online search engine* under **Settings →
+Hearth → Search → Search bar**. The available engines are **DuckDuckGo** (the
+default), **DuckDuckGo without AI**, **Brave**, **Kagi**, **Google**,
+**Mojeek**, **Ecosia** and **Qwant**.
+
+The button also carries a small arrow. Clicking the arrow lets you search with
+any of the other engines for that one query, without changing which engine the
+button uses from then on.
+
+Web search opens a browser; it does not send anything from your vault other than
+the text you typed.
+
+## Using Omnisearch as the engine
+
+Hearth can hand the whole job over to the
+[Omnisearch](https://github.com/scambier/obsidian-omnisearch) community plugin,
+which maintains its own fuzzy full-text index.
+
+Set *Search engine* to **Omnisearch** under **Settings → Hearth → Search →
+Search bar**. Omnisearch must be installed and enabled; if it is not, Hearth
+says so and offers a link to it in Obsidian's community plugin browser. The
+choice only sticks while Omnisearch is enabled — disable the plugin and Hearth
+falls back to its built-in engine rather than showing you an empty search.
+
+Tag, frontmatter and command modes are Hearth's own and continue to work the
+same way; it is the plain-text query that is handed to Omnisearch.
+
+## File icons in results
+
+If you use the [Iconic](https://obsidian.md/plugins?id=iconic) or
+[Iconize](https://obsidian.md/plugins?id=obsidian-icon-folder) community plugins
+to give individual files their own icons, Hearth shows those icons in search
+results, and in the Recent, Favorites and saved-query cards.
+
+This is on by default and lives at **Settings → Hearth → Integrations → File
+icons / Iconic / Iconize**. Lucide icons and emoji are shown; a file using an
+icon from a downloaded icon pack keeps Hearth's own file-type icon. If you have
+renamed Iconize's frontmatter property, tell Hearth the new name there — Iconize's
+own default is `icon`.
+
+Turning the setting off makes every file show Hearth's file-type icon. Leaving it
+on in a vault with neither plugin installed changes nothing, and it starts
+working the moment you install one.
+
+## Hiding the search section
+
+The search section can be turned off entirely.
+
+- Vault-wide: **Settings → Hearth → Appearance → Home → Show search section**.
+- Per dashboard: *Dashboard settings → Header → Search visibility*, which can
+  follow the vault-wide default or override it to show or hide on that board.
+
+A board that hosts a plugin view starts with the search hidden, because the
+hosted view takes the whole pane; that is a per-board default you can switch
+back on.
+
+## Per-dashboard search options
+
+Beyond visibility, each dashboard can set:
+
+- its own *Search placeholder* (the greyed-out text in the empty field),
+- whether the button beside the field is shown, what it does, and its label,
+- which filter chips it offers.
+
+All of these are on the **Header** tab of that dashboard's settings, and each
+follows the vault-wide value until the board says otherwise. They travel with
+the board when you export it.

--- a/docs/user-guide/05-dashboards.md
+++ b/docs/user-guide/05-dashboards.md
@@ -1,0 +1,200 @@
+# 5. Dashboards: creating, switching and configuring boards
+
+A **dashboard** (also called a **board** in this guide) is one arrangement of
+cards, with its own name, its own icon in the switcher, and its own optional
+overrides for almost every visual setting Hearth has. A vault can hold as many
+dashboards as you like, and switching between them is instant.
+
+This chapter covers the dashboards themselves. Adding and arranging the cards
+*on* a dashboard is [chapter 6](06-arranging-cards.md).
+
+## The dashboard switcher
+
+The switcher is the strip of small buttons in the top-left of the Home view:
+`[1] [2] [3] … [+]`.
+
+| Action | How |
+| --- | --- |
+| Switch to a board | Click its button |
+| Create a board | Click `+` |
+| Reorder boards | Drag a button |
+| Open a board's settings | Right-click its button → *Dashboard settings…* |
+| Duplicate a board | Right-click → *Duplicate* |
+| Export a board to a file | Right-click → *Export dashboard…* |
+| Import a board from a file | Right-click → *Import dashboard…* |
+| Delete a board | Right-click → *Delete* (asks for confirmation and names how many cards go with it; this cannot be undone) |
+
+A new dashboard is named *Dashboard N* by default. A duplicate is named
+*<original> copy*.
+
+## Switching with the keyboard
+
+Several commands are bindable under **Settings → Hotkeys**:
+
+- **Switch to dashboard 1 … 9** — changes the active board.
+- **Open dashboard 1 … 9** — changes the active board *and* brings Hearth up.
+  This is the useful one: it means jumping to a particular board from anywhere
+  in the vault is a single shortcut, whether or not Hearth is currently in
+  front.
+- **Next dashboard** and **Previous dashboard**.
+- **Open home dashboard** — opens Hearth on whichever board is active.
+
+## Dashboard settings
+
+Open with a right-click on the switcher button, or with *Dashboard settings* in
+the Arrange toolbar. The dialog has up to six tabs.
+
+### General tab
+
+| Setting | Meaning |
+| --- | --- |
+| *Name* | What this board is called in the switcher and in exports |
+| *Dashboard type* | **Cards** (the normal board) or **Plugin view** (see below) |
+| *Switcher icon* | An emoji or short text on the switcher button. Empty shows the number |
+| *Switcher Lucide icon* | A Lucide icon such as `home`, `star`, `layout-dashboard`. Takes precedence over the emoji |
+| *Linked workspace* | Automatically switch to this dashboard when the named Obsidian workspace loads. Requires the core Workspaces plugin |
+| *Default on mobile* | Open this dashboard when Hearth loads on a phone or tablet. Only one board can hold this; enabling it clears it on the others |
+
+### Header tab
+
+Everything about the title block and the search row on this one board. Each
+control offers an explicit *Use global default* option, and tells you what the
+global default currently is.
+
+- *Title visibility*, *Title text*, *Title icon*.
+- *Title alignment* (default centre, left, centre, right), *Title size*, *Title
+  icon size*, *Title top margin*, *Spacing below title/header*.
+- *Accent colour on the title* — which parts of this board's brand mark follow
+  the theme's icon colour: neither, the icon, the title, or both. Hearth's tab
+  and ribbon icons keep following the vault-wide setting.
+- *Search visibility*, *Search placeholder*.
+- *Button beside search* (shown or hidden), *What that button does* (new note or
+  search online), *Button label*.
+- *Filter chips* — which file-type chips this board offers.
+
+### Layout tab
+
+- *Content width* and *Full width* — override the vault-wide width ceiling.
+- *Fit to page* — override whether this board scrolls.
+- *Compact spacing* — override the vault-wide spacing.
+- *Stack when narrow* — whether this board reflows into one full-width column
+  when the pane is too narrow for the free-form layout, or keeps the scaled
+  layout.
+- *Arrange button* and *Dashboard switcher* — always visible, or fade in on
+  hover, on this board.
+
+### Style tab
+
+Per-board overrides of the card surface: *Card opacity*, *Card blur*, *Card
+corner radius*, *Card border*.
+
+### Background tab
+
+A per-board override of the whole background: type (none, Hearth default, solid
+colour, vault image, image URL, live weather sky), the value, *Opacity*,
+*Blur*, *Background layout* (full or banner), *Banner height*, *Fade the lower
+edge*, *Full width*, and *Animate the sky*. Choosing *Follow the global setting*
+drops the override.
+
+Backgrounds in detail are [chapter 11](11-appearance.md).
+
+### Plugin view tab
+
+Only relevant when *Dashboard type* is **Plugin view**. See the next section.
+
+## Plugin view dashboards
+
+Setting a board's *Dashboard type* to **Plugin view** stops it being a grid of
+cards. The whole board becomes one other plugin's view — your RSS reader, a
+Kanban board, a Canvas, the outline — at full size and fully working, with the
+switcher, header and background still around it.
+
+The point is reachability. The reader you check twenty times a day becomes one
+click from your task board, instead of a tab you have to find your way back to.
+
+### Choosing the view
+
+On the board's **Plugin view** tab, *View* lists every view the application has
+registered right now, so it follows which plugins are enabled. Obsidian's own
+document surfaces are in the list too — Markdown, PDF, image, audio, video —
+which means a specific note, drawing or PDF can *be* a dashboard.
+
+Beside the view picker is a *File* picker. Some views need a file (a PDF viewer
+has to be told which PDF); others are happy without one and will say so. A full
+board has the room for both pickers side by side.
+
+### The other plugin-view settings
+
+| Setting | Meaning |
+| --- | --- |
+| *Hide the view's own header* | Drops the hosted view's breadcrumbs, back/forward arrows and kebab menu. Its own toolbars and tabs are untouched |
+| *Keep running in the background* | Stay loaded while another dashboard is showing, so coming back is instant instead of a reload. Turn it off for a heavy plugin you would rather not leave running |
+| *Let the view take focus (experimental)* | Make this the active pane while you work in it, so the plugin's own commands and hotkeys find it. Obsidian also opens notes into the active pane, so a link you click may replace the view until you switch boards |
+
+### Edge to edge
+
+A plugin board gives the hosted view the whole pane: no page gutter, no card
+frame, no toolbar row. The only chrome left is the switcher strip across the top
+with the board's settings gear at the end of it. The title and search start
+hidden for the same reason. All of that is an ordinary per-board override you can
+switch back on.
+
+A plugin board also always fits the pane rather than scrolling, because the
+hosted view fills it and scrolls itself.
+
+### Switching is instant
+
+A plugin board stays loaded while another board is showing rather than reloading
+from cold. Up to three boards are kept warm at a time, and a heavy plugin can opt
+out per board with *Keep running in the background*.
+
+### Cards are kept
+
+Turning a board into a plugin view does not throw away its cards. Switch the
+*Dashboard type* back to **Cards** and they come back untouched.
+
+### The performance cost
+
+A hosted view is the plugin doing its full job, not a preview of it. It costs
+what opening that plugin costs, and it keeps that plugin's own timers, listeners
+and rendering going for as long as the board is open. Views that are slow in
+their own tab are slow here too. Hearth's performance tier cannot slow a hosted
+view down, because the view manages itself.
+
+The same warning applies to the **Plugin view** *card*, which hosts a view
+inside a single card rather than filling a board; see
+[chapter 10](10-cards-integrations.md).
+
+## Pinned cards
+
+A card can be **pinned to all dashboards**. A pinned card appears on every
+board, sharing one definition and one position — edit it on any board and every
+board sees the change. This is set on the card's own settings, under *Pin to all
+dashboards*.
+
+Pinning is the right tool for a clock, a search bar, or a launchpad you want
+present everywhere. It is the wrong tool for anything you want to differ between
+boards; for that, use *Copy to dashboard* on the card instead, which drops an
+independent duplicate at the end of another board.
+
+## How many dashboards should you have?
+
+There is no limit and no cost to an unused board beyond the space it takes in
+your settings file, but there are two costs worth knowing:
+
+- A **plugin view** board with *Keep running in the background* on keeps another
+  plugin loaded. Up to three boards are kept warm at once.
+- Every board's cards are stored in Hearth's plugin data, which syncs with your
+  vault.
+
+A common arrangement is three or four boards: a home board with search and
+launchers, a work board, a planning board with calendars and tasks, and one
+plugin-view board for whatever plugin you live in.
+
+## Picking up changes made on another device
+
+If you sync your vault, Hearth can apply dashboard changes made on another
+device as soon as sync brings them in, rather than at the next Obsidian restart.
+That is *Pick up synced changes* under **Settings → Hearth → Behaviour →
+Startup & tabs**, and it is on by default. Turn it off only if a board reloading
+mid-session gets in your way.

--- a/docs/user-guide/06-arranging-cards.md
+++ b/docs/user-guide/06-arranging-cards.md
@@ -1,0 +1,219 @@
+# 6. Arrange mode: adding, moving, resizing and styling cards
+
+Everything about the cards on a Hearth dashboard is edited from the board
+itself, in **arrange mode**. The plugin settings page holds vault-wide defaults;
+it deliberately does not hold a card editor. *Settings → Hearth → Dashboard*
+says as much in a row of its own: open the Home view, hit Arrange, then use
+*Add card*, *Dashboard settings* and each card's settings button.
+
+## Entering and leaving arrange mode
+
+Press **Arrange** in the top-right corner of the Home view. The button becomes
+**Done arranging**; press it again (or press it in the toolbar) to leave.
+
+The Arrange button can be set to stay always visible, or to fade in only when
+the pointer comes near it. That is *Arrange button visibility* under **Settings
+→ Hearth → Dashboard → Dashboard controls** vault-wide, and *Dashboard settings
+→ Layout → Arrange button* per board.
+
+## The arrange toolbar
+
+While arranging, a toolbar offers:
+
+| Control | What it does |
+| --- | --- |
+| **Add card** | Opens the card picker (below) |
+| **Gallery** | Opens the dashboard gallery, to install a board somebody else has arranged. Only shown when a gallery address is configured — see [chapter 16](16-sharing-and-gallery.md) |
+| **Dashboard settings** | Opens this board's own settings — see [chapter 5](05-dashboards.md) |
+| **Show titles / Hide titles** | Toggles the display of card titles across the board |
+| **Show card headers / Hide card headers** | Toggles the header rows |
+| **Preview at phone width** | Builds and shows the phone layout inside a drawn phone, so you can check the stacked column without a phone — see [chapter 13](13-mobile.md) |
+| **Done arranging** | Leaves arrange mode |
+
+## Adding a card
+
+**Add card** opens a searchable picker. Type to match a card's name or its
+description, or browse the six categories down the left rail:
+
+- **Notes & files** — embedded notes, images, slideshows, canvases, bases,
+  drawings, daily and periodic notes, recent files, favourites, bookmarks.
+- **Planning** — tasks, calendars, mini calendar, clock and greeting.
+- **Vault insight** — saved queries, a search bar, vault statistics, an activity
+  heatmap.
+- **Tools** — launchpads, command buttons, a text scratchpad, a calculator, a
+  web page.
+- **Integrations** — Templater, Dataview, Datacore, Git, Jira, RSS, Weather,
+  Operon, Plugin view.
+- **Fun** — the Pet.
+
+Cards backed by a community plugin are **always listed**, whether or not the
+plugin is installed. A card whose dependency is missing is marked *Needs
+Dataview* (or *Needs Git*, *Needs Operon*, and so on) and carries a one-click
+link that opens that plugin in Obsidian's community plugin browser. You can add
+the card anyway: it shows a prompt until the dependency arrives.
+
+At the bottom of the rail is **Request a card**. It opens a pre-filled GitHub
+issue, or a pre-filled email to the maintainer if you would rather not use
+GitHub. Both are pre-filled with a few prompts and with your Hearth and Obsidian
+version numbers, and you can edit anything before sending.
+
+A newly added card is placed automatically, packed left to right into the first
+free slot.
+
+## Moving and resizing
+
+The board is **free-form**. A card is stored as a position, a width expressed as
+a percentage of the board's width, and a height in pixels. Cards can sit
+anywhere; they are not snapped to a rigid row-and-column grid.
+
+- **Move** — drag the card.
+- **Resize** — drag any edge or any corner.
+- **Snap** — as you drag, the card snaps magnetically to the edges and centres
+  of its neighbours and of the board itself. The snap threshold is 8 pixels, so
+  a deliberate small nudge still overrides it.
+- **Minimum size** — a card cannot be made smaller than 120 pixels wide or 56
+  pixels tall.
+
+If you would rather type the numbers than drag them, every card's settings has a
+**Size** section on its Layout tab: *Width* as a percentage of the board, and
+*Height* in pixels. There is also a *Reset to default size* action.
+
+### Edge-merging
+
+Snap two cards together and their shared border drops out, so the pair reads as
+one continuous tile. Merged cards also blur as one seamless sheet rather than as
+two overlapping panes of glass. This happens automatically when the edges meet;
+there is nothing to switch on.
+
+## Card controls in arrange mode
+
+Each card grows a small set of controls while the board is being arranged:
+
+| Control | What it does |
+| --- | --- |
+| Gear / settings | Opens that card's settings dialog |
+| Remove | Deletes the card from the dashboard, after a confirmation naming it |
+| Expand / collapse | Folds the card down to its title row |
+| Move card up / Move card down | Reorders the card in the stacked column (used in phone preview) |
+| Hide on a narrow board | Leaves this card out when the board stacks into one column |
+
+## The card settings dialog
+
+Every card's settings dialog has the same three tabs.
+
+### Content tab
+
+What this card shows. The contents differ completely from one card kind to the
+next; chapters [7](07-cards-notes-and-files.md) through
+[10](10-cards-integrations.md) document every card's Content tab in detail.
+
+Two controls are common to all cards:
+
+- *Type* — what this card shows. Changing it converts the card in place.
+- *Title* — shown in the card's header. **Leave it empty for a headerless
+  card**, which is how you get a clean, chrome-free panel.
+
+### Style tab
+
+Per-card visual overrides. Each defers to the dashboard's value, and the
+dashboard's value defers to the vault-wide value.
+
+| Setting | Meaning |
+| --- | --- |
+| *Accent* | An accent colour for this card. Clearable |
+| *Background* | A background tint for this card. Clearable |
+| *Card opacity* | Transparency of this card's surface |
+| *Card blur* | Frosted-glass blur behind this card. Requires opacity below 100% to be visible |
+| *Card border* | Border thickness in pixels. 0 removes the border and the line under the title |
+
+### Layout tab
+
+| Section | Meaning |
+| --- | --- |
+| *Size* | Width as a percentage of the board, height in pixels |
+| *On a narrow board* | The four mobile options below |
+| *Pin to all dashboards* | Show this card on every dashboard, sharing one definition and position |
+| *Copy to dashboard* | Add an independent duplicate of this card to the end of another dashboard |
+
+The four *On a narrow board* options control what happens when the board reflows
+into one full-width column:
+
+| Option | Meaning |
+| --- | --- |
+| *Hide* | Leave this card out of the stacked column. For a card that needs width to make sense — a wide table, a board view — hiding beats squeezing |
+| *Start collapsed* | Show only the card's title row, and build the card when it is tapped open. A card nobody opens costs one row and runs nothing |
+| *Height* | Height in pixels when stacked. Left empty, the card keeps its own height, capped so that one tall card cannot fill the screen |
+| *Position* | Where this card comes in the stack, counting from 0. Left empty, it follows the order the board reads in: top to bottom, left to right |
+
+## Pinning versus copying
+
+These two are easy to confuse.
+
+**Pin to all dashboards** creates *one* card that appears on every board, at the
+same position, sharing one definition. Editing it anywhere edits it everywhere.
+Use this for a clock, a search bar, or a launchpad you always want present.
+
+**Copy to dashboard** creates a *separate, independent* duplicate at the end of
+another board. The two diverge freely from that point on. Use this when you want
+a similar card on two boards but expect to tune each.
+
+## Cards, dashboards and the settings cascade
+
+Three visual properties — opacity, blur, border width — plus corner radius exist
+at three levels:
+
+1. **Vault-wide**, at *Settings → Hearth → Dashboard → Card surface*.
+2. **Per dashboard**, at *Dashboard settings → Style*.
+3. **Per card**, at that card's *Style* tab.
+
+The most specific level that has an opinion wins. Every control at levels 2 and
+3 offers an explicit *Use dashboard default* or *Use global default* choice and
+shows you what that default currently is, so you can always tell whether you are
+overriding something.
+
+## Card sizing on tile cards
+
+Three cards — **Links / launchpad**, **Commands** and **New note from
+template** — are grids of buttons rather than single panels, and they have their
+own sizing model on top of the card's.
+
+*Button sizing* offers two styles:
+
+- **Fill the card** — every button is visible however big the card is, growing
+  and shrinking with it. Buttons stop shrinking once they would be too small to
+  use, and a card too small for them at that point scrolls.
+- **Fixed size (legacy)** — buttons keep a fixed pixel size, and a card too
+  small for them all scrolls. Cards created before the *Fill the card* style
+  existed stay on this until you switch them.
+
+Each style keeps its own sizes, so switching back restores what you had.
+
+With *Fill the card*:
+
+- *Buttons across* sets how many buttons wide the card is, and so how wide one
+  button is. The rows share the card's height between them, so a shorter card
+  means shorter buttons rather than hidden ones.
+- *Minimum button size* sets how small a whole button may get, in pixels, before
+  the card scrolls instead of shrinking them further. It is low by default so
+  that buttons fit rather than a scrollbar appearing; raise it to keep buttons
+  comfortable on a card you often make small.
+- An individual button can be made two or three cells wide or tall by dragging
+  its bottom-right corner in arrange mode. The tile grid takes half steps in
+  both directions, so a button can also be half a cell.
+
+All three tile cards also offer *Auto-shift tiles (beta)*: when it is on, tiles
+shove each other aside as one is dragged, the way phone widgets do. It is off by
+default, which means tiles are pure free-form and may overlap.
+
+## Things that live on the board rather than in settings
+
+To summarise, because it is the single most common source of "where is that
+setting?":
+
+| You are looking for | It is here |
+| --- | --- |
+| What a card shows | Arrange → the card's gear |
+| A card's colour, opacity, blur, border | Arrange → the card's gear → Style |
+| A card's size, mobile behaviour, pinning | Arrange → the card's gear → Layout |
+| This board's name, icon, type, background | Arrange → Dashboard settings, or right-click its switcher button |
+| Vault-wide defaults for all of the above | Settings → Hearth |

--- a/docs/user-guide/07-cards-notes-and-files.md
+++ b/docs/user-guide/07-cards-notes-and-files.md
@@ -1,0 +1,269 @@
+# 7. Cards for notes and files
+
+This chapter documents the Hearth cards in the **Notes & files** category of the
+Add card picker. Every card is added the same way — press **Arrange** in the
+Home view, press **Add card**, and pick it — and every card is configured from
+its own gear button while arranging. See [chapter 6](06-arranging-cards.md) for
+the mechanics.
+
+The eleven cards in this category are: Embedded note, Daily note, Periodic note,
+Embedded image, Slideshow, Embedded canvas, Excalidraw drawing, Embedded base,
+Recent files, Favorites and Bookmarks.
+
+---
+
+## Embedded note
+
+**What it shows:** any note in your vault, rendered live by Obsidian on the
+dashboard.
+
+**Requires:** nothing.
+
+This is the workhorse card. The note is rendered by Obsidian itself, so
+everything in it behaves as it does in a normal pane, and the card follows vault
+events without losing your cursor.
+
+### Options
+
+| Setting | Meaning |
+| --- | --- |
+| *File to embed* | A note, image, canvas or `.base` file in your vault. There is a file picker |
+| *Zoom* | Scales the embedded content. Applies when you close the dialog |
+| *Editable* | Edit the embedded note's text in place, saving to the vault. Markdown notes only |
+| *Live preview* | Edit in Obsidian's own Live Preview editor instead of the plain raw-Markdown box, so formatting renders as you type. Off shows the raw Markdown source, edited on double-click |
+| *Second file to embed* | Optional. When set, the card shows a switcher between the two views — in the header when the card has a title, or floating on hover when it does not |
+| *Open button* | Show a button that opens the embedded file in its own tab. Off by default |
+
+### Embedding a `.base` file
+
+If the embedded file is a `.base`, two extra options appear:
+
+- *Base view* — choose a named view from that `.base` file, or use its default
+  view. Views whose names contain characters that cannot survive a wikilink are
+  hidden, and the card tells you how many were hidden.
+- *Hide base header* — hide the Bases view's own toolbar (its view switcher and
+  filter/property controls) so that only the results show.
+
+This requires Obsidian's core **Bases** plugin.
+
+### Empty states
+
+- *Pick a file to embed in settings* — no file chosen yet.
+- *Enable the core Bases plugin to embed .base files*.
+- *Enable the core Canvas plugin to embed canvases*.
+- *Install the Excalidraw plugin to embed drawings*.
+
+---
+
+## Daily note
+
+**What it shows:** always today's daily note. The note is created on first
+click if it does not exist.
+
+**Requires:** Obsidian's core **Daily notes** plugin.
+
+Today's note is resolved from the Daily notes plugin's own date format and
+folder, so it matches what the rest of your vault does. The card updates live as
+you edit.
+
+### Options
+
+| Setting | Meaning |
+| --- | --- |
+| *Editable* | Edit today's note in place instead of read-only. Saves to the vault |
+| *Open button* | Show a button to open today's note in the editor |
+
+---
+
+## Periodic note
+
+**What it shows:** always the current week's, month's, quarter's or year's note.
+Because it is always the *current* one, the card moves on by itself when the
+period ends.
+
+**Requires:** the [Periodic Notes](https://github.com/liamcain/obsidian-periodic-notes)
+community plugin.
+
+The note is resolved — and, if missing, created from your own template — by
+Periodic Notes itself, so its folder, date format and template all apply. The
+card updates live as you edit.
+
+### Options
+
+| Setting | Meaning |
+| --- | --- |
+| *Period* | Daily, Weekly, Monthly, Quarterly or Yearly |
+| *Editable* | Edit the note in place instead of read-only |
+| *Open button* | Show a button to open the note in the editor |
+
+---
+
+## Embedded image
+
+**What it shows:** a picture from your vault, filling the card.
+
+**Requires:** nothing.
+
+This is the Embedded note card pointed at an image, with picture-specific
+framing options.
+
+### Options
+
+| Setting | Meaning |
+| --- | --- |
+| *Picture fit* | *Original size*, *Fit the whole picture*, *Fill the card (crop)*, *Stretch to the card*, or *Fit the width (scroll)*. Every mode except *Original size* hands the picture the whole card, edge to edge |
+| *Picture position* | Which of nine anchor points the picture sits at — top left, top, top right, left, center, right, bottom left, bottom, bottom right. When the fit is a crop, this decides which part of the picture the crop keeps |
+| *Zoom* | Scales the picture inside the frame it was fitted to. Zooming a cropped picture crops in further |
+| *Open button* | Show a button that opens the picture in its own tab |
+
+---
+
+## Slideshow
+
+**What it shows:** pictures from a list you curate or from a folder, rotated on
+a timer, once a day, or only by hand.
+
+**Requires:** nothing.
+
+### Choosing the pictures
+
+*Pictures from* is either **A list of pictures** or **A folder**.
+
+With a list, you add pictures one at a time, each with an optional caption, and
+you can reorder and remove them. There is also an *Add a folder's pictures*
+action that bulk-adds a folder's contents into the list.
+
+With a folder, every image in that folder is shown, optionally including
+subfolders. Leaving the folder empty means the vault root. The dialog tells you
+how many images it finds there right now.
+
+### Playback
+
+| Setting | Meaning |
+| --- | --- |
+| *Order* | List order, Name A→Z, Name Z→A, Date created oldest or newest first, Date modified oldest or newest first, or Random |
+| *Change picture* | **On a timer**, **Once a day**, or **Only by hand** |
+| *Seconds per picture* | Timer mode only. 0 holds the first picture and turns rotation off |
+| *Days per picture* | Daily mode only. 1 changes at midnight; 7 gives you a picture of the week |
+| *Transition* | Cut (no animation), Crossfade, Slide or Zoom |
+| *Transition length* | How long the transition takes, in milliseconds |
+| *Slow zoom* | Drift slowly into each picture while it is shown — the "Ken Burns" effect |
+
+The **Once a day** mode works its picture out from today's date rather than from
+a running timer, so the picture stays put all day however often the board is
+redrawn. Both daily and manual modes remember where they were left.
+
+### Display
+
+| Setting | Meaning |
+| --- | --- |
+| *Fit* | Fill the card (crop) or Fit the whole picture |
+| *Controls* | Show previous / pause / next buttons and the position indicator, on hover. On by default |
+| *Caption* | Show each picture's caption over it, falling back to its file name |
+| *Pause on hover* | Hold the current picture while the pointer is over the card |
+| *Open button* | Show a button that opens the picture on screen in its own tab |
+
+Note that on the **Minimal** performance tier a slideshow holds one picture
+instead of rotating; see [chapter 12](12-performance.md).
+
+---
+
+## Embedded canvas
+
+**What it shows:** a canvas from your vault, interactive and edge to edge. You
+can pan around it in place.
+
+**Requires:** Obsidian's core **Canvas** plugin.
+
+This is the Embedded note card pointed at a `.canvas` file.
+
+---
+
+## Excalidraw drawing
+
+**What it shows:** an Excalidraw drawing, with native pan and zoom.
+
+**Requires:** the [Excalidraw](https://github.com/zsviczian/obsidian-excalidraw-plugin)
+community plugin.
+
+Drawings render live. Hearth also exposes a *Create new Excalidraw drawing*
+command and a mobile action button for it; both run Excalidraw's own "new
+drawing" command rather than reimplementing it.
+
+---
+
+## Embedded base
+
+**What it shows:** a `.base` file, rendered by Obsidian's own Bases.
+
+**Requires:** Obsidian's core **Bases** plugin.
+
+See *Embedding a `.base` file* under [Embedded note](#embedded-note) above for
+the *Base view* and *Hide base header* options.
+
+---
+
+## Recent files
+
+**What it shows:** the files you opened most recently.
+
+**Requires:** nothing.
+
+### Options
+
+| Setting | Meaning |
+| --- | --- |
+| *Fit to card height* | List as many files as the card is tall enough to show, instead of a fixed number. Resizing the card then changes how many appear |
+| *Number of files* | How many recently-opened files to list, when not fitting to height. There is a ceiling, which is as far back as Hearth's recent-file history goes |
+| *File types* | Only list files of the selected types. Pick any combination; selecting none shows every type |
+
+If you use Iconic or Iconize, each file shows its own icon here. See
+[chapter 14](14-integrations.md).
+
+---
+
+## Favorites
+
+**What it shows:** the notes you have starred in Hearth.
+
+**Requires:** nothing.
+
+Favorites are Hearth's own list, separate from Obsidian's Bookmarks.
+
+By default every Favorites card shows one vault-wide list, which is edited from
+the card's settings (*Add favorite*, plus move up, move down and remove).
+
+A single card can be given a list of its own with *Give this card its own list*.
+Turning it on starts from the list the card is showing now; turning it back off
+drops the card's own list and returns it to following the vault-wide favourites.
+
+---
+
+## Bookmarks
+
+**What it shows:** your Obsidian bookmarks, groups and all, with site favicons
+for bookmarked URLs.
+
+**Requires:** Obsidian's core **Bookmarks** plugin.
+
+The card reads Obsidian's bookmarks directly, so anything you bookmark anywhere
+in the app appears here.
+
+---
+
+## Common behaviour across these cards
+
+**Where a clicked note opens** is governed by **Settings → Hearth → Behaviour →
+Opening notes**. There is a general *Open notes in* choice and a per-source
+override for *Notes in cards*, which covers the Recent, Bookmarks, Favorites,
+Calendar, Heatmap and Tasks cards.
+
+**Liveness.** Embedded and editable notes follow vault events without losing
+your cursor. The Recent, Bookmarks and saved-query cards update as the vault
+changes if *Live refresh on vault changes* is on under **Settings → Hearth →
+Behaviour**. Switching back to the Hearth tab always refreshes it regardless of
+that setting.
+
+**Headerless cards.** Leaving a card's *Title* empty draws it without a header
+row. For image, slideshow, canvas and drawing cards this is usually what you
+want: the picture then fills the card completely.

--- a/docs/user-guide/08-cards-planning.md
+++ b/docs/user-guide/08-cards-planning.md
@@ -1,0 +1,393 @@
+# 8. Cards for planning: tasks, calendars and clocks
+
+This chapter documents the Hearth cards in the **Planning** category of the Add
+card picker: **Tasks**, **Calendar**, **Mini calendar**, and **Clock &
+greeting**. These are the largest and most configurable cards Hearth has, and
+the Tasks card in particular repays reading in full.
+
+Cards are added with **Arrange → Add card** in Hearth's Home view and configured
+from each card's own gear button while arranging; see
+[chapter 6](06-arranging-cards.md).
+
+---
+
+## The Tasks card
+
+**What it shows:** your tasks, as a list or as a drag-and-drop Kanban board.
+
+**Requires:** nothing for Markdown checkboxes. The TaskNotes or Kanban community
+plugins for those sources.
+
+### Choosing a source
+
+*Source* is the first decision, and it changes what the rest of the card offers.
+
+| Source | What it reads |
+| --- | --- |
+| **Markdown checkboxes** | Ordinary `- [ ]` checkboxes anywhere in your vault. Works with no plugin at all |
+| **TaskNotes plugin** | One-note-per-task vaults managed by the TaskNotes community plugin, read from frontmatter |
+| **Kanban plugin** | A single board note from the Kanban community plugin, one column per heading |
+
+#### The Markdown checkboxes source
+
+Reads checkboxes from your notes. Two options shape how they are read:
+
+- *Dates & priorities* — read the dates, priority and repeat marks written
+  inline on each checkbox, in the format the
+  [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian-tasks)
+  plugin uses, so they show as indicators, sort the list, and can be edited from
+  the item's right-click menu. Off reads checkboxes as plain text.
+- *Task states (board columns)* — the checkbox states shown as columns on a
+  Kanban board, one per line as `[symbol] Label`, where the symbol is the
+  character inside `- [ ]`. Add `(done)` to mark a state complete. Dragging a
+  card to a column writes that column's symbol. Leave it empty for the default
+  set of To do, In progress and Done.
+
+#### The TaskNotes source
+
+TaskNotes stores each task as its own note, with the task's metadata in
+frontmatter. TaskNotes has no stable API for other plugins to query, so Hearth
+reads that frontmatter directly — which means it has to be told the field names.
+
+The field names live at **Settings → Hearth → Integrations → Tasks /
+TaskNotes**: *Status field*, *Due date field*, *Priority field* and the
+*"Done" status value*. The defaults are TaskNotes' own defaults (`status`,
+`due`, `priority`, `done`). If you renamed a field inside TaskNotes, match it
+here.
+
+The setup wizard reads these from TaskNotes for you when it builds a Tasks card;
+see [chapter 2](02-getting-started.md).
+
+On the card itself, *Statuses counted as complete* lets one card treat extra
+status values as complete — one per line. Leave it empty to use just the done
+value from the vault-wide settings; add, for example, `canceled` to count
+cancelled tasks as complete too. Complete tasks are hidden unless *Show
+completed* is on, and struck through when shown.
+
+#### The Kanban source
+
+Reads a single Kanban-plugin board note, one column per heading.
+
+- *Board note* — which board to read. Leave it empty to auto-detect the first
+  note in scope carrying a `kanban-plugin` frontmatter key.
+- *Dates & priorities* — as above, reading the obsidian-tasks-compatible marks
+  written on each card.
+
+**Kanban write-back:** when you drag a card between columns, Hearth writes the
+change in Kanban's own format, so the note stays fully editable in the Kanban
+plugin. Hearth is not a second, disagreeing owner of the board.
+
+### Layout: list or board
+
+*Layout* is either **List** or **Kanban board**.
+
+On a board:
+
+- Drag cards between columns.
+- Drag column headers to reorder columns.
+- Use a column's eye icon to hide it.
+- Use a column's check icon to make it auto-complete cards dropped into it.
+- Right-click a card to convert it into its own note.
+
+The card's settings summarise the current column state — which are hidden, which
+auto-complete, whether a custom order is set — and offer *Show all* and *Reset
+column order, visibility & done columns*.
+
+Completed tasks always appear in the Done column on a board, regardless of the
+*Show completed* setting.
+
+### Dates, priorities and recurrence
+
+With *Dates & priorities* on, Hearth understands the full obsidian-tasks mark
+set: the priority marks 🔺 ⏫ 🔼 🔽 ⏬, the recurrence mark 🔁, and the date
+marks 🛫 (start), ⏳ (scheduled), 📅 (due) and ✅ (done).
+
+It renders relative labels ("Today", "Next Friday") rather than raw dates,
+accepts natural-language input when you edit a date (`📅 in 3 days`), and
+handles per-occurrence completion for recurring tasks — completing one
+occurrence of a repeating task leaves the series intact.
+
+### Sorting and filtering
+
+Sorting is either a **smart chain** — due date, then scheduled date, then
+priority, then created date — or a custom multi-rule sort you define. Sorting is
+set per list and per Kanban column.
+
+Other filters on the card:
+
+| Setting | Meaning |
+| --- | --- |
+| *Show completed* | Include finished tasks |
+| *Max tasks shown* | A ceiling. Tasks are sorted by due date (overdue and soonest first), then by file |
+| *Scope* | *Whole vault*, *Only these folders*, or *Everywhere except these folders* |
+| *Folders* | One folder path per line, used by the two scoped modes |
+
+### Custom task fields
+
+This is opt-in and off by default. Until you turn it on, tasks keep their usual
+fixed look.
+
+*Customize task fields* replaces the fixed metadata a task shows with fields you
+define yourself. Turning it on starts from a blank slate: tasks then show only
+the fields you add. The fields are defined vault-wide at **Settings → Hearth →
+Integrations → Tasks / TaskNotes → Fields shown on a task**, and a single card
+can define its own instead from that card's settings.
+
+A field has:
+
+- a **name** — what it is called; optionally shown on the task as a prefix
+  ("Priority: Urgent"),
+- a **display style** — how its values are drawn,
+- one or more **keys** — where it reads from,
+- optional **value mappings** — a nicer label and a colour per value.
+
+The six display styles are:
+
+| Style | Effect |
+| --- | --- |
+| *Chip* | A small pill on the task |
+| *Colored dot* | A coloured dot |
+| *Colored dot with label* | The form the built-in priority uses; offered to fields that read a priority |
+| *Plain text* | The value, as text |
+| *Tint the whole task* | Shows nothing on the task; colours the task's background |
+| *Glow around the task* | Shows nothing on the task; puts a coloured ring around it |
+
+The last two are **ambient**: a task has one background and one ring, so only
+one field can use each. If a second field asks for one, Hearth says which field
+already holds it and that this one will colour nothing. Both ambient styles have
+a *Strength* control for how strongly the colour is laid on; only a value that
+has a colour mapped affects the task at all.
+
+**Keys.** A field can read several keys at once, so one field can gather several
+pieces of metadata under one name. The pickers offer two groups: *Values Hearth
+parses itself* — status (TaskNotes), board column (Kanban), priority, start
+date, scheduled date, due date, done date and description — and *Properties
+found in your notes*, which is anything in your frontmatter.
+
+**Value mappings.** For a key with discrete values you can map each value to a
+nicer label and a colour, chosen from the theme's eight named colours (red,
+orange, yellow, green, cyan, blue, purple, pink) or a custom colour. Hearth
+offers the values that key actually takes elsewhere in your vault, so you are
+picking from real data. Values you do not map still show, as themselves.
+
+**Dates.** A property can be marked *Treat as a date*, which shows it as a
+relative date ("Tomorrow"), colours it by whether it falls before today, today,
+or after today, and edits it with a calendar. A date has no fixed values to map,
+so it is coloured by where it falls rather than by a value table.
+
+A description key is always drawn as its own block of sub-bullets.
+
+### Quick view
+
+*Quick view on click* (on by default) makes clicking a task open a compact
+popover — its metadata and description, editable in place, with buttons to open
+the full note or delete the task — instead of jumping into the note. Turning it
+off opens the note on click.
+
+### Converting a card into a note
+
+Right-clicking a task and choosing **Convert to note** turns an inline checkbox
+into its own note, leaving a link on the board. Two settings shape this:
+
+- *Convert-to-note template* — seed the new note from a template. Supports
+  `{{title}}`, `{{date}}` and `{{time}}`. Leave empty for a blank note.
+- *Scrape metadata to frontmatter* — move the card's dates, priority and repeat
+  marks into the new note's YAML frontmatter instead of leaving the emoji
+  markers on the board link.
+
+*New tasks as notes* applies the same treatment up front: each new card is
+created as its own note straight away rather than as an inline checkbox.
+
+### Empty states
+
+- *Enable the TaskNotes plugin, or switch source to checkboxes*
+- *No open tasks*
+- *No tasks match the filter*
+- *No Kanban board found — pick a board note in card settings, or create one
+  with the Kanban plugin*
+
+---
+
+## The Calendar card
+
+**What it shows:** month, week, day and list views over the same set of event
+sources, with a scrolling time grid, overlapping-event columns and an all-day
+band.
+
+**Requires:** nothing, but it is only useful with at least one source — the core
+Daily notes plugin, or a subscribed calendar feed, or TaskNotes.
+
+### Views and toolbar
+
+| Setting | Meaning |
+| --- | --- |
+| *Opens in* | The view the card shows when the board is opened. You can switch views on the card itself at any time |
+| *Views offered* | Which of the four views the card's switcher lists. Leaving all four on keeps every one a click away; offering a single view hides the switcher entirely |
+| *Toolbar* | Show the navigation row — back, today, forward, the period being shown, and the view switcher. Turning it off pins the card to the current period |
+
+### Daily notes
+
+*Daily notes* marks days that already have a daily note, and opens (or offers to
+create) that note when a day is clicked. Turning it off makes the card purely an
+event calendar.
+
+### The week
+
+| Setting | Meaning |
+| --- | --- |
+| *Week starts on* | Which day the month and week grids start from. Defaults to following Obsidian's language, and tells you which day that currently is |
+| *Hide weekends* | Leave Saturday and Sunday out of the month and week grids |
+| *Week numbers* | Show a week-number column down the left edge |
+| *Clock* | How event times are written: follow Obsidian's language, 12-hour (9:00 AM), or 24-hour (09:00) |
+
+### Month view
+
+- *Events shown as* — **Named chips**, which read at a glance on a card with
+  room, or **Dots**, which suit a small card the way the Mini calendar draws
+  them.
+- *Events per day* — how many events a day cell lists before the rest collapse
+  into a "+N more" link. 0 lists every one and lets the cell scroll.
+
+### Week and day views
+
+The time grid draws the whole day by default and opens scrolled to the first
+event, so nothing can sit outside the visible hours.
+
+| Setting | Meaning |
+| --- | --- |
+| *Hours drawn* | The first and last hour of the grid. Anything outside them moves to the all-day band above rather than disappearing |
+| *Hour height* | How tall one hour is, in pixels. Taller shows more detail; shorter fits more of the day |
+| *Current time line* | Draw a line across today's column at the current time |
+
+### List view
+
+*Days listed* sets how far ahead the list reaches, starting from the day it is
+showing.
+
+---
+
+## The Mini calendar card
+
+**What it shows:** a compact month grid or an agenda, with dots for days that
+have notes, ISO week numbers, and an optional edit heatmap.
+
+**Requires:** Obsidian's core **Daily notes** plugin for the daily-note
+features. Calendar subscriptions and TaskNotes are optional extras.
+
+Mini calendar and Calendar overlap, but they are different cards with different
+option sets. Mini calendar is the one that carries external calendar
+subscriptions and the event-note builder.
+
+### Layout
+
+| Setting | Meaning |
+| --- | --- |
+| *Layout* | **Month grid** or **Agenda** |
+| *Days ahead* | Agenda only: how many days the agenda lists, starting from today |
+| *Week numbers* | Show an ISO week-number column down the left edge |
+| *Heatmap* | Tint each day by note activity that day |
+
+### External calendar subscriptions
+
+*External calendars* subscribes the card to ICS/iCal feeds — Google, iCloud,
+Fastmail, Nextcloud and anything else that publishes one. Events appear as
+coloured dots on the grid and are listed in the agenda view.
+
+Each subscription has a name, a URL (`https://` or `webcal://`), and a
+show/hide toggle. *Refresh every* sets how often feeds are re-fetched, in
+minutes; 0 fetches only when the card opens.
+
+Feeds are network requests, so they are silenced by *Disable external calls*;
+see [chapter 17](17-privacy-and-network.md).
+
+### TaskNotes as a source
+
+If the TaskNotes community plugin is enabled, the Mini calendar can draw
+TaskNotes items. The card mirrors what TaskNotes' own calendar shows, using
+TaskNotes' own field names, statuses and colours.
+
+| Setting | Meaning |
+| --- | --- |
+| *Use TaskNotes* | Draw TaskNotes items on this calendar |
+| *Scheduled tasks* | Tasks on their scheduled date, sized by their time estimate |
+| *Due dates* | Tasks on their due date |
+| *Recurring tasks* | Unroll a recurring task into one entry per occurrence. Off shows only its next date |
+| *Timeblocks* | Timeblocks written into your daily notes |
+| *Show completed* | Keep finished tasks on the calendar, struck through |
+| *Show archived* | Include tasks carrying TaskNotes' archive tag |
+| *Complete from the calendar* | Offer a completion box on each task, writing back exactly what TaskNotes writes, per-occurrence for recurring tasks |
+| *TaskNotes calendars* | Also show the calendars subscribed inside TaskNotes itself |
+
+Each of these toggles reports what TaskNotes currently has set, and offers a
+*Follow TaskNotes* reset.
+
+Task colours come from *Colour by*: **TaskNotes status**, **TaskNotes
+priority**, or **One fixed colour**. There are separate optional colours for
+due-date entries and for timeblocks that carry no colour of their own.
+
+### Operon tasks
+
+If the Operon integration is connected, *Show Operon tasks* marks days that have
+an Operon task due and lists those tasks in the agenda, in a colour you choose.
+It reads through Operon's developer API, so Operon must have approved Hearth;
+see [chapter 14](14-integrations.md). Tasks that are only scheduled, with no due
+date, are not included.
+
+### Entry details
+
+*Entry details* chooses what each agenda entry shows beside its title. On a
+narrow card the markers compete with the title itself, so these are worth
+pruning.
+
+| Chip | Shows |
+| --- | --- |
+| *Time* | The start time, or "All day" |
+| *Calendar name* | Which calendar an entry came from. Only ever shown when there is more than one source |
+| *Status* | A task's TaskNotes status, for example "In progress". Off by default |
+| *Priority* | A task's TaskNotes priority, for example "High" |
+| *Due marker* | The "Due" badge on a due-date entry |
+| *Recurring marker* | The "Recurring" badge on a repeating task |
+| *Timeblock marker* | The "Timeblock" badge on a timeblock |
+
+### Creating a note from an event
+
+The event popup can offer a **Create note** button, which turns a calendar event
+into a note in your vault. This is configured under *Event notes*:
+
+| Setting | Meaning |
+| --- | --- |
+| *Show "Create note"* | Offer the button in the event details popup |
+| *Folder* | Where new event notes are created. Empty means the vault root |
+| *Filename* | The note name. Placeholders include `{{summary}}`, `{{date}}`, `{{start}}`, `{{location}}` |
+| *Template* | An optional note whose contents seed the body. The same `{{…}}` placeholders are substituted |
+| *Link property* | A frontmatter property that stores the event's ID, so an event always maps to one note. Empty disables linking |
+| *Customise field routing* | Off uses sensible defaults — date and time as properties, description in the body. On lets you route each value yourself |
+
+With field routing on, each event value — Name, Date, Start time, End time,
+Location, Description, URL, Calendar — can be **ignored**, written as a
+**property** (with a property name and an optional format such as `HH:mm`), or
+**appended to the body** under an optional heading.
+
+---
+
+## The Clock & greeting card
+
+**What it shows:** the time, the date, and an optional greeting.
+
+**Requires:** nothing.
+
+### Options
+
+| Setting | Meaning |
+| --- | --- |
+| *Style* | **Digital** or **Analog** |
+| *Time format* | Automatic (from your locale), 12-hour, or 24-hour |
+| *Show seconds* | Include seconds, and on the analogue face a sweeping second hand |
+| *Show greeting* | Show a greeting line |
+| *Playful greetings* | Cheeky, randomised greetings instead of the plain ones |
+| *Greeting override* | Fixed text of your own. Leave empty for the automatic greeting |
+| *Date* | Weekday-day-month; Weekday-day-month-year; Short (locale); ISO (2026-06-29); Weekday only; a custom format; or Hidden |
+| *Custom date format* | A moment.js format string, for example `ddd D MMM` or `YYYY/MM/DD` |
+
+On the **Reduced** and **Minimal** performance tiers, clock cards drop seconds
+and the sweeping second hand; see [chapter 12](12-performance.md).

--- a/docs/user-guide/09-cards-vault-tools-and-fun.md
+++ b/docs/user-guide/09-cards-vault-tools-and-fun.md
@@ -1,0 +1,310 @@
+# 9. Cards for vault insight, tools and fun
+
+This chapter documents three categories from Hearth's Add card picker: **Vault
+insight** (Query, Search bar, Vault statistics, Activity heatmap), **Tools**
+(Links / launchpad, Commands, Text / jot-down, Calculator, Web page) and **Fun**
+(Pet).
+
+Cards are added with **Arrange → Add card** in Hearth's Home view and configured
+from each card's own gear button while arranging; see
+[chapter 6](06-arranging-cards.md).
+
+---
+
+# Vault insight
+
+## The Query card
+
+**What it shows:** a saved search, kept live.
+
+**Requires:** nothing.
+
+The Query card runs one query and lists what matches, refreshing as the vault
+changes.
+
+| Setting | Meaning |
+| --- | --- |
+| *Query* | The same syntax as Hearth's search bar: plain text matches names and bodies, `#tag` matches tags, `key:value` matches a frontmatter property |
+| *Display* | **List** (compact) or **Tiles** |
+| *Max results* | The most matches to show at once |
+
+Example queries: `#project`, `status:active`, `meeting notes`.
+
+Empty states: *Set a query in card settings*, and *No matches*.
+
+---
+
+## The Search bar card
+
+**What it shows:** a search field on the board — the same search Hearth's header
+offers, placed wherever you want it.
+
+**Requires:** nothing.
+
+| Setting | Meaning |
+| --- | --- |
+| *Placeholder* | Text shown in the empty field. Leave blank to use the vault-wide one |
+| *Filter row* | Show the file-type chips under the field. They need a taller card to sit in |
+| *Filter chips* | Which chips this card offers. A chip only appears when the vault actually holds that kind of file |
+| *Button* | An action button beside the field: **None**, **New note**, or **Search online** |
+| *Seamless* | Drop the card frame — no border, background or title row — so this reads as a standalone search bar on the board rather than as a card |
+
+The field is as thick as the card is tall, so you set the bar's chunkiness by
+dragging the card's edge in arrange mode.
+
+A chip hidden vault-wide under *Settings → Hearth → Search → Search filters* is
+hidden for every search bar, and the card says so.
+
+The *New note* button here obeys the same *The "New note" button* settings as
+the header's; see [chapter 4](04-search.md).
+
+---
+
+## The Vault statistics card
+
+**What it shows:** counts describing your vault — notes, attachments, folders,
+tags, and a daily-note streak.
+
+**Requires:** nothing. The day-streak statistic only appears when daily notes
+are set up.
+
+By default the card shows a sensible built-in set. Turning on *Advanced* opens
+three further controls:
+
+| Setting | Meaning |
+| --- | --- |
+| *Stats to show* | Pick which built-in statistics appear |
+| *Attachment breakdown* | Add a separate count tile for each selected file type — images, PDFs, and so on |
+| *Custom counts* | Each row counts the files matching a query and shows the total as a tile |
+
+A custom count has a label, an icon, and a query. Query syntax matches the search
+bar: `#tag`, `key:value` for a property, or plain text. For example, a tile
+labelled "Active projects" with the query `status:active`.
+
+---
+
+## The Activity heatmap card
+
+**What it shows:** a year of vault activity, day by day, as a grid of coloured
+squares — or, in advanced mode, any metric you define.
+
+**Requires:** nothing.
+
+### Simple mode
+
+| Setting | Meaning |
+| --- | --- |
+| *Metric* | **Notes edited** or **Notes created** |
+| *Weeks* | How many weeks of history to show |
+
+### Advanced mode
+
+Turning on *Advanced* lets you build your own metric out of three parts.
+
+**Which date a note lands on** — *Day comes from*:
+
+- **Date modified** (the file's own modification time),
+- **Date created** (the file's own creation time),
+- **A frontmatter date**, where you name the property. It accepts a date, a date
+  and time, or a `[[daily note]]` link; a list counts once per entry. Notes
+  without the property are skipped.
+
+**What each note contributes** — *Each note adds*:
+
+- **1 (count the notes)**, or
+- **A number from a property** — minutes read, pages written, kilometres run.
+  You name the property. Notes whose value is not a number are skipped rather
+  than counted as one.
+
+*Unit* names what one unit is when a day is described — "5 workouts". Leaving it
+blank follows the metric.
+
+**Which notes count at all** — *Which notes count* is a list of rules. With no
+rules, every note counts. Each rule tests a **Property**, **Tag**, **Folder** or
+**Path** with one of these operators: *is*, *is not*, *contains*, *does not
+contain*, *is more than*, *is less than*, *is set*, *is not set*. The rules are
+combined with *Match: All rules (AND)* or *Any rule (OR)*.
+
+Example: count only notes in `Journal/` that carry a `words` property, summing
+that property, to draw a writing-volume heatmap.
+
+---
+
+# Tools
+
+## The Links / launchpad card
+
+**What it shows:** a grid of buttons, each opening a note, a URL or a command.
+
+**Requires:** nothing.
+
+Each link has a **label**, an **icon**, and a **target**. The target is one of:
+
+| Type | Target |
+| --- | --- |
+| **Note** | A note path in your vault |
+| **URL** | Any web address |
+| **Command** | Any Obsidian command, chosen from a picker |
+
+The icon field accepts a Lucide icon id (`home`, `star`, `calendar` — browse
+them at lucide.dev/icons) or the vault path of an image such as
+`Attachments/icon.png`, so you can use your own picture as a button icon.
+
+Links can be reordered with move up and move down, and removed.
+
+### Button sizing
+
+The Links card, the Commands card and the New note from template card share a
+sizing model, documented in full in [chapter 6](06-arranging-cards.md). In
+summary: *Button sizing* is either **Fill the card** (buttons grow and shrink
+with the card, down to a *Minimum button size*, after which the card scrolls) or
+**Fixed size (legacy)**. Each button can be made two or three cells wide or tall
+by dragging its bottom-right corner in arrange mode, in half-cell steps.
+
+*Auto-shift tiles (beta)*, off by default, makes tiles shove each other aside as
+one is dragged, the way phone widgets do. With it off, tiles are pure free-form
+and may overlap.
+
+---
+
+## The Commands card
+
+**What it shows:** buttons that run Obsidian commands.
+
+**Requires:** nothing.
+
+This is the Links card narrowed to one target type. Each entry is a command
+chosen from a picker, with an optional label, an optional icon and an optional
+per-tile size in pixels.
+
+*Button size* sets the default tile size; individual tiles can be resized by
+dragging their bottom-right corner. *Auto-shift tiles (beta)* behaves as it does
+on the Links card.
+
+---
+
+## The Text / jot-down card
+
+**What it shows:** a quick Markdown scratchpad.
+
+**Requires:** nothing.
+
+The text is stored with the card, not in a note. That makes it right for a
+running list you do not want to file anywhere, and wrong for anything you need
+to search or link to.
+
+Because the text lives on the card, it is one of the things Hearth removes when
+you export a board with *Leave out my private information* on, and it is always
+removed when you publish to the gallery; see
+[chapter 16](16-sharing-and-gallery.md).
+
+---
+
+## The Calculator card
+
+**What it shows:** a free-text calculator in the spirit of a search box —
+arithmetic, unit conversions, number bases, currency, and plain-language
+queries.
+
+**Requires:** network access for currency rates only. Everything else is
+computed locally with no network and no dependencies.
+
+You type one line and get an answer. It understands five kinds of question:
+
+| Kind | Examples |
+| --- | --- |
+| Arithmetic | `2 + 2`, `3 * (4 + 5)`, `2^10`, `sqrt(16)`, `sin(30)` |
+| Unit conversions | `10 km to miles`, `100 f in c`, `1 hour in minutes` |
+| Plain language | `20% of 150`, `3 plus 4`, `10 squared`, `2 x 3` |
+| Currency | `10 € to USD`, `$5 in czk` |
+| Number bases | `FF hex to decimal`, `1010 binary to hex`, `255 to hex` |
+
+Unit families it knows include length, mass, time, volume, area, speed, digital
+storage (both decimal SI and binary IEC) and angle. It accepts scientific
+notation (`1e5`, `2.5e-3`) and `**` as an alias for `^`. Currency symbols are
+recognised before or after the number, so `$10` and `10€` both work.
+
+| Setting | Meaning |
+| --- | --- |
+| *Angle unit* | The unit trigonometric functions assume: **Degrees** (the default, so `sin(30)` is 0.5) or **Radians** |
+| *Keypad* | **Hidden**, **Basic** (digits and operations), or **Scientific** (adds functions, powers and constants) |
+
+Currency conversion uses European Central Bank rates fetched from the free,
+key-less [Frankfurter](https://www.frankfurter.app/) API. When rates are not
+available — you are offline, or external calls are disabled — a currency query
+says so rather than guessing.
+
+---
+
+## The Web page card
+
+**What it shows:** any `http(s)` URL, in a sandboxed iframe.
+
+**Requires:** network access.
+
+| Setting | Meaning |
+| --- | --- |
+| *URL* | The page to show |
+| *Trusted site* | Allow the page same-origin access — cookies and storage. This relaxes the iframe sandbox, so only enable it for sites you trust |
+| *Auto-refresh* | Re-render the card every N seconds to pick up changes. 0 turns it off |
+
+On the **Minimal** performance tier, web cards stop refreshing on their timer;
+manual refresh still works.
+
+---
+
+# Fun
+
+## The Pet card
+
+**What it shows:** a small pixel-art companion that lives on your dashboard and
+whose mood follows your vault activity.
+
+**Requires:** nothing, and nothing reaches the network.
+
+The pet is drawn, animated, and can watch your pointer. It is deliberately
+consequence-free: nothing you do or fail to do can make it unwell or lose it. A
+quiet vault only sends it to sleep, and any writing wakes it straight back up.
+
+### Appearance
+
+| Setting | Meaning |
+| --- | --- |
+| *Animal* | Cat, Dog, Bird, Fox, Frog or Blob |
+| *Name* | What to call it. Leave empty to use the animal's name |
+| *Colors* | A body colour and an accent. The outline, shading and belly are derived from the body colour. There is a reset to this animal's own colours |
+| *Size* | Small, Medium or Large |
+| *Eyes follow the pointer* | **Never**, **On its own card**, or **Anywhere on the dashboard**. A sleeping pet keeps its eyes shut whatever you set |
+| *Show name*, *Show mood*, *Show today's activity* | What text appears under the pet |
+
+### Mood
+
+*Feed it with* chooses which vault activity the mood follows: **Notes edited**
+or **Notes created**.
+
+The mood thresholds are yours to set, counted in notes touched today:
+
+| Setting | Meaning |
+| --- | --- |
+| *Bouncing with joy at* | Notes touched today, or more |
+| *Happy at* | Notes touched today — your good day |
+| *Content at* | Notes touched today. Below this the pet gets bored |
+| *Falls asleep after* | Minutes with nothing touched anywhere in the vault. The pet sleeps whatever its mood; any activity wakes it again where the day left it |
+| *A petting lasts* | Minutes of guaranteed happiness after you click the pet |
+
+The mood labels you will see are: *Bouncing with joy*, *Happy*, *Content*, *A
+little bored*, *Fast asleep* and *Asleep for the night*.
+
+### Night
+
+*At night* decides what the clock is allowed to do:
+
+- **Nothing — only the vault matters**,
+- **A bored or content pet sleeps instead**,
+- **Always asleep at night**.
+
+*Night runs from* sets the window in your local time, and the window may cross
+midnight. A thin small hour is the hour, not neglect: a good day still shows as
+a good day, and petting wakes the pet whatever you set here.
+
+Clicking the pet pets it, and earns hearts.

--- a/docs/user-guide/10-cards-integrations.md
+++ b/docs/user-guide/10-cards-integrations.md
@@ -1,0 +1,397 @@
+# 10. Integration cards
+
+This chapter documents the cards in the **Integrations** category of Hearth's
+Add card picker. Each one is a window onto another plugin or another service:
+Templater, Dataview, Datacore, Git, Jira, RSS, Weather, Operon (four cards) and
+the Plugin view card.
+
+A card whose plugin is not installed is still listed in the picker, marked
+*Needs Dataview* (or Git, Operon, and so on) with a one-click link to install
+it. You can add the card anyway; it shows a prompt until the dependency arrives.
+
+For the full catalogue of what Hearth integrates with, including things that are
+not cards, see [chapter 14](14-integrations.md).
+
+---
+
+## New note from template
+
+**What it shows:** a grid of buttons, each of which creates a note from one of
+your Templater templates.
+
+**Requires:** the [Templater](https://github.com/SilentVoid13/Templater)
+community plugin.
+
+This card does something Templater's own per-template commands cannot: **the
+same template can feed three different folders from three different buttons**.
+Each tile carries its own template, its own destination folder and its own
+filename pattern.
+
+Templater still does the templating. Your user scripts, `tp.system.prompt()`
+dialogs and `tp.file.cursor()` placement all behave exactly as they do when the
+template is run from Templater's own command.
+
+### Per-tile settings
+
+| Setting | Meaning |
+| --- | --- |
+| *Label* | The text on the tile |
+| Template | The Templater template this tile runs, chosen from a picker. The picker lists the templates in Templater's own template folder |
+| Folder | The folder the new note goes in. The vault root means "wherever Obsidian puts new notes" |
+| *Filename* | The name, without the extension. Leave empty to let Templater name it |
+| Open toggle | Whether the new note opens, or is filed away silently |
+
+### Filename tokens
+
+Filenames may use:
+
+| Token | Substituted with |
+| --- | --- |
+| `{{date}}` | Today's date |
+| `{{date:FMT}}` | Today's date in a moment.js format, for example `{{date:YYYY-MM}}` |
+| `{{time}}` | The current time |
+| `{{time:FMT}}` | The current time in a format, for example `{{time:HH-mm}}` |
+| `{{prompt}}` | Asks you for the rest of the name before the note is made |
+
+Everything inside the template itself — `<% tp.* %>`, your user scripts,
+`tp.system.prompt()` — is Templater's own.
+
+### Card-level settings
+
+*Button sizing*, *Buttons across*, *Minimum button size* and *Auto-shift tiles
+(beta)* behave as they do on the Links card; see
+[chapter 6](06-arranging-cards.md).
+
+If Templater is not enabled, the card says so and keeps its configuration, so
+installing Templater later makes the tiles start working with nothing else to
+change.
+
+---
+
+## Dataview query
+
+**What it shows:** a Dataview query, rendered by Dataview's own live renderers.
+
+**Requires:** the [Dataview](https://github.com/blacksmithgu/obsidian-dataview)
+community plugin.
+
+| Setting | Meaning |
+| --- | --- |
+| *Query type* | **Dataview query (DQL)** — TABLE, LIST or TASK — or **DataviewJS** |
+| *Query* | The query itself, written exactly as it would be inside a fenced code block, without the fences |
+
+Table columns rendered by this card are resizable.
+
+An important limitation: the card runs with **no "current note"**. Global
+queries work fully; queries written relative to `this.file` have no file to
+resolve against.
+
+DataviewJS runs arbitrary JavaScript with the `dv` API in scope. Only use code
+you trust.
+
+Example DQL: `TABLE file.mtime AS "Modified" FROM #project SORT file.mtime DESC`
+Example DataviewJS: `dv.list(dv.pages('#project').file.link)`
+
+The card refreshes as Dataview's index changes.
+
+---
+
+## Datacore query
+
+**What it shows:** a Datacore query rendered as a live list, or a full Datacore
+script rendering its own view.
+
+**Requires:** the [Datacore](https://github.com/blacksmithgu/datacore)
+community plugin. Datacore is Dataview's successor.
+
+| Setting | Meaning |
+| --- | --- |
+| *Query type* | **Datacore query**, or a script in **JSX**, **JS**, **TSX** or **TS** |
+| *Query* | A Datacore query such as `@page and #project`. Hearth renders the matches as a live list of links |
+| *Script* | A Datacore script, as inside a `datacorejsx` block without the fences. The `dc` API is in scope and the script returns the view to render |
+| *Rows per page* | Page the generated list at this many rows. 0 shows every match at once |
+
+As with Dataview, the card runs with no "current note", so global queries work
+fully and file-relative ones have nothing to resolve against. Scripts run
+arbitrary code; only use code you trust.
+
+One card runs **one** query. If you paste several, the card says so rather than
+guessing which you meant.
+
+---
+
+## Git
+
+**What it shows:** your repository's branch, staged and changed files, unpushed
+commits and recent log, with working buttons.
+
+**Requires:** the [Git](https://github.com/Vinzent03/obsidian-git) community
+plugin, with a repository set up.
+
+The Git card is a window onto the Git plugin rather than a second Git client.
+Commits go through the Git plugin's own task queue, so your remote, your
+credentials and your commit-message template all apply unchanged.
+
+### Sections and buttons
+
+*Sections* chooses which parts of the card are drawn. *Buttons* is a list you
+build: commit, sync, push, pull, stage, discard and so on. Each button can be
+removed and new ones added. *Button style* is **Icon only** (compact) or **Icon
+and label** (readable on a wide card).
+
+Buttons that discard work are marked as such: "Cannot be undone."
+
+### Committing
+
+| Setting | Meaning |
+| --- | --- |
+| *What to commit* | **Staged if anything is staged, otherwise everything**, **Everything**, or **Only staged files** |
+| *Ask for a message* | Have the Git plugin prompt for a commit message each time, exactly as its "…with specific message" commands do |
+| *Commit message* | Used by this card's commit buttons. Leave empty to use the Git plugin's own commit-message template. Supports `{{date}}` |
+| *Skip confirmations* | Run discarding actions immediately instead of asking first. Discarded changes cannot be recovered |
+
+### Display
+
+| Setting | Meaning |
+| --- | --- |
+| *Changed files shown* | 0 lists every changed file |
+| *Show folders* | Print each changed file's folder under its name |
+| *Commits shown* | How many recent commits the log section lists |
+| *Re-read every* | Minutes between extra reads of the repository, on top of following the Git plugin's own updates. 0 — the default — follows those updates only, which already covers everything done inside Obsidian |
+
+Per-file diffs are available from the card.
+
+---
+
+## Jira filter
+
+**What it shows:** issues from a saved Jira filter or a JQL search.
+
+**Requires:** a Jira Cloud or Jira Server instance reachable over HTTPS, and a
+personal access token.
+
+| Setting | Meaning |
+| --- | --- |
+| *Jira host* | The Jira site origin, for example `https://jira.example.com`. HTTPS is required when sending a personal access token |
+| *Personal access token* | A bearer PAT used for this card. Stored in Hearth's plugin data |
+| *API base path* | A relative Jira REST path such as `/rest/api/latest`. Full URLs are rejected |
+| *Saved filter* | Load your favourite Jira filters, then choose one |
+| *Filter controls* | Which controls the card offers for narrowing the list |
+| *Max results* | The most issues to show, up to 200 |
+| *Auto-refresh (minutes)* | How often to refresh. 0 refreshes only when the card is opened or refreshed by hand |
+| *Cache interval (minutes)* | How long successful Jira responses stay in memory. 0 disables caching |
+
+Issues can be filtered by status, assignee, priority, type, sprint and version.
+
+Favourite filters cannot be loaded while *Disable external calls* is on, and the
+card says so. If loading fails, check the host, the API path and the token.
+
+**The personal access token is never included in an export.** See
+[chapter 16](16-sharing-and-gallery.md).
+
+---
+
+## RSS feed
+
+**What it shows:** headlines from any RSS 2.0 or Atom feed.
+
+**Requires:** network access.
+
+### Feeds
+
+Each feed has an optional name and a URL. There is also an **Add from GitHub**
+helper: enter a repository as `owner/repo`, or paste its URL, choose
+**Releases**, **Commits** or both, and Hearth builds the Atom feed URLs for you.
+
+*Combined "All" tab* adds a leading tab that merges every feed into one stream,
+newest first.
+
+### Display
+
+| Setting | Meaning |
+| --- | --- |
+| *Layout* | **List** (title and date), **Cards** (excerpt and image), or **Compact** (headlines) |
+| *Items per feed* | How many recent items to show |
+| *Auto-refresh (minutes)* | How often to refetch. 0 fetches only when opened |
+| *Show images* | Show item thumbnails when the feed provides them |
+| *Show excerpt* | Show a short text snippet under each item |
+| *Show date* | Show each item's publish time |
+
+With external calls disabled, the card says *Feeds are off (external calls
+disabled)* rather than failing silently.
+
+---
+
+## Weather
+
+**What it shows:** current conditions and a forecast, in five styles up to a
+full painted sky.
+
+**Requires:** network access. Forecasts come from
+[Open-Meteo](https://open-meteo.com) — free, key-less, no account. Only the
+coordinates you pick are ever sent.
+
+### Location
+
+You can find a place by name — Hearth stores the coordinates on the card, so the
+lookup happens once — or type latitude and longitude in decimal degrees
+yourself. There is also a *Reuse a location* picker offering places already set
+on your other weather cards, and a *Label* for what the card calls the place.
+
+Place search is unavailable while external calls are disabled; entering
+coordinates by hand still works.
+
+### Style
+
+| Style | What it draws |
+| --- | --- |
+| *Minimal* | A glyph and a temperature |
+| *Compact* | One row |
+| *Detailed* | A grid of metrics |
+| *Forecast* | An hourly curve |
+| *Artistic* | An edge-to-edge painted sky that follows the real conditions and time of day |
+
+*Animate the sky* adds drifting clouds, falling rain and twinkling stars. It is
+always off in low power mode.
+
+Clicking a card opens the full forecast, hour by hour.
+
+### Units
+
+Temperature in Celsius or Fahrenheit; wind speed in km/h, m/s, mph or knots;
+precipitation in millimetres or inches; time in 12-hour, 24-hour or automatic
+(locale) format.
+
+### What to display
+
+Individually switchable: place name, condition, feels-like, today's high and
+low, humidity, wind, precipitation (chance of rain, how much has fallen, and
+per-hour chances), UV index, pressure, sunrise and sunset, and last updated.
+
+*Hours ahead* sets how many hours the hourly strip covers (0 hides it) and *Days
+ahead* how many days the daily forecast covers (0 hides it). *Auto-refresh
+(minutes)* sets how often the forecast is refetched; 0 fetches only when opened.
+
+### The weather sky as a background
+
+The same painted sky can be used as the whole board's background, which is a
+separate feature described in [chapter 11](11-appearance.md). A sky pinned to
+one fixed condition needs no location at all and never goes online.
+
+---
+
+## The four Operon cards
+
+**What they show:** four different views onto [Operon](https://github.com/hasanyilmaz/operon):
+a **task list**, a **status board** (Operon's pipeline statuses as columns), an
+**agenda** covering the next few days, and the running **timer**.
+
+**Requires:** the Operon plugin, desktop only, Obsidian 1.12.2 or newer, and an
+approval step inside Operon. See [chapter 14](14-integrations.md) for the
+connection setup, which is the one integration that needs an action from you.
+
+All four read through Operon's own in-process Developer API, so recurrence,
+statuses, priorities and completion stay Operon's to define. Hearth never parses
+Operon's notes.
+
+### Common settings
+
+| Setting | Meaning |
+| --- | --- |
+| *View* | Task list, Status board, Agenda or Timer |
+| *Scope* | Use one of Operon's own scoped views — *All tasks*, *Happening today*, *Overdue*, *Recently touched* — or **Custom filters** |
+| *Tasks shown* | Maximum tasks in the list, or per board column |
+| *Days ahead* | Agenda only: how many days it covers, including today |
+| *Sort* | **Smart (date, priority, age)**, **Date**, **Priority**, **Created** or **Alphabetical**, with a direction toggle. Open tasks always come before completed ones |
+
+Handing the question to one of Operon's own scopes means Operon decides what
+counts as overdue or happening today, so the card stays correct as Operon's own
+rules evolve.
+
+### Custom filters
+
+With *Scope* set to **Custom filters**, the card filters by *Pipelines*,
+*Statuses*, *Priorities*, *Completion* (Open, Done, Cancelled — open only by
+default) and a free-text *Text match* against the task description. Selecting
+nothing in a picker means "all".
+
+The pickers are populated from what Operon actually has, so a card added before
+the connection is live shows *Add an Operon card to the board first to load
+these options*.
+
+### What each task row shows
+
+Individually switchable: dates, priority, status, a recurring marker, a running
+timer marker, a pinned marker, and the note name.
+
+Clicking a task opens its note at the exact line.
+
+### Making changes
+
+Reading is the default. Writing is a choice, switched on at **Settings → Hearth
+→ Integrations → Operon → Allow changes**.
+
+With changes allowed:
+
+- the board card lets you drag a task into another status column, or pick one
+  from the row's right-click menu so it works without a mouse,
+- every card grows a **+** that creates a task where Operon's own settings say
+  new tasks go.
+
+Hearth previews the change, Operon rates it and applies it, and anything more
+than routine is confirmed with you first, in Operon's own words. A move carries
+the status the board was drawn from, so a drag onto a stale board is refused
+rather than quietly undoing someone else's change.
+
+*New tasks* on the card chooses what the **+** asks Operon to make: **Operon's
+default** (following Operon's own settings), **Inline, in a note**, or **Its own
+note**. Where the task actually goes is Operon's decision either way. If Operon
+is set to ask where each new inline task goes — which a dashboard card cannot
+answer — the card tells you to choose *Its own note* instead.
+
+### Empty and error states
+
+The Operon cards are unusually explicit about why they are not showing anything:
+*Enable the Operon plugin*, *The Operon integration is off*, *Operon's developer
+API is desktop-only and needs Obsidian 1.12.2 or newer*, *Approve Hearth in
+Settings → Operon → Core → General → Developer API Integrations*, *Operon
+suspended Hearth's access*, *Operon access was revoked*, *Operon is still
+starting up*, and *Operon refused the connection*, with Operon's own error text
+shown underneath.
+
+---
+
+## Plugin view (beta)
+
+**What it shows:** another plugin's registered side-panel view, hosted inside a
+card — a calendar, an outline, a tag pane, a Kanban board.
+
+**Requires:** any plugin that registers a view.
+
+| Setting | Meaning |
+| --- | --- |
+| *View to host* | A registered view from a core or community plugin. The list depends on which plugins are enabled |
+| *File to show* | Optional. Open a specific vault file in the hosted view — an Excalidraw drawing, a canvas, a note. Leave empty to host the view without a file; some views then show a blank or "new file" screen |
+| *Hide view header* | Hide the hosted view's own breadcrumbs, back/forward arrows and menu. Handy when the card shows a single file |
+
+The card can also be pinned to one file, which is what makes it useful for a
+specific drawing or PDF.
+
+### The performance warning, in full
+
+This is by far the heaviest card Hearth has. It runs another plugin's full view
+live inside the dashboard, so it keeps that plugin's own timers, listeners and
+rendering going for as long as the board is open, and **every one of these cards
+costs again**. Use one or two at most, and expect a slower dashboard on modest
+hardware.
+
+Hearth's performance tier cannot slow this card down, because a hosted view
+manages itself. If you have stepped the tier down and the dashboard still feels
+heavy, this is the one card worth removing.
+
+### Beta status
+
+Some views expect to live in a sidebar and may render or size oddly inside a
+card. If you want a hosted view at full size, consider a **plugin view
+dashboard** instead, which gives the view the whole board; see
+[chapter 5](05-dashboards.md).

--- a/docs/user-guide/11-appearance.md
+++ b/docs/user-guide/11-appearance.md
@@ -1,0 +1,233 @@
+# 11. Appearance: backgrounds, banners, frosted glass and icons
+
+This chapter covers how a Hearth dashboard looks: the backdrop behind it, the
+surface the cards are drawn on, and the marks and icons around them.
+
+Nearly everything here exists at two or three levels. The vault-wide value lives
+under **Settings → Hearth**; a dashboard can override it from *Dashboard
+settings*; and for the card-surface properties an individual card can override it
+again from its own Style tab. The most specific level with an opinion wins, and
+every overriding control tells you what it is overriding.
+
+---
+
+## The background
+
+Vault-wide: **Settings → Hearth → Appearance → Background**.
+Per dashboard: *Dashboard settings → Background*.
+
+### The six background types
+
+| Type | What it is |
+| --- | --- |
+| *Hearth default* | The soft ambient wallpaper that ships with the plugin. Note that this image is served from `raw.githubusercontent.com`, so it is a web request like any other |
+| *None* | Your theme's own background, untouched |
+| *Solid color* | Any CSS colour, for example `#1e1e2e` or `rgb(30,30,46)` |
+| *Vault image* | An image path in your vault, for example `Attachments/bg.png` |
+| *Image URL* | A direct image URL |
+| *Live weather sky* | A painted sky — see below |
+
+### Opacity and blur
+
+*Opacity* controls how much the background shows through; lower is more subtle.
+*Blur* is the background blur in pixels.
+
+The defaults are deliberately ambient: opacity 0.35 and blur 2. The background
+is visible but does not compete with the content, and the image is still
+recognisable rather than a wash of colour.
+
+### Full background or banner
+
+*Background layout* wears the same backdrop two ways:
+
+- **Full background** — it fills the whole view. This is what Hearth has always
+  done, and stays the default.
+- **Banner** — a strip across the top of the board, the way a cover image sits
+  above a note, with the cards below it on your theme's own surface.
+
+Banner mode has three further controls: *Banner height* in pixels, *Fade the
+lower edge* (let the banner dissolve into the page instead of ending on a hard
+line), and *Full width* (run the banner edge to edge instead of lining it up
+with the content below).
+
+Each of these is a per-board override, so one dashboard can show the vault's
+background as a banner while the next keeps it as a wallpaper.
+
+### The live weather sky
+
+Instead of an image, the board's backdrop can be a **painted sky** — the same
+sky the Weather card's *Artistic* style draws, spread across the whole window.
+
+There are two ways to run it:
+
+**Follow the real weather** over a place you pick. Conditions come from
+Open-Meteo; only the coordinates are sent, and nothing is fetched while external
+calls are off. The sky follows the real conditions and the real time of day.
+
+**Pin one sky** — clear night, snow, thunder, and so on — and keep it whatever
+the weather is doing. A pinned sky **needs no location at all and never goes
+online**. If you like the look but do not want the network, this is the option.
+
+| Setting | Meaning |
+| --- | --- |
+| *Sky* | **Live weather** or **A fixed sky** |
+| *Condition* | Fixed sky only: the weather this sky always shows |
+| *Time of day* | **Follow the clock**, **Always day**, or **Always night** |
+| *Animate the sky* | Drifting clouds, falling rain and twinkling stars behind the board |
+
+Animation is always off in low power mode, and for readers whose system asks for
+reduced motion. Each dashboard can also override *Animate the sky* on its own.
+
+### External calls and backgrounds
+
+An *Image URL* background and a title icon given as a web address are both
+network requests. While *Disable external calls* is on under **Settings → Hearth
+→ Behaviour**, the settings page says the background will not be shown and
+suggests a vault image instead; a URL background falls back to no picture, and a
+URL title icon falls back to the Hearth crystal.
+
+---
+
+## The card surface
+
+Vault-wide: **Settings → Hearth → Dashboard → Card surface**.
+Per dashboard: *Dashboard settings → Style*.
+Per card: that card's *Style* tab.
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Card opacity* | 0.5 | Transparent card backgrounds, so the dashboard background shows through |
+| *Card blur* | 0 (off) | Frosted-glass blur behind translucent cards. Needs card opacity below 100% to show |
+| *Card corner radius* | 14 px | How rounded card corners are. 14 is both the default and the maximum; lower makes corners sharper, down to 0 |
+| *Card border* | 1 px | Thickness of the card border and the header divider. 0 hides the border |
+
+### Why frosted glass is off by default
+
+Card blur defaults to 0, and this is the one default that was chosen for power
+rather than for looks. Every blurred card is a `backdrop-filter` layer that the
+compositor re-evaluates whenever anything behind it changes. On a board with a
+moving wallpaper that means re-blurring every frame at the display's full pixel
+density.
+
+Translucency is kept — alpha compositing is cheap — so cards still read as glass
+over the wallpaper. If you want the full frosted look and your hardware can
+carry it, raise *Card blur*.
+
+Vaults that already had a blur value set keep it; the change in default only
+affects fresh installs.
+
+### Merged cards blur as one
+
+When two cards are snapped edge to edge their shared border drops out and they
+blur as a single seamless sheet, rather than as two overlapping panes of glass.
+This is automatic; see [chapter 6](06-arranging-cards.md).
+
+### Per-card colours
+
+Beyond opacity, blur and border, each card can take an **accent** colour and a
+**background tint** of its own, both clearable back to the dashboard's default.
+
+---
+
+## Spacing and width
+
+| Setting | Where | Meaning |
+| --- | --- | --- |
+| *Compact spacing* | Settings → Hearth → Dashboard; per board on the Layout tab | Tighten card padding and the top margin to enlarge the usable area |
+| *Content width* | Settings → Hearth → Appearance → Home; per board on the Layout tab | The widest the home content may grow, in pixels. Default 1600. It is a ceiling, not a width — the content still shrinks to fit a narrower pane |
+| *Full width* | Same places | Let the content fill the pane instead of stopping at the width above. Cards keep their proportions as the pane widens, but text does not grow with them, so a very wide board reads sparser |
+| *Fit to page* | Settings → Hearth → Dashboard; per board on the Layout tab | Keep the dashboard to one screen instead of allowing it to scroll. On by default |
+
+---
+
+## The title and its icon
+
+Vault-wide: **Settings → Hearth → Appearance → Home**.
+Per dashboard: *Dashboard settings → Header*.
+
+| Setting | Meaning |
+| --- | --- |
+| *Show title* | Display the big title and its icon at the top |
+| *Title* | The heading text. The default is `Obsidian` |
+| *Title icon* | The mark drawn next to the title |
+| *Tab icon* | A Lucide icon for Hearth's tab header and ribbon button, in place of the Hearth crystal |
+| *Follow theme icon color* | Draw the crystal icon and/or the title text in your theme's icon colour instead of the default purple crystal and normal text. Four choices: **Off**, **Icon**, **Title**, **Icon and title** |
+
+### One title icon, four kinds of value
+
+The *Title icon* field accepts any of four things, and works out which you gave
+it:
+
+1. A **Lucide icon id** such as `home` or `layout-dashboard`. A search button
+   browses the whole Lucide set, so you do not have to remember ids.
+2. An **emoji**, or a couple of characters.
+3. The **vault path of an image**, such as `Attachments/logo.png`. There is a
+   picker button for this.
+4. The **URL of an image on the web**.
+
+Leave it empty for the Hearth crystal.
+
+Each dashboard can override the title icon, so one board can wear a logo and the
+next the crystal. Hearth's tab and ribbon icons follow the vault-wide setting
+even when a board overrides its own title mark.
+
+### Title layout, per board
+
+A dashboard's Header tab additionally offers *Title alignment* (default centre,
+or left, centre, right), *Title size*, *Title icon size*, *Title top margin* and
+*Spacing below title/header*. These are per-board only; there is no vault-wide
+equivalent, because they are layout decisions that tend to differ from board to
+board.
+
+---
+
+## Chrome visibility
+
+The dashboard switcher and the Arrange button can each be set to **Always
+visible** or **Show on hover**.
+
+Vault-wide those are *Arrange button visibility* and *Dashboard switcher
+visibility* under **Settings → Hearth → Dashboard → Dashboard controls**. Per
+board they are *Arrange button* and *Dashboard switcher* on the Layout tab of
+that dashboard's settings.
+
+Hiding both gives a completely clean board that reveals its controls only when
+you reach for them.
+
+---
+
+## A dashboard's own search row
+
+Beyond the title, each dashboard can set its own search placeholder, its own
+button beside the search field (or none), its own filter chips, and whether the
+search section is shown at all. Each follows the vault until the board says
+otherwise, and each travels with the board when you export it. See
+[chapter 4](04-search.md) and [chapter 5](05-dashboards.md).
+
+---
+
+## Themes
+
+Hearth draws its own surfaces but honours your Obsidian theme's colours, and the
+*Follow theme icon color* setting exists specifically so the brand mark can join
+in rather than sitting apart from the theme.
+
+When you publish a dashboard to the gallery you can note which theme it was
+built for. That is a note to whoever installs it — nothing is installed or
+changed on their side. See [chapter 16](16-sharing-and-gallery.md).
+
+---
+
+## Putting a look together: three worked examples
+
+**A calm, low-contrast board.** Background: *Hearth default* at opacity 0.25,
+blur 4. Card surface: opacity 0.6, blur 12, radius 14, border 0. Compact
+spacing off. Chrome on hover.
+
+**A photograph board.** Background: *Vault image* at opacity 1.0, blur 0, layout
+*Banner* with a 320 px height and *Fade the lower edge* on. Card surface: opacity
+1.0 (solid), so the cards read cleanly under the photograph.
+
+**A cheap-to-draw board for a laptop on battery.** Background: *Solid color*.
+Card surface: opacity 1.0, blur 0. Performance tier: *Reduced*, so nothing moves.
+See [chapter 12](12-performance.md).

--- a/docs/user-guide/12-performance.md
+++ b/docs/user-guide/12-performance.md
@@ -1,0 +1,136 @@
+# 12. Performance tiers and battery life
+
+A Hearth dashboard can be an expensive thing to draw. A painted animated sky, a
+frosted-glass blur behind every card, a handful of cards refreshing on timers,
+and a hosted plugin view all cost CPU, GPU and battery. Hearth therefore has an
+explicit performance control rather than leaving you to guess which setting is
+the expensive one.
+
+It lives at **Settings → Hearth → Appearance → Performance**.
+
+## The performance tier
+
+*Performance tier* is a single dropdown with four steps. Each step down drops
+the next most expensive thing the board does.
+
+**Nothing you have configured is overwritten.** Your settings are kept exactly as
+they are and come back when you move the tier back up. The sections whose
+settings a tier currently overrides say so in place, so you are never left
+wondering why a switch appears to do nothing.
+
+### The four tiers
+
+| Tier | What it means |
+| --- | --- |
+| **Full — everything on** | Every effect at full strength |
+| **Balanced — a lighter sky** | The painted sky is drawn at half density |
+| **Reduced — nothing moves** | No motion, no frosted glass |
+| **Minimal — plain and still** | A flat colour, opaque cards, nothing moving, nothing refreshing |
+
+**Full.** Every effect at full strength. The painted weather sky is the most
+expensive thing here: if the board is warming up your machine, this is the
+setting to step down.
+
+**Balanced.** The painted sky is drawn at half density — fewer raindrops, stars,
+clouds and wisps of fog. Nothing is switched off and nothing stops moving; there
+is simply less of it, for about a third less work. This is the default on
+mobile.
+
+**Reduced.** Nothing on the board moves, and the frosted glass behind cards is
+off. Your wallpaper stays, cards stay translucent, and every card still
+refreshes on its timer — the board just holds still.
+
+**Minimal.** The frugal end: a flat colour instead of the wallpaper, opaque
+cards, no motion, and no card refreshing itself on a timer.
+
+### Exactly what each tier changes
+
+Hearth lists the effects of the selected tier under the dropdown. The full set of
+possible effects, in the order the tiers apply them, is:
+
+| Effect | Applies at |
+| --- | --- |
+| The painted weather sky is drawn at half density | Balanced |
+| Transitions, hover lifts, shadows and animations are off | Reduced |
+| No frosted-glass blur behind cards | Reduced |
+| Clock cards drop seconds and the sweeping second hand | Reduced |
+| Slideshow cards hold one picture instead of rotating | Reduced |
+| The background is a flat colour — no image, GIF, opacity layer or blur | Minimal |
+| Cards are opaque rather than translucent | Minimal |
+| Web, RSS, calendar-subscription and Jira cards stop refreshing on a timer (manual refresh still works) | Minimal |
+| The dashboard stops rebuilding itself on vault changes | Minimal |
+
+### The minimal background colour
+
+*Minimal background* sets the flat colour shown behind the home view on the
+minimal tier. It accepts any CSS colour, for example `#4a4459`.
+
+## Pausing animation when you are not looking
+
+*Pause animation when Obsidian isn't in front* holds every animation while you
+are working in another application or another window. It is on by default.
+
+The reasoning is worth knowing: a Hearth tab hidden behind another Obsidian tab
+already costs nothing, because it is not being drawn. This setting covers the
+case a hidden tab does not — a **visible** board in a window you are not using,
+sitting beside a browser or on a second screen.
+
+Turn it off if you deliberately keep the dashboard running on a second display
+and want the sky to keep moving.
+
+## A separate tier for mobile
+
+Phones and tablets draw the animated sky and the frosted glass on the smallest
+screen and pay for it out of a battery, so Hearth keeps a **separate tier for
+mobile**: *Performance tier on mobile*, under **Settings → Hearth → Mobile →
+Layout**.
+
+It defaults to **Balanced**. It can also be set to *Match desktop*. Your desktop
+tier is stored separately and is never changed by the mobile one.
+
+## What the tier cannot help with
+
+Three costs sit outside the tier system, and it is worth knowing which:
+
+**Hosted plugin views.** The **Plugin view** card and a **plugin view
+dashboard** both run another plugin's full view live. That plugin manages its own
+timers, listeners and rendering, so Hearth's tier cannot slow it down. The card's
+own settings say as much, and add that if you have already stepped the tier down
+and the dashboard still feels heavy, this is the one card worth removing.
+
+**The number of cards.** Thirty cards cost more than ten, at any tier.
+
+**Other plugins.** A Dataview query over a large vault costs what Dataview costs.
+
+## A practical tuning order
+
+If a Hearth board is making your machine work harder than you want, change
+things in roughly this order — each step is cheaper to give up than the one
+before it:
+
+1. **Turn off the animated sky**, or step the tier to *Balanced*. This is the
+   single largest cost on most boards.
+2. **Turn card blur down or off.** Every blurred card is a compositor layer
+   re-evaluated whenever anything behind it changes.
+3. **Remove any Plugin view cards**, or turn off *Keep running in the
+   background* on plugin view dashboards you rarely visit.
+4. **Raise the refresh intervals** on web, RSS, calendar-subscription and Jira
+   cards, or set them to 0 so they only fetch when opened.
+5. **Step the tier to *Reduced***, which stops all motion.
+6. **Step the tier to *Minimal***, which drops the wallpaper and stops timers.
+
+## Reduced-motion preferences
+
+If your operating system asks for reduced motion, Hearth honours it: the painted
+sky holds still regardless of the tier and regardless of the per-board *Animate
+the sky* setting. This is accessibility behaviour and is not something you have
+to configure in Hearth.
+
+## Further reading
+
+The repository contains a detailed engineering investigation into Hearth's power
+use on macOS, at
+[`docs/performance/macos-power-investigation.md`](../performance/macos-power-investigation.md),
+along with the benchmarks it was based on. That document is written for
+developers, but it explains in depth *why* the sky and the blur are the two
+expensive things.

--- a/docs/user-guide/13-mobile.md
+++ b/docs/user-guide/13-mobile.md
@@ -1,0 +1,147 @@
+# 13. Hearth on a phone or a narrow pane
+
+Hearth runs on Obsidian for iOS and Android as a first-class board, not as a
+reduced version of the desktop one. It also applies the same treatment to a
+narrow pane on the desktop, because the problem is the same: a free-form layout
+stops meaning anything below a certain width.
+
+Everything in this chapter except the per-card options lives under **Settings →
+Hearth → Mobile**.
+
+## The threshold is width, not platform
+
+A Hearth board is laid out freely: cards sit where you drop them, at a fraction
+of the board's width. At or below **600 pixels** of measured board width that
+stops working, so the board **reflows into a single full-width column**, top to
+bottom, in the order the desktop board reads in.
+
+The threshold is the **measured width of the board**, not the platform. So:
+
+- a phone gets the stacked column,
+- a narrow split pane on the desktop gets the same stacked column,
+- and you can see your phone layout on your desktop simply by dragging a pane
+  narrow.
+
+**Your layout is never rewritten.** The stored board is untouched and comes back
+at full width. The same board is a launcher on your phone and a wall of cards on
+your monitor.
+
+## The stacked column
+
+*Stack cards on narrow screens* under **Settings → Hearth → Mobile → Layout** is
+on by default. Turning it off keeps the free-form layout at any width, scaled
+down.
+
+Each dashboard can override this from *Dashboard settings → Layout → Stack when
+narrow*: **Stack into one column** or **Keep the scaled layout**.
+
+While stacked, cards are full width, one per row.
+
+## Per-card behaviour in the column
+
+Every card's settings has an *On a narrow board* section on its **Layout** tab
+with four options. These are the tools for turning a desktop board into a
+readable phone board without maintaining two boards.
+
+| Option | Meaning |
+| --- | --- |
+| *Hide* | Leave this card out of the stacked column entirely. For a card that needs width to make sense — a wide table, a Kanban board — hiding beats squeezing |
+| *Start collapsed* | Show only the card's title row, and build the card when it is tapped open. A card nobody opens costs one row and runs nothing |
+| *Height* | Height in pixels when stacked. Left empty, the card keeps its own height (falling back to 184 pixels if it has none), clamped to at least 56 pixels and at most 420, so a tall card cannot fill the screen on its own |
+| *Position* | Where this card comes in the stack, counting from 0. Left empty, it follows the order the board reads in: top to bottom, left to right |
+
+*Start collapsed* is the important one for performance. An expensive card — a
+Dataview query, an embedded note, a hosted view — costs one row and runs nothing
+until it is tapped.
+
+In arrange mode, a card's header also carries a **Hide on a narrow board** /
+**Show on a narrow board** toggle, which is the same setting reached faster.
+
+## Previewing the phone layout without a phone
+
+Press **Arrange → Preview at phone width**. Hearth builds and shows the stacked
+board inside a drawn phone, so the proportions read properly rather than being a
+narrow strip in a wide window.
+
+While in the preview you can:
+
+- drag a card's bottom edge to set its stacked height,
+- use the **move up** and **move down** buttons in a card's header to reorder the
+  column.
+
+Leave the preview with **Leave phone preview**.
+
+## What else changes on a narrow board
+
+- **Edge to edge.** The side gutters go; the device's safe-area insets stay.
+- **Tap targets.** Filter chips and search results grow to 44-pixel tap targets.
+- **Full-width search.** The chips and results span the screen instead of the
+  search bar's share of it, and the button beside the field drops to an icon.
+- **Keyboard-aware.** The visible area tracks the on-screen keyboard, so the
+  field you are typing in is not hidden behind it.
+
+## A separate performance tier
+
+Phones draw the animated sky and the frosted glass on the smallest screen and
+pay for it out of a battery, so Hearth keeps a separate tier for them.
+
+*Performance tier on mobile* defaults to **Balanced** and can also be set to
+*Match desktop*. Your desktop tier is stored separately and is never changed by
+this one. See [chapter 12](12-performance.md).
+
+## Choosing which board opens on a phone
+
+A dashboard's *Default on mobile* setting (on its **General** tab) makes Hearth
+open that board when it loads on a phone or tablet. Only one board can hold this;
+turning it on clears it on the others.
+
+This is how you keep a dense desktop board and a spare phone board in the same
+vault without switching by hand each time.
+
+## Mobile mode: search only
+
+*Mobile mode (search only)* under **Settings → Hearth → Mobile → Layout** is a
+different proposition from the stacked column. It hides the dashboard entirely
+on phones and tablets and shows **only the search field**, turning Hearth into a
+pure launcher on a phone. It has no effect on desktop.
+
+It is off by default. Use it if the dashboard is a desktop thing for you and the
+phone is for finding notes.
+
+## The mobile action bar
+
+In Mobile mode (search only), a row of buttons replaces the *New note* button
+beside the search bar, appearing under the search field and filters instead.
+
+*Show action bar* switches the row on; it is on by default.
+
+The default buttons are **New note**, **New drawing**, **Record voice** and
+**Open daily note**. Each button can be changed to run any command, open a note
+or file, or open a URL — exactly like a launchpad tile. Each has a label and an
+icon, and buttons can be reordered, removed, added, and reset to the defaults.
+
+Three of the defaults depend on other plugins:
+
+- *New drawing* runs the Excalidraw plugin's own "new drawing" command.
+- *Record voice* starts and stops Obsidian's core Audio recorder.
+- *Open daily note* uses Obsidian's core Daily notes plugin.
+
+If one of those is not enabled, Hearth says which plugin to enable rather than
+failing silently.
+
+## Its own settings category
+
+All of the above lives under **Settings → Hearth → Mobile**, which is a category
+of its own rather than two sections buried in Behaviour. Hearth runs on a phone
+as a first-class board, and the settings pane says so.
+
+## Exporting on mobile
+
+One mobile-specific detail worth knowing: on mobile, an export file is saved to
+your vault's root folder rather than downloaded, because mobile Obsidian has no
+download folder. Hearth tells you the filename it saved. See
+[chapter 16](16-sharing-and-gallery.md).
+
+Publishing to the dashboard gallery needs a screenshot of the board, and
+screenshots need the desktop application. You can still save a dashboard as a
+file on mobile and publish it later from a desktop vault.

--- a/docs/user-guide/14-integrations.md
+++ b/docs/user-guide/14-integrations.md
@@ -1,0 +1,287 @@
+# 14. Integrations: every plugin and service Hearth works with
+
+Hearth integrates with twenty-five other things: community plugins, Obsidian's
+own core plugins, and external services. Almost all of them are picked up
+automatically — nothing to connect, no keys to paste. The exceptions are named
+explicitly below.
+
+The full live catalogue is inside the plugin at **Settings → Hearth →
+Integrations**. It lists every integration whether or not it is installed,
+shows its current status, and says where its settings live. Rows for
+integrations that need a setting link straight down to it; rows for missing
+plugins offer an **Install** button that opens that plugin in Obsidian's
+community plugin browser.
+
+## Reading the status pills
+
+| Pill | Meaning |
+| --- | --- |
+| **Enabled** | Installed and enabled — Hearth is using it |
+| **Disabled** | Installed but turned off, so Hearth cannot use it right now |
+| **Not installed** | Not installed. Everything else in Hearth works without it |
+| **Network** | An outbound request, not a plugin |
+| **Always available** | Nothing to install |
+
+## Where an integration's settings live
+
+| Note on the row | Meaning |
+| --- | --- |
+| *Settings below on this tab* | It has a section further down the Integrations tab |
+| *Settings under <tab>* | It is configured on another Hearth settings tab |
+| *Configured on the card itself, on your dashboard* | Open the card's gear in arrange mode |
+| *Uses that plugin's own settings — nothing to set in Hearth* | Hearth reads the other plugin's configuration |
+| *Nothing to configure* | It just works |
+
+---
+
+## Community plugins
+
+### Omnisearch
+
+**What Hearth does with it:** swaps the search bar over to
+[Omnisearch](https://github.com/scambier/obsidian-omnisearch)'s fuzzy, full-text
+index instead of Hearth's built-in engine.
+
+**Configured in:** *Settings → Hearth → Search → Search bar → Search engine*.
+
+The choice only sticks while Omnisearch is enabled — disable the plugin and
+Hearth falls back to its own engine rather than showing you an empty search.
+
+### TaskNotes
+
+**What Hearth does with it:** Tasks cards read one-note-per-task vaults — status,
+due date and priority straight from frontmatter. Mini calendar cards can also
+draw TaskNotes items: scheduled tasks, due dates, recurring occurrences,
+timeblocks, and the calendars subscribed inside TaskNotes.
+
+**Configured in:** *Settings → Hearth → Integrations → Tasks / TaskNotes*.
+
+TaskNotes has no stable API for other plugins, so Hearth reads its frontmatter
+directly, which means it has to be told the field names. Hearth's defaults are
+TaskNotes' own defaults (`status`, `due`, `priority`, `done`); if you renamed a
+field inside TaskNotes, match it here. The setup wizard reads these from
+TaskNotes for you when it builds a Tasks card.
+
+See [chapter 8](08-cards-planning.md).
+
+### Dataview
+
+**What Hearth does with it:** the Dataview card runs DQL queries and DataviewJS
+blocks and renders them with
+[Dataview](https://github.com/blacksmithgu/obsidian-dataview)'s own renderers,
+refreshing as its index changes.
+
+**Configured in:** the card itself.
+
+### Datacore
+
+**What Hearth does with it:** the Datacore card runs a
+[Datacore](https://github.com/blacksmithgu/datacore) query — or a JS, JSX, TS or
+TSX script — and renders it with Datacore's own live views. Datacore is
+Dataview's successor.
+
+**Configured in:** the card itself.
+
+### Templater
+
+**What Hearth does with it:** the *New note from template* card turns your
+[Templater](https://github.com/SilentVoid13/Templater) templates into buttons,
+each carrying its own template, destination folder and filename pattern.
+Templater's *New note* integration is also available for the search bar's action
+button.
+
+**Configured in:** the card itself, and *Settings → Hearth → Search → Search
+bar*.
+
+Templater does the templating throughout: your user scripts,
+`tp.system.prompt()` dialogs and cursor placement behave exactly as they do from
+Templater's own command.
+
+### Periodic Notes
+
+**What Hearth does with it:** the Periodic note card shows this week's, month's,
+quarter's or year's note, resolved — and created, from your own template — by
+[Periodic Notes](https://github.com/liamcain/obsidian-periodic-notes) itself.
+
+**Configured in:** the card itself.
+
+### Git
+
+**What Hearth does with it:** the Git card shows your repository's branch,
+changes and recent commits, and commits, syncs, pushes and pulls through the
+[Git](https://github.com/Vinzent03/obsidian-git) plugin itself — its remote,
+credentials and commit-message template all apply unchanged.
+
+**Configured in:** the card itself.
+
+### Operon
+
+**What Hearth does with it:** four cards — tasks, board, agenda and timer — read
+through [Operon](https://github.com/hasanyilmaz/operon)'s own Developer API, so
+its statuses, priorities and recurrence stay its to define.
+
+**Configured in:** *Settings → Hearth → Integrations → Operon*.
+
+This is the one integration that needs a step from you. It has its own section
+below.
+
+### Iconic and Iconize
+
+**What Hearth does with them:** per-file icons set with
+[Iconic](https://obsidian.md/plugins?id=iconic) or
+[Iconize](https://obsidian.md/plugins?id=obsidian-icon-folder) (formerly
+Obsidian Icon Folder) show up wherever Hearth lists a file — Recent, Favorites,
+saved searches and search results. Iconize icons set through a frontmatter
+property are included.
+
+**Configured in:** *Settings → Hearth → Integrations → File icons / Iconic /
+Iconize*.
+
+Lucide icons and emoji are shown; a file using an icon from a downloaded icon
+pack keeps Hearth's own file-type icon. Turning the setting off shows Hearth's
+file-type icon for every file, ignoring both plugins. Leaving it on in a vault
+with neither plugin installed changes nothing and starts working as soon as one
+is installed.
+
+If you renamed Iconize's frontmatter property, tell Hearth the new name;
+Iconize's own default is `icon`.
+
+### Excalidraw
+
+**What Hearth does with it:** Embed cards render
+[Excalidraw](https://github.com/zsviczian/obsidian-excalidraw-plugin) drawings
+live with native pan and zoom, and the *New drawing* action creates one through
+Excalidraw's own command.
+
+**Configured in:** the card itself.
+
+### Kanban
+
+**What Hearth does with it:** Tasks cards read and write
+[Kanban](https://github.com/obsidian-community/obsidian-kanban) board notes in
+Kanban's own format, so a board dragged around in Hearth stays fully editable in
+Kanban.
+
+**Configured in:** the card itself.
+
+---
+
+## Obsidian core plugins
+
+These are built into Obsidian. Enable them in **Settings → Core plugins** if a
+Hearth card says one is missing.
+
+| Core plugin | What Hearth does with it |
+| --- | --- |
+| **Daily notes** | The Daily note, Mini calendar and Vault statistics cards resolve today's note from Daily notes' own folder, date format and template |
+| **Bases** | Embed cards can show a `.base` view on the dashboard |
+| **Canvas** | Embed cards can show a canvas, interactive and edge to edge |
+| **Bookmarks** | The Bookmarks card lists your Obsidian bookmarks, groups and all |
+| **Search** | Hands a query over to Obsidian's own search pane when you ask for the full results |
+| **File explorer** | Powers *Reveal in file explorer* on Hearth's search results |
+| **Workspaces** | A dashboard can switch to a saved workspace when you open it |
+| **Audio recorder** | The *Record voice* mobile action button starts and stops Obsidian's own recorder |
+| **Any plugin with a side panel** | The Plugin view card hosts another plugin's registered view inside a card; a whole dashboard can also be given over to one |
+
+---
+
+## External services
+
+Every one of these is an outbound network request. **All of them are silenced at
+once** by *Disable external calls* under **Settings → Hearth → Behaviour →
+Privacy & network**. See [chapter 17](17-privacy-and-network.md).
+
+| Service | Used by | Account or key needed |
+| --- | --- | --- |
+| [Open-Meteo](https://open-meteo.com) | Weather cards and the live weather sky | None. Only the coordinates you pick are sent, and a pinned sky needs no location at all |
+| [Frankfurter](https://www.frankfurter.app/) (European Central Bank rates) | Calculator currency conversion | None |
+| Jira Cloud or Jira Server | Jira cards, over REST with bearer PAT authentication | Yours, entered on the card. Exports never include the token |
+| RSS and Atom feeds | RSS cards | None |
+| ICS and webcal feeds | Mini calendar subscriptions — Google, iCloud, Fastmail, Nextcloud and others | The feed URL |
+| DuckDuckGo, Brave, Kagi, Google, Mojeek, Ecosia, Qwant | The search bar's optional web-search button | None |
+| Whatever host you name | A background image or title icon given as a web address. Hearth's own bundled default wallpaper is one of these, served from `raw.githubusercontent.com` | None |
+| A dashboard gallery server | The gallery browser and publisher | An anonymous handle Hearth generates locally, needed only for voting and publishing |
+
+---
+
+## Operon in detail
+
+Operon is the one integration that needs an explicit action from you, because
+Operon requires plugins to be approved before they may read anything.
+
+### Before you add an Operon card
+
+| | |
+| --- | --- |
+| **Platform** | Desktop only, Obsidian 1.12.2 or newer |
+| **Approval** | Hearth's request appears in **Settings → Operon → Core → General → Developer API Integrations** — approve it there. Until then the cards say exactly what they are waiting for |
+| **Widening it** | Operon grants all-or-nothing, so turning on *Allow changes* needs a fresh approval |
+| **Status and kill switch** | **Settings → Hearth → Integrations → Operon** shows the connection, what was requested, and how to cut it |
+
+### How the connection works
+
+*Connect to Operon* under **Settings → Hearth → Integrations → Operon** is on by
+default, but it is inert until an Operon card exists: no session is opened, and
+so no grant is requested, until one renders. Switching it off is a kill switch —
+Operon cards stop reading and Hearth never asks Operon for access.
+
+The *Connection* row reports one of these states:
+
+| State | Meaning |
+| --- | --- |
+| Operon isn't installed or enabled | Nothing to connect to |
+| Operon's developer API is desktop-only and needs Obsidian 1.12.2 or newer | The platform does not support it |
+| Operon is running but still starting up | Wait |
+| Waiting for approval | Approve Hearth in Operon's Developer API Integrations |
+| Access is suspended | Review Hearth's pending scope in Operon's Developer API Integrations |
+| Access was revoked | Grant it again |
+| Connected — Operon cards can read tasks | Working |
+| Not connected yet | Add an Operon card to open a session |
+| The integration is switched off | The kill switch is on |
+| Operon refused the connection | Operon's own error text is shown underneath |
+
+*Recheck now* reopens the connection after approving, revoking or reloading
+Operon.
+
+### Requested access
+
+Hearth asks for all of its capabilities at once, because Operon does not open a
+partly approved session. The request is read-only unless *Allow changes* is on,
+which adds the task-transition and task-creation permissions. The settings
+section lists what has been requested and names anything not yet granted.
+
+### Allowing changes
+
+*Allow changes* lets the board card move a task to another status by dragging
+it, and adds a **+** for creating one. Operon decides where a new task goes and
+whether a move is legal; Hearth only asks.
+
+Turning this on **widens what Hearth requests**, so you will need to approve
+Hearth again in Operon's Developer API Integrations. Until you do, reading keeps
+working and the cards stay read-only, and Hearth says so.
+
+Off means Hearth can only read.
+
+### How writes are handled
+
+Hearth previews the change, Operon rates it, and Operon applies it. Anything
+more than routine is confirmed with you first, using Operon's own summary of
+what would happen rather than Hearth's guess at it.
+
+A move carries the status the board was drawn from, so a drag onto a stale board
+is refused rather than quietly undoing someone else's change.
+
+If Operon cannot confirm whether a change was applied, Hearth reports "unknown"
+rather than "failed", re-reads the card, and does **not** offer a retry — a retry
+could apply the change twice.
+
+See [chapter 10](10-cards-integrations.md) for the four Operon cards themselves.
+
+---
+
+## Integrations that need no setup at all
+
+For completeness, this is the set that simply works once the other plugin is
+enabled, with nothing to configure in Hearth: Dataview, Datacore, Excalidraw,
+Kanban, Periodic Notes, Git, Bases, Canvas, Bookmarks, Daily notes, Search, File
+explorer, Workspaces, Audio recorder, and any plugin with a side panel.

--- a/docs/user-guide/15-settings-reference.md
+++ b/docs/user-guide/15-settings-reference.md
@@ -1,0 +1,384 @@
+# 15. Complete settings reference
+
+This chapter lists every setting on Hearth's own settings page, in the order the
+page presents them, with what each one does and its default value where the
+default is meaningful.
+
+To reach it: **Obsidian Settings → Hearth**. The page opens on an index of eight
+categories, grouped into four headings. Choosing one opens that category; a back
+link returns to the index.
+
+| Index group | Categories |
+| --- | --- |
+| **Look & feel** | Appearance, Dashboard |
+| **How it works** | Search, Behaviour, Mobile |
+| **Data & plugins** | Integrations, Backup |
+| **Etc** | About |
+
+Each category also carries a one-line description on its index row and again at
+the top of its page:
+
+| Category | Description |
+| --- | --- |
+| Appearance | Title, title icon, background, and low power mode |
+| Search | The search bar and which results it offers |
+| Dashboard | Grid, card surface, and the controls around the board |
+| Behaviour | Startup, how notes open, and privacy |
+| Mobile | The stacked layout on a phone, and the action bar |
+| Integrations | TaskNotes, file icons, and every plugin Hearth reads |
+| Backup | Export and import your layout and settings |
+| About | Version, what's new, and where to report things |
+
+Sliders and text fields whose factory default is meaningful carry a **Reset to
+default** button.
+
+If a single section fails to render, Hearth shows a message in its place —
+*The "<name>" section couldn't be shown* — with a hint to open the developer
+console and report it. The other settings are unaffected.
+
+---
+
+## Appearance
+
+Three sections: Performance, Home, Background.
+
+### Performance
+
+*How much of the decoration to pay for. Trade visual effects for battery life
+and smoothness on slower hardware.*
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Performance tier* | Full | **Full — everything on**, **Balanced — a lighter sky**, **Reduced — nothing moves**, **Minimal — plain and still**. Nothing you configured is overwritten; your settings come back when you move back up |
+| *Pause animation when Obsidian isn't in front* | On | Hold every animation while you are working in another app or window. Covers a visible board in a window you are not using — beside a browser, or on a second screen |
+| *Minimal background* | `#4a4459` | The flat colour shown behind the home view on the minimal tier. Any CSS colour |
+
+The full effects of each tier are in [chapter 12](12-performance.md).
+
+### Home
+
+*Title, title and tab icons, search visibility and overall content width.*
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Show title* | On | Display the big title and its icon at the top |
+| *Show search section* | On | Display the search and command bar with its results and filter buttons. Individual dashboards can override this |
+| *Title* | `Obsidian` | The heading text at the top of the home view |
+| *Title icon* | empty (the Hearth crystal) | Takes a Lucide icon id, an emoji or a couple of characters, a vault image path, or an image URL. Each dashboard can override it |
+| *Tab icon* | empty (the Hearth crystal) | A Lucide icon for Hearth's tab header and ribbon button |
+| *Follow theme icon color* | Off | Draw the crystal icon and/or the title text in your theme's icon colour. **Off**, **Icon**, **Title**, **Icon and title** |
+| *Full width* | Off | Let the content fill the pane instead of stopping at the width below |
+| *Content width* | 1600 px | The widest the home content may grow. A ceiling, not a width — content still shrinks to fit a narrower pane |
+
+### Background
+
+*The backdrop behind the home view, and how much it shows through.*
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Background type* | Hearth default | **Hearth default**, **None**, **Solid color**, **Vault image**, **Image URL**, **Live weather sky** |
+| *Background value* | — | A CSS colour, a vault image path, or a direct image URL, depending on the type |
+| *Opacity* | 0.35 | How much the background shows through |
+| *Blur* | 2 px | Background blur |
+| *Background layout* | Full background | **Full background** or **Banner** |
+| *Banner height* | 220 px | How tall the banner strip is, in pixels |
+| *Fade the lower edge* | On | Let the banner dissolve into the page |
+| *Full width* (banner) | Off | Run the banner edge to edge instead of lining it up with the content |
+
+Weather sky settings, shown when the type is *Live weather sky*:
+
+| Setting | Meaning |
+| --- | --- |
+| *Sky* | **Live weather** (follow a real place) or **A fixed sky** |
+| *Condition* | Fixed sky only: the weather this sky always shows |
+| *Time of day* | **Follow the clock**, **Always day**, **Always night** |
+| *Animate the sky* | Drifting clouds, falling rain and twinkling stars |
+
+A URL background is not shown while *Disable external calls* is on, and the
+settings page says so.
+
+---
+
+## Search
+
+Two sections: Search bar, Search filters.
+
+### Search bar
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Search placeholder* | `Search or command` | The greyed-out text in the empty field |
+| *Search note contents* | On | Also match text inside note bodies, not just names, tags and properties. Body matches appear after name matches with a snippet |
+| *Search engine* | Hearth (built-in) | **Hearth (built-in)** or **Omnisearch**. Omnisearch requires that community plugin to be installed and enabled |
+| *Show "New note" button* | On | Show the action button beside the search field |
+| *Search-bar button* | New note | What the button does: **New note** or **Search online** |
+| *Online search engine* | DuckDuckGo | Which engine the *Search online* button opens. Also available: DuckDuckGo without AI, Brave, Kagi, Google, Mojeek, Ecosia, Qwant. The arrow beside the button searches with any of the others for one query without changing this |
+
+Then a sub-heading, **The "New note" button** — what the button makes, and where.
+The same settings drive the button beside the search bar, the one on a Search bar
+card, and Hearth's *Create new note* command.
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Button text* | empty ("New note") | Text on the button |
+| *Template* | Blank note | Make the note from a Templater template instead of a blank one. Requires Templater |
+| *Location* | Default location | Folder the new note goes in, created if it does not exist. "Default location" means wherever Obsidian puts new notes |
+| *Filename* | empty ("Untitled") | Name without the extension. Supports `{{date}}`, `{{date:FMT}}`, `{{time}}`, `{{time:FMT}}` and `{{prompt}}` |
+
+### Search filters
+
+*Filters are auto-detected from the file types in your vault. Hide any you don't
+want.*
+
+The possible groups are Folders, Notes, Excalidraw, Canvas, Bases, Images,
+Videos, Audio, PDF, Documents, Sheets, Slides, 3D and Other. A chip only appears
+if your vault holds that kind of file. Hiding a chip here hides it for every
+search bar, including Search bar cards.
+
+---
+
+## Dashboard
+
+Three sections plus an informational row.
+
+### Grid & spacing
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Fit to page* | On | Keep the dashboard to one screen instead of allowing it to scroll |
+| *Compact spacing* | Off | Tighten card padding and top margin to enlarge the usable area |
+
+The board itself is free-form, so there is no column count to set here. Hearth
+keeps an internal column count (12) and seed row height (92 px) that it uses only
+when it has to place a new card for you; neither is exposed as a control.
+
+### Dashboard controls
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Arrange button visibility* | Always visible | **Always visible** or **Show on hover** |
+| *Dashboard switcher visibility* | Always visible | **Always visible** or **Show on hover** |
+
+### Card surface
+
+*Transparency and frosted-glass blur applied to every card.*
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Card opacity* | 0.5 | Transparent card backgrounds so the dashboard background shows through |
+| *Card blur* | 0 (off) | Frosted-glass blur behind translucent cards. Needs opacity below 100% to show |
+| *Card corner radius* | 14 px | 14 is both the default and the maximum; lower is sharper, down to 0 |
+| *Card border* | 1 px | Thickness of the card border and header divider. 0 hides the border |
+
+### Cards
+
+An informational row, not a control: *Add and configure cards on the dashboard
+itself: open the home view, hit Arrange, then use Add card, Dashboard settings
+and each card's settings button.*
+
+---
+
+## Behaviour
+
+Three sections: Startup & tabs, Opening notes, Privacy & network.
+
+### Startup & tabs
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Open on startup* | On | Open the home view when the vault loads |
+| *Replace new tabs* | On | Show the home view instead of an empty new tab |
+| *Focus search on open* | Off | Place the cursor in the search field whenever a home view opens. Desktop only |
+| *Live refresh on vault changes* | Off | Keep an open home view current as the vault changes — Recent, Bookmarks and saved-query cards update without reopening the tab. Switching back to the Hearth tab always refreshes it regardless |
+| *Pick up synced changes* | On | Apply dashboard changes made on another device as soon as sync brings them in, instead of at the next Obsidian restart |
+
+### Opening notes
+
+*Where a note opens when you click it in Hearth.*
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Open notes in* | A new tab | **A new tab**, **The current tab (replace Hearth)**, **A split pane**, **A new window**. Ctrl/Cmd-click always opens a new tab regardless |
+
+Four per-source overrides, each of which may also be set to *Same as above*:
+
+| Source | Covers |
+| --- | --- |
+| *Links* | Links inside notes, tasks and the Links card |
+| *Search results* | Hits from the search bar and the Search card |
+| *Notes in cards* | Notes listed by Recent, Bookmarks, Favourites, Calendar, Heatmap and Tasks cards, and by mobile action buttons |
+| *Notes Hearth creates* | New notes, daily notes and event notes, opened as they are made |
+
+One further setting:
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Notes opened from outside Hearth* | The current tab (replace Hearth) | Covers the file explorer, the quick switcher, the graph, and anything a card embeds that opens links itself. Obsidian hands those to whichever tab is focused, so a Hearth tab gets taken over. Choose **A new tab (keep Hearth open)** to keep the Hearth tab — the file explorer then stops following what you open |
+
+### Privacy & network
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Disable external calls* | Off | Block all outbound network requests Hearth makes, including Jira, external calendars, RSS feeds, the calculator's currency-rate lookup, and background images and title icons given as a web address — those fall back to no picture and the Hearth crystal |
+
+---
+
+## Mobile
+
+Two sections: Layout, Mobile action bar.
+
+### Layout
+
+*How the board is laid out when the screen is too narrow for its own layout.*
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Mobile mode (search only)* | Off | On phones and tablets, hide the dashboard and show only the search field. No effect on desktop |
+| *Stack cards on narrow screens* | On | When the board is too narrow for its layout, show the cards as one full-width column instead. Your layout is untouched and comes back at full width |
+| *Performance tier on mobile* | Balanced | The tier to use on phones and tablets. Can also be **Match desktop**. Your desktop tier is kept separately and is not changed |
+
+### Mobile action bar
+
+*In Mobile mode (search only), this row of buttons replaces the "New note"
+button beside the search bar, appearing under the search field and filters
+instead. Each button can run a command, open a note or file, or open a URL —
+just like a launchpad tile.*
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Show action bar* | On | Show the row of action buttons beneath the search field in Mobile mode |
+| The button list | New note, New drawing, Record voice, Open daily note | Each has a label, an icon and a target. Buttons can be moved up and down, removed, added, and reset to the defaults |
+
+---
+
+## Integrations
+
+Four sections: All integrations, Tasks / TaskNotes, Operon, File icons.
+
+### All integrations
+
+The catalogue: everything Hearth can work with, listed whether or not it is
+installed, in three groups — **Community plugins**, **Obsidian core plugins**
+and **External services**. Each row shows a status pill, a description, where its
+settings live, and either an **Install** button (for a missing plugin), a
+**Show** button (jumping to its section below) or an **Open** button (jumping to
+another Hearth settings tab).
+
+The full catalogue is documented in [chapter 14](14-integrations.md).
+
+### Tasks / TaskNotes
+
+*Field names read by Tasks cards in TaskNotes mode. TaskNotes has no stable API
+for other plugins, so this reads its frontmatter directly — match these to
+whatever TaskNotes' own settings have them mapped to.*
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Status field* | `status` | Frontmatter field read for a task's status |
+| *Due date field* | `due` | Frontmatter field read for a task's due date |
+| *Priority field* | `priority` | Frontmatter field read for a task's priority indicator |
+| *"Done" status value* | `done` | The status value that marks a TaskNotes task complete |
+| *Customize task fields* | Off | Replace the fixed metadata Tasks cards show with fields you define yourself. Turning it on starts from a blank slate: tasks then show only the fields you add |
+| *Fields shown on a task* | empty | The fields every Tasks card shows. A single card can define its own instead |
+
+Custom task fields are documented in [chapter 8](08-cards-planning.md).
+
+### Operon
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Connect to Operon* | On (but inert until an Operon card exists) | Off is a kill switch: Operon cards stop reading and Hearth never asks Operon for access |
+| *Connection* | — | Reports the current state, with Operon's own error text where relevant |
+| *Allow changes* | Off | Lets the board card move a task by dragging, and adds a **+** for creating one. Widens what Hearth requests, so it needs a fresh approval in Operon |
+| *Requested access* | — | What Hearth asks for, and anything not yet granted |
+| *Recheck* | — | Reopen the connection after approving, revoking or reloading Operon |
+
+Operon is documented in full in [chapter 14](14-integrations.md).
+
+### File icons / Iconic / Iconize
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Use icons from Iconic / Iconize* | On | Off shows Hearth's file-type icon for every file, ignoring both plugins |
+| *Iconize frontmatter property* | `icon` | The property Iconize stores a note's icon in, for icons set through frontmatter rather than its menu |
+
+---
+
+## Backup
+
+One section, plus the gallery settings.
+
+### Import / export
+
+*Share one dashboard, or back up your whole setup, as a JSON file.*
+
+| Setting | Meaning |
+| --- | --- |
+| *Export this dashboard* | Save the dashboard you are on as a file others can import. Everything about how it looks travels with it, and you choose whether to include its wallpaper |
+| *Import* | Open a Hearth file — one dashboard, a layout, or a full backup. It tells you what is in it before anything changes, and a single dashboard is added alongside your own rather than replacing anything |
+| *Export layout* | Download every dashboard plus the grid and layout settings as a JSON file |
+| *Export settings* | Download every Hearth setting — the full layout plus header, background, behaviour, appearance and TaskNotes options — as a JSON backup file |
+
+On mobile, an export file is saved to your vault's root folder rather than
+downloaded.
+
+### Dashboard gallery
+
+| Setting | Meaning |
+| --- | --- |
+| *Gallery address* | The gallery Hearth browses and publishes to. Nothing is fetched until you open it and nothing is sent until you publish. **Clearing this field turns the gallery off entirely, and it stays off.** HTTPS only, or HTTP on localhost for a gallery you run yourself |
+| *Browse the gallery* | Opens the gallery browser |
+
+Export, import and the gallery are documented in
+[chapter 16](16-sharing-and-gallery.md).
+
+---
+
+## About
+
+| Row | What it does |
+| --- | --- |
+| *Set up Hearth* / *Build a dashboard* | Runs the setup wizard. It is always added as a new board, so your existing dashboards are never touched |
+| *What's new* | Read the release notes for this and every past version |
+| *GitHub repository* | Browse the source, star the project, or read the changelog |
+| *Report an issue* | Open an issue on GitHub |
+| *Support Hearth* | A Ko-fi tip link. Completely optional; no features are locked |
+| *Version* | The Hearth build you are running |
+
+---
+
+## Commands
+
+Hearth registers these commands. They appear in Obsidian's command palette and
+can be bound to hotkeys under **Settings → Hotkeys**.
+
+| Command | What it does |
+| --- | --- |
+| *Open home dashboard* | Opens the Home view |
+| *Create new note (default location)* | Makes a note using the *The "New note" button* settings |
+| *Create new Excalidraw drawing* | Runs Excalidraw's own new-drawing command |
+| *Start/stop voice recording* | Uses Obsidian's core Audio recorder |
+| *Open today's daily note* | Uses Obsidian's core Daily notes plugin |
+| *Set up Hearth (first-run wizard)* | Runs the setup wizard, always adding a new board |
+| *Switch to dashboard 1 … 9* | Changes the active board |
+| *Open dashboard 1 … 9* | Changes the active board **and** brings Hearth up |
+| *Next dashboard* | Moves to the next board |
+| *Previous dashboard* | Moves to the previous board |
+
+The ribbon button is labelled *Open Hearth home*.
+
+## Keyboard shortcuts inside the view
+
+| Key | In the search field |
+| --- | --- |
+| `↑` / `↓` | Move through the results |
+| `Enter` | Open the selected result, or run the selected command |
+| `Esc` | Dismiss the results |
+| `Ctrl`/`Cmd` + click | Always open a result in a new tab, whatever *Open notes in* says |
+
+## Per-dashboard settings
+
+Every dashboard also has its own settings dialog, reached by right-clicking its
+switcher button or from *Arrange → Dashboard settings*. Those are documented in
+[chapter 5](05-dashboards.md), and per-card settings in
+[chapter 6](06-arranging-cards.md).

--- a/docs/user-guide/16-sharing-and-gallery.md
+++ b/docs/user-guide/16-sharing-and-gallery.md
@@ -1,0 +1,319 @@
+# 16. Sharing dashboards: export, import and the gallery
+
+Hearth can save a dashboard as a file that looks the same in someone else's
+vault, back up your whole setup as JSON, and — if a gallery server is configured
+— publish a board where other people can browse, rate, comment on and install it
+in one click.
+
+This chapter covers all three. The underlying file format is documented for
+developers in [`docs/dashboard-package.md`](../dashboard-package.md).
+
+## Why a dashboard needs a special file format
+
+A Hearth dashboard never described itself completely. Half its appearance lives
+on the board and half in the vault's global settings, which the board falls back
+to for anything it has not overridden. A board handed to another vault would
+therefore arrive wearing *that* vault's grid, card opacity, wallpaper and search
+placeholder.
+
+The export format solves this by optionally **flattening**: writing the resolved
+appearance values onto the dashboard itself so it looks the same wherever it
+lands. This is a switch you control.
+
+---
+
+## Exporting one dashboard
+
+**Where:** *Settings → Hearth → Backup → Export this dashboard*, or right-click
+a dashboard's switcher button → *Export dashboard…*.
+
+The dialog is titled **Share dashboard** and has two destinations: **Save a
+file**, and **Publish** to a gallery if one is configured.
+
+### The basics
+
+| Field | Meaning |
+| --- | --- |
+| *Name* | What this dashboard is called in the file. Defaults to the board's own name |
+| *Description* | Optional. A line or two about what this dashboard is for |
+| *Tags* | Optional, comma separated. Useful if the dashboard is going somewhere it can be browsed |
+| *Recommended with my theme* | Note that the board is meant to be seen under the community theme you are currently using. It is a note for whoever installs it — nothing is installed or changed on their side |
+
+### What travels
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| *Include the wallpaper and images* | On | Carries the board's background picture, any image icons and any explicit slideshow pictures **inside** the file, so it looks right in a vault that has never seen them. Makes the file bigger. Turn it off for a backup of your own vault, where the pictures are already in place |
+| *Leave out my private information* | Off for a file, forced on for a publish | Removes the parts of the board that are about you rather than about the design |
+
+Hearth tells you exactly what the current settings mean in numbers — for
+example, "As it stands, this file will mention 4 paths from this vault and 1
+calendar feed URL."
+
+### What "leave out my private information" removes
+
+Four groups, each of which you can also toggle individually in the details
+section:
+
+| Group | What comes out |
+| --- | --- |
+| *Remove note and folder paths* | Everything the board points at in your vault, and the folder each embedded picture came from. The pictures themselves still travel if the wallpaper switch is on; it is the folder they lived in that goes |
+| *Remove calendar feeds, private hosts and your location* | ICS calendar links (anyone holding one can read that calendar), an internal Jira host, and the place a weather card is set to |
+| *Remove text you typed on the board* | A text card's body and a calculator's last input |
+| *Remove searches and Dataview queries* | Off by default: a board without its queries stops doing anything. Worth turning on if a query names a private folder |
+| *Remove command ids and view types* | Off by default: these name plugins, not you. Removing them leaves the buttons that ran them doing nothing |
+
+The board still looks exactly the same afterwards. The cards simply arrive
+pointing at nothing, which whoever downloads it has to fill in anyway.
+
+Leave the switch **off** for a copy of your own board, which needs its paths to
+keep working.
+
+### The details disclosure
+
+*See and tune exactly what travels* opens a section that lists each group with
+**the actual values read from this board underneath it**, so it is a list you can
+check rather than a promise you have to trust. It also carries:
+
+*Copy this vault's appearance settings onto the dashboard* — the flattening
+switch described above. Turn it off and the board carries only its own overrides
+and adapts to wherever it lands.
+
+Hearth tells you how many values will be removed, and warns you if any exported
+value **still looks like a vault path** after the strip: "Exported, but N values
+still look like vault paths. Worth opening the file before you share it."
+
+### Credentials are never exported
+
+A Jira personal access token, and anything else a card can hold as a credential,
+is always removed. This is not a switch.
+
+### Where the file goes
+
+On desktop, the file downloads. On mobile, it is saved to your vault's root
+folder and Hearth tells you the filename.
+
+---
+
+## Backing up everything
+
+Two further exports live at **Settings → Hearth → Backup**:
+
+- *Export layout* — every dashboard plus the grid and layout settings, as JSON.
+- *Export settings* — every Hearth setting: the full layout plus header,
+  background, behaviour, appearance and TaskNotes options.
+
+These are backups of your vault's Hearth configuration, not things to share.
+
+---
+
+## Importing
+
+**Where:** *Settings → Hearth → Backup → Import*, or right-click a dashboard's
+switcher button → *Import dashboard…*.
+
+Hearth reads the file and **tells you what is in it before anything changes**:
+
+- which of the three kinds it is — *One dashboard*, *A dashboard layout*, or *A
+  full settings backup*,
+- who made it, if it carries a checkable signature,
+- which Hearth version it was made with,
+- how many kinds of card it holds,
+- how many pictures it brings with it,
+- how many vault paths it points at,
+- which plugins it wants.
+
+### How to import it
+
+| Mode | Meaning |
+| --- | --- |
+| *Add as a new dashboard* | Adds it alongside your own. Leaves every one of your settings alone |
+| *Add its dashboards to mine* | For a multi-board file |
+| *Update "<name>" in place* | Replaces one existing board |
+| *Replace all my settings* | Replaces your dashboards and every Hearth setting with the ones in the file. **This cannot be undone**, and Hearth says so |
+
+### Worth knowing
+
+Before importing, Hearth lists anything that will not work perfectly:
+
+- plugins the file wants that are not installed or not enabled here — those cards
+  will be empty until they are,
+- notes or folders the board points at that are not in your vault, with examples,
+- how many things the board loads from the internet when you open it.
+
+None of this stops the import. The cards come through and you can point them at
+your own notes.
+
+After importing, Hearth may add further warnings: that its task cards use custom
+fields and you will need to turn on task field customisation to see them, that
+some cards need a newer Hearth and were left out, or that some of its pictures
+were missing from the file.
+
+### Signatures
+
+A file that claims an author but whose signature does not check out — because it
+was edited after signing, or somebody put another maker's handle on it — is
+imported **without** an author, and Hearth says so plainly. Everything else about
+the import is unaffected.
+
+---
+
+## Your publishing identity
+
+To publish to a gallery, or to vote on someone else's dashboard, you need a
+**handle**.
+
+A Hearth handle is an anonymous name derived from a signing key that is
+generated in your vault and never leaves it. There is no account, no email, and
+nothing about who you are. Because each file you publish is signed with that
+key, **nobody else can publish under your handle**.
+
+- *Create my handle* mints one. It is minted on first use and never before: a
+  vault that has not shared anything has no identity to have.
+- *Copy my recovery key* copies the key. **This is the only way to get the handle
+  back.** It is held nowhere but this vault: if you lose it there is no reset and
+  nobody to ask, and the handle — along with everything published under it —
+  would be gone.
+- *Use a key from another install* pastes a key in, so you can carry your handle
+  to another vault. If you have not copied your current key first, Hearth warns
+  you: replacing it cannot be undone, anything already published under the old
+  handle stays published, but you could never post as it again.
+
+Browsing and installing from a gallery need no handle at all.
+
+---
+
+## The dashboard gallery
+
+The gallery is a server that stores published dashboards. Hearth ships pointed
+at one, and the address is a setting.
+
+**Nothing is fetched until you open the gallery, and nothing is sent until you
+publish.** Clearing the *Gallery address* field under *Settings → Hearth →
+Backup → Dashboard gallery* turns the gallery off for good.
+
+Anyone can run their own: the server is a separate open-source project and starts
+with one Docker command. See [`docs/gallery-hosting.md`](../gallery-hosting.md).
+
+### Browsing
+
+The gallery browser offers a search field, an *All dashboards* / *Published by
+me* switch, and four sort orders: **Trending**, **Top rated**, **Newest** and
+**Most installed**.
+
+Dashboards are filed under nine categories: Getting things done; Planning &
+calendar; Study & research; Writing & journaling; Work & projects; Personal &
+home; Minimal; Information-dense; Everything else.
+
+Each card in the list shows a picture of the board, its author's handle, its
+install count, its score and its card count, and marks whether it hosts a plugin
+view.
+
+### A dashboard's detail page
+
+Opening one shows the full picture, the description and tags, when it was
+published and last updated, the author's version, the Hearth version it was made
+with, and the theme it is recommended with if any.
+
+It also shows two lists that matter before you install:
+
+- **What's on this board** — the cards it contains.
+- **What it needs** — the plugins, hosted views and settings it depends on, or
+  *Nothing beyond Hearth itself*.
+
+And an explicit network statement: either *Nothing on this board is loaded from
+the internet*, or *N things on this board are loaded from the internet*.
+
+A board that arrived without a checkable signature is marked as such: who made it
+cannot be established.
+
+**Install** downloads it and adds it as a new dashboard.
+
+### Voting, comments and profiles
+
+You can upvote or downvote a dashboard, and leave a comment. Both need a handle;
+Hearth offers to make you one at that moment.
+
+An author's profile page shows their **karma** (every upvote across everything
+they have published, minus every downvote), their total installs, how many
+dashboards they have published, and when they first published.
+
+### Publishing
+
+Publishing happens from the same dialog you export from, with a **Category**
+picker added.
+
+Before it uploads, Hearth says plainly: *This board becomes public: anyone using
+this gallery can find and install it. You can withdraw it at any time, though
+people who already installed it keep their copy.*
+
+Two things are enforced for a publish that are optional for a file:
+
+1. **Private information is always removed.** The paths, private-host, location
+   and typed-text groups are pinned on and cannot be switched off.
+2. **A picture of the board is required**, and you have to confirm you have
+   looked at it.
+
+### The screenshot, and why you have to look at it
+
+Publishing needs a picture of the board. Hearth takes it by scrolling through the
+board, so a long board is captured whole.
+
+**Every word inside your cards is blanked out before the shot is taken.** The
+header, the toolbar and each card's own title stay, and so does a card with
+nothing of yours in it, such as a clock.
+
+Then Hearth asks you to look. Click the picture to see it full size and read it.
+Card titles, the header and anything a card shows that is not yours are meant to
+be there; a note's text, a task, a file name, an event, a number from your life
+is not. Publishing waits until you switch on *I've looked — nothing private is
+readable in it*.
+
+If something of yours **is** readable, do not publish the board: the picture
+cannot be taken back once people have installed it. Report it instead — that is a
+bug in the blanking, and it is worth fixing before it happens to somebody else.
+There is a *Report it on GitHub* link right there.
+
+Screenshots need the desktop application; on mobile, Hearth says so and suggests
+saving the dashboard as a file and publishing it later from a desktop vault.
+Hearth can also only photograph the board that is currently open, so you have to
+switch to a board before publishing it.
+
+### After publishing
+
+Your own entries carry an **Update** button, which publishes the board again over
+the existing listing rather than beside it, and a **Remove from the gallery**
+button. Removing it means nobody new can find it; people who already installed it
+keep their copy.
+
+If the gallery accepts a board but its own check sees something that still looks
+like a path from your vault, the board is **held for review** rather than listed,
+and Hearth tells you.
+
+### Gallery errors, and what they mean
+
+| Message | Meaning |
+| --- | --- |
+| *No gallery is set up* | Put a gallery address in Hearth's settings |
+| *The gallery is a server on the internet, and this vault has "Disable external calls" turned on* | Turn that setting off to browse or publish |
+| *Couldn't reach the gallery* | It may be down, or this device may be offline |
+| *That address answered, but not like a Hearth gallery* | Wrong address |
+| *The gallery didn't accept this vault's identity* | An authentication problem |
+| *The gallery is asking you to slow down* | Rate limited; try again in a few minutes |
+| *That dashboard is too large for this gallery* | Turn off the wallpaper, or shrink it |
+| *Hearth couldn't sign the file, so it wasn't published* | An unsigned board has no provable author. Your recovery key may be damaged; try pasting it in again |
+
+---
+
+## A summary of what is safe to share
+
+| Kind of data | In a file export | In a gallery publish |
+| --- | --- | --- |
+| Layout, styling, colours, card settings | Always included | Always included |
+| Searches and Dataview queries | Included by default | Included by default; removable |
+| Public pages and feeds the board shows | Included | Included |
+| Vault note and folder paths | Included unless you strip them | Always removed |
+| Calendar feed URLs, private hosts, your location | Included unless you strip them | Always removed |
+| Text you typed on a text card, a calculator's last sum | Included unless you strip them | Always removed |
+| Jira personal access tokens and other credentials | Never included | Never included |
+| A picture of the board | Optional | Required, with every word inside cards blanked, and you must confirm you looked |

--- a/docs/user-guide/17-privacy-and-network.md
+++ b/docs/user-guide/17-privacy-and-network.md
@@ -1,0 +1,162 @@
+# 17. Privacy, network access and your data
+
+This chapter answers, in one place: what data Hearth holds, where it holds it,
+what it sends over the network, when, and how to stop it.
+
+The short version: Hearth has **no telemetry, no account and no phone-home**.
+The only outbound requests it makes are the ones a card you added needs, and a
+single switch silences all of them.
+
+## Where Hearth stores your data
+
+Everything Hearth knows lives in your vault, in the plugin's own data file under
+`.obsidian/plugins/hearth/`. That includes your dashboards, your cards and their
+configuration, your vault-wide settings, your Favorites list, and your
+publishing key if you have created one.
+
+Two things deliberately live elsewhere:
+
+- **Search history.** The last six files you opened through Hearth's search are
+  kept in the vault's local storage rather than in the settings file, so they
+  never appear in the settings UI and are never included in an export.
+- **Nothing at all is stored outside the vault.** There is no cloud component,
+  no cache directory elsewhere on your machine, and no server that holds your
+  configuration.
+
+Because it all lives in the vault, it travels with whatever sync you already
+use, and it is included in whatever backup you already take of the vault.
+
+## The master switch
+
+**Settings → Hearth → Behaviour → Privacy & network → Disable external calls.**
+
+Turning this on blocks **all** outbound network requests Hearth makes. Its
+description is exhaustive: Jira, external calendars, RSS feeds, the calculator's
+currency-rate lookup, and background images and title icons given as a web
+address — those last two fall back to no picture and to the Hearth crystal.
+
+Cards do not fail silently under this setting. Each one says why it is empty:
+*Feeds are off (external calls disabled)*, *Place search is unavailable while
+external calls are disabled*, *Favorite filters can't be loaded while external
+calls are disabled*, and so on. The background settings section says the URL
+background will not be shown and suggests a vault image instead.
+
+The gallery is also blocked, with a message saying exactly that.
+
+## Everything Hearth can send, and to whom
+
+There are eight categories of outbound request. Nothing else exists.
+
+| Destination | Sent by | What is sent | Account or key |
+| --- | --- | --- | --- |
+| [Open-Meteo](https://open-meteo.com) | Weather cards, and the live weather sky background | Only the coordinates you picked | None. Free, key-less, no account |
+| [Frankfurter](https://www.frankfurter.app/) | The Calculator card, for currency conversion | A rate request. Your sum is computed locally | None |
+| Your Jira Cloud or Server instance | Jira cards | A REST query, authenticated with the personal access token you entered on the card | Yours |
+| RSS and Atom feed hosts | RSS cards | A feed request | None |
+| ICS and webcal hosts | Mini calendar subscriptions | A feed request | The feed URL you entered |
+| A web search engine | The search bar's *Search online* button | Only the text you typed in the search field | None |
+| Any host you name | A background image or title icon given as a web address | An image request | None |
+| A dashboard gallery server | The gallery browser and publisher | Nothing until you open the gallery; nothing published until you press Publish | An anonymous handle generated locally |
+
+Two of these deserve a note.
+
+**Hearth's own default wallpaper is a web request.** The bundled ambient
+background is served from `raw.githubusercontent.com`. If that matters to you,
+choose a vault image or a solid colour instead, or turn on *Disable external
+calls*, which makes it fall back to no picture.
+
+**A pinned weather sky needs no network at all.** If you like the painted sky but
+not the request, set the background's *Sky* to **A fixed sky** and choose a
+condition. It needs no location and never goes online. Only *Live weather* asks
+Open-Meteo anything.
+
+**The Web page card** is a special case: it renders a page you named in a
+sandboxed iframe, so whatever that page loads, it loads. The card's *Trusted
+site* option relaxes the iframe sandbox to allow same-origin access — cookies
+and storage — and should only be enabled for sites you trust.
+
+## What Hearth never does
+
+- It does not send anything about your vault, your notes, your usage or your
+  machine anywhere.
+- It has no analytics, crash reporting or update-check beacon of its own.
+  Obsidian's own plugin updater is Obsidian's, not Hearth's.
+- It does not require an account for any feature. Publishing to a gallery uses a
+  key generated in your vault, not a sign-up.
+- It does not read anything a card is not asked to read.
+
+## Credentials
+
+The only credential Hearth stores is a **Jira personal access token**, entered on
+a Jira card and stored in Hearth's plugin data alongside the rest of your
+configuration.
+
+It is **never included in any export**, of any kind, with any setting. This is
+not a switch you can get wrong.
+
+## Sharing a dashboard safely
+
+When you export a dashboard to a file, Hearth offers *Leave out my private
+information*, which removes vault paths, calendar feed URLs, private hosts, your
+location, and any text you typed on a text or calculator card. The details
+section lists **the actual values** it will remove, read from your board, so you
+can check rather than trust.
+
+When you **publish** to a gallery, that removal is not optional — those groups are
+pinned on — and a screenshot is required, taken with every word inside your cards
+blanked out, which you must look at and confirm before publishing goes ahead.
+
+Both flows are documented in full in [chapter 16](16-sharing-and-gallery.md).
+
+## The gallery, specifically
+
+The gallery is the only Hearth feature that is a server relationship rather than
+a one-off request, so it is worth being precise:
+
+- **Nothing is fetched until you open the gallery.** It does not poll, prefetch
+  or check in.
+- **Nothing is sent until you publish.** Browsing does not upload anything about
+  your vault.
+- **The address is a setting.** Clearing the *Gallery address* field under
+  *Settings → Hearth → Backup* turns the gallery off entirely, and it stays off.
+- **Your identity is a local key.** The handle you publish under is derived from
+  a signing key generated in your vault that never leaves it. It says nothing
+  about who you are. Voting and publishing need one; browsing and installing do
+  not.
+- **You can run your own.** The gallery server is open source and starts with one
+  Docker command; see [`docs/gallery-hosting.md`](../gallery-hosting.md).
+
+## Installing someone else's dashboard
+
+A dashboard from the gallery, or a file from a friend, is data rather than code —
+but it can point at things. Before you install, Hearth tells you:
+
+- exactly which plugins and hosted views it needs,
+- how many things on the board are loaded from the internet, or explicitly that
+  none are,
+- whether its signature checks out, and therefore whether its author can be
+  established at all.
+
+Two cards can run code you did not write if you paste it in: the **Dataview**
+card (DataviewJS) and the **Datacore** card (scripts). Both say so in their own
+settings: "Runs arbitrary JavaScript — only use code you trust." An imported
+board's scripts are worth reading before you open the board.
+
+## A quick audit of your own vault
+
+If you want to know what your Hearth setup currently reaches out to:
+
+1. Open **Settings → Hearth → Integrations**. The **External services** group
+   lists every network-using integration with a live status pill.
+2. Open the **Share dashboard** dialog for each board and read the details
+   disclosure. It lists the actual feed URLs, hosts and locations the board
+   holds.
+3. Turn on *Disable external calls* for a session. Every card that wanted the
+   network will say so in place, which is a fast way to find the ones you forgot
+   about.
+
+## Accessibility and reduced motion
+
+Not privacy, but adjacent and easy to miss: if your operating system asks for
+reduced motion, Hearth honours it. The painted sky holds still regardless of the
+performance tier and regardless of the per-board *Animate the sky* setting.

--- a/docs/user-guide/18-troubleshooting.md
+++ b/docs/user-guide/18-troubleshooting.md
@@ -1,0 +1,400 @@
+# 18. Troubleshooting and frequently asked questions
+
+This chapter collects the questions people actually ask about Hearth, the
+messages Hearth shows when something is not working, and what to do about each.
+
+---
+
+## Getting Hearth open
+
+### Hearth does not open when Obsidian starts
+
+Check *Open on startup* under **Settings → Hearth → Behaviour → Startup &
+tabs**. It is on by default, so if it is off, something turned it off.
+
+### A new tab is empty instead of showing Hearth
+
+Check *Replace new tabs* under the same section. It is on by default.
+
+### I cannot find the ribbon icon
+
+The ribbon button is labelled *Open Hearth home*. If you have changed the *Tab
+icon* setting under **Settings → Hearth → Appearance → Home**, it will be
+wearing your Lucide icon rather than the Hearth crystal. You can also open
+Hearth with the command *Open home dashboard*, which you can bind to a hotkey.
+
+### Opening a note from the file explorer replaces my Hearth tab
+
+This is Obsidian's behaviour: it hands a file to whichever tab is focused, and a
+focused Hearth tab gets taken over.
+
+Set *Notes opened from outside Hearth* to **A new tab (keep Hearth open)** under
+**Settings → Hearth → Behaviour → Opening notes**. The trade-off, which Hearth
+states: the file explorer then stops following what you open.
+
+### Clicking things inside Hearth opens them in the wrong place
+
+**Settings → Hearth → Behaviour → Opening notes** has a general *Open notes in*
+setting and four per-source overrides — Links, Search results, Notes in cards,
+and Notes Hearth creates. Each override can also follow the general setting.
+
+`Ctrl`-click, or `Cmd`-click on macOS, always opens a new tab regardless.
+
+---
+
+## Finding settings
+
+### Where do I change what a card shows?
+
+Not in the settings window. Open the Home view, press **Arrange**, then press
+that card's gear button. The settings page says so in a row of its own under
+*Settings → Hearth → Dashboard → Cards*.
+
+### Where do I change one dashboard rather than all of them?
+
+Right-click that dashboard's button in the top-left switcher and choose
+*Dashboard settings…*, or press *Dashboard settings* in the Arrange toolbar.
+
+### A setting appears to do nothing
+
+Three likely causes, in order of frequency:
+
+1. **The performance tier is overriding it.** Steps below *Full* switch off
+   animation, blur, translucency, timed refresh, and the wallpaper. The affected
+   sections say so in place: "The performance tier overrides these right now.
+   They are kept as they are and take effect again when you move back up."
+2. **A more specific level is overriding it.** Opacity, blur, border and corner
+   radius exist vault-wide, per dashboard and per card. The most specific level
+   with an opinion wins.
+3. **Card blur needs translucency.** Frosted-glass blur only shows when card
+   opacity is below 100%. The setting says so.
+
+### Card blur is set but I see no frosted glass
+
+Card opacity must be below 100% for a blur to have anything to blur. Also check
+the performance tier: *Reduced* and *Minimal* switch the blur off.
+
+---
+
+## Cards that are empty or complaining
+
+Hearth's cards say why they are empty rather than showing nothing. The complete
+set of these messages, and what each means:
+
+### Cards waiting for a core plugin
+
+| Message | Fix |
+| --- | --- |
+| *Enable the core Daily notes plugin* | Settings → Core plugins → Daily notes |
+| *Enable the core Bases plugin to embed .base files* | Settings → Core plugins → Bases |
+| *Enable the core Canvas plugin to embed canvases* | Settings → Core plugins → Canvas |
+| *Enable the core Bookmarks plugin* | Settings → Core plugins → Bookmarks |
+
+### Cards waiting for a community plugin
+
+| Message | Fix |
+| --- | --- |
+| *Install the Excalidraw plugin to embed drawings* | Install and enable Excalidraw |
+| *Install the Periodic Notes plugin* | Install and enable Periodic Notes |
+| *Enable the Templater plugin to create notes from templates* | Install and enable Templater. The card keeps its configuration meanwhile |
+| *Enable the Dataview plugin to run queries* | Install and enable Dataview |
+| *Enable the Datacore plugin to run queries* | Install and enable Datacore |
+| *Enable the Git plugin to manage your vault's repository* | Install and enable Git |
+| *Enable the TaskNotes plugin, or switch source to checkboxes* | Either install TaskNotes, or change the Tasks card's *Source* to Markdown checkboxes |
+| *This view isn't available — enable the plugin that provides it* | A Plugin view card is pointing at a view whose plugin is gone |
+
+### Cards waiting for configuration
+
+| Message | Fix |
+| --- | --- |
+| *Pick a file to embed in settings* | Open the card's settings and choose a file |
+| *Set a query in card settings* | The Query card has no query |
+| *Set a Dataview query in card settings* / *Set a Datacore query in card settings* | Same, for those cards |
+| *Set a web URL in settings* | The Web page card has no URL |
+| *Add pictures in card settings* | The Slideshow card has an empty list |
+| *No images in this folder* | The Slideshow card's folder holds no images right now |
+| *Add favorites in settings* | The Favorites card's list is empty |
+| *Add links in settings* / *Add commands in card settings* / *Add a template in card settings* | Those tile cards are empty |
+| *Add a feed in card settings* | The RSS card has no feeds |
+| *Pick a location in card settings* | The Weather card has no place |
+| *Pick a plugin view in card settings* | The Plugin view card has no view |
+| *Pick a view for this board in dashboard settings* | A plugin view dashboard has no view chosen |
+| *Pick a file for this board in dashboard settings* | That hosted view needs a file |
+| *Enable the core Daily notes plugin, or subscribe to a calendar in this card's settings* | The Calendar card has no sources at all |
+| *No Kanban board found — pick a board note in card settings, or create one with the Kanban plugin* | Auto-detection found no note with a `kanban-plugin` frontmatter key |
+| *No repository open yet — set one up in the Git plugin* | The Git plugin is enabled but has no repository |
+
+### Cards that found nothing
+
+*No matches*, *No open tasks*, *No tasks match the filter*, *No recent files*,
+*No bookmarks yet*, *No items in this feed*, *No Operon tasks match*, *Nothing
+scheduled in this window*. These are not errors: the card is working and there
+is nothing to show.
+
+### Network-blocked cards
+
+*Feeds are off (external calls disabled)* and similar messages mean *Disable
+external calls* is on under **Settings → Hearth → Behaviour → Privacy &
+network**.
+
+### A card that failed to draw
+
+*This card couldn't be drawn — see the console for details.* Open the developer
+console (`Cmd`/`Ctrl` + `Option` + `I`) to see the error, and please report it on
+GitHub. Only that card is affected.
+
+Similarly, if a whole settings section fails, Hearth shows *The "<name>" section
+couldn't be shown* in its place, with the same advice. The other settings are
+unaffected.
+
+---
+
+## Tasks
+
+### My TaskNotes tasks do not appear
+
+TaskNotes has no stable API, so Hearth reads its frontmatter directly and has to
+be told the field names. Open **Settings → Hearth → Integrations → Tasks /
+TaskNotes** and match *Status field*, *Due date field*, *Priority field* and
+*"Done" status value* to whatever TaskNotes is configured with. The defaults are
+TaskNotes' own defaults.
+
+### Some completed TaskNotes tasks still show as open
+
+Hearth treats one status value as "done" by default. If your vault also uses,
+say, `canceled`, add it to *Statuses counted as complete* on the Tasks card, one
+value per line.
+
+### Dragging a Kanban card in Hearth broke my board note
+
+It should not: Hearth writes drops in Kanban's own format precisely so the note
+stays editable in the Kanban plugin. If a board note comes out malformed, that is
+a bug worth reporting with the note's contents.
+
+### My custom task fields disappeared after importing a board
+
+Turn on *Customize task fields* under **Settings → Hearth → Integrations**.
+Hearth warns about this at import time: "Its task cards use custom fields — turn
+on task field customization in Settings → Integrations to see them."
+
+### Only one of my fields tints the task
+
+Correct, and deliberate. A task has one background and one ring, so only one
+field can use *Tint the whole task* and one *Glow around the task*. Hearth names
+the field that already holds it.
+
+---
+
+## Operon
+
+Operon is the integration most likely to need an action from you. Its messages
+are specific:
+
+| Message | What to do |
+| --- | --- |
+| *Operon's developer API is desktop-only and needs Obsidian 1.12.2 or newer* | Nothing — the cards cannot work on this platform or version |
+| *The Operon integration is off — turn it on in Settings → Hearth → Integrations* | The kill switch is on |
+| *Approve Hearth in Settings → Operon → Core → General → Developer API Integrations* | Go there and approve it |
+| *Operon suspended Hearth's access* | Review Hearth's pending scope in Operon's Developer API Integrations |
+| *Operon access was revoked* | Grant it again in the same place |
+| *Operon is still starting up* | Wait, then press *Recheck now* |
+| *Operon refused the connection* | Operon's own error text is shown underneath |
+| *Reading works, but the change permissions haven't been granted yet* | You turned on *Allow changes*, which widens the request. Approve Hearth again in Operon |
+
+### Operon could not confirm whether my change was applied
+
+Hearth reports "unknown" rather than "failed", re-reads the card, and does not
+offer a retry — a retry could apply the change twice. Check the task before
+trying again.
+
+### A drag onto an Operon board was refused
+
+A move carries the status the board was drawn from. If the board is stale — the
+task moved elsewhere since it was drawn — the move is refused rather than quietly
+undoing someone else's change. Refresh and try again.
+
+---
+
+## Performance
+
+### The board is warming up my machine
+
+Work through the tuning order in [chapter 12](12-performance.md). In short: the
+animated painted sky is the single largest cost, card blur is second, and hosted
+plugin views are a cost the performance tier cannot touch.
+
+### I stepped the tier down and the board is still heavy
+
+Look for **Plugin view** cards. A hosted view runs another plugin's full view
+live, keeping its timers, listeners and rendering going for as long as the board
+is open, and Hearth's tier cannot slow it down. The card says as much in its own
+settings.
+
+### My animations stop when I switch to another app
+
+That is *Pause animation when Obsidian isn't in front*, on by default. Turn it
+off if you deliberately keep the dashboard on a second display.
+
+### My laptop is on battery and the phone board is fine but the desktop one is not
+
+The two have separate tiers. *Performance tier on mobile* defaults to *Balanced*
+while the desktop tier defaults to *Full*.
+
+---
+
+## Layout and mobile
+
+### My board looks completely different on my phone
+
+At or below 600 pixels of measured board width, Hearth reflows the board into one
+full-width column. Your stored layout is untouched and returns at full width.
+
+If you would rather it did not, turn off *Stack cards on narrow screens* under
+**Settings → Hearth → Mobile → Layout**, or set *Stack when narrow* to *Keep the
+scaled layout* on that one board.
+
+### A narrow split pane on my desktop is stacking too
+
+That is the same feature: the threshold is the measured width of the board, not
+the platform. It is also how you preview your phone layout — drag a pane narrow.
+
+### One card ruins the phone layout
+
+Open that card's settings, go to **Layout → On a narrow board**, and either
+*Hide* it, give it a *Position* in the column, set a *Height*, or *Start
+collapsed* so it builds only when tapped.
+
+### How do I check the phone layout without a phone?
+
+**Arrange → Preview at phone width**. It draws the stacked board inside a phone
+so the proportions read properly. While in it you can drag card heights and
+reorder with the move up and move down buttons.
+
+### Two cards merged into one and I did not ask them to
+
+That is edge-merging: cards snapped edge to edge lose their shared border so the
+pair reads as one tile. Drag one of them a few pixels apart to separate them.
+
+---
+
+## Sharing and the gallery
+
+### The shared dashboard looks wrong in my friend's vault
+
+Half a board's appearance normally lives in the vault's global settings. Turn on
+*Copy this vault's appearance settings onto the dashboard* — the flattening
+switch in the export dialog's details section — so the board carries its resolved
+values instead of picking up theirs.
+
+### Cards in an imported board point at nothing
+
+Expected, if the board was published rather than exported as a personal backup:
+publishing always removes vault paths. Point the cards at your own notes.
+
+Hearth also tells you at import time how many paths are missing, with examples.
+
+### The gallery says my board is held for review
+
+The gallery's own check saw something that still looks like a path from your
+vault. It will not be listed until somebody there has looked at it.
+
+### The gallery will not let me publish from my phone
+
+Publishing needs a picture of the board, and screenshots need the desktop
+application. Save the dashboard as a file on mobile and publish it later from a
+desktop vault.
+
+### I lost my publishing recovery key
+
+There is no reset and nobody to ask: the key is held nowhere but the vault it was
+made in. The handle and everything published under it are gone. Make a new handle
+and copy its key somewhere safe this time.
+
+### An imported file says its author cannot be established
+
+Either it carries no signature, or its signature does not check out — it was
+edited after signing, or somebody put another maker's handle on it. Hearth
+imports it without an author. Everything else about the import is unaffected.
+
+---
+
+## Search
+
+### Search does not find text inside my notes
+
+Check *Search note contents* under **Settings → Hearth → Search → Search bar**.
+It is on by default.
+
+### I chose Omnisearch and now search is Hearth's again
+
+The Omnisearch choice only sticks while the Omnisearch plugin is enabled. Disable
+it and Hearth falls back to its own engine rather than showing an empty search.
+Re-enable Omnisearch and select it again.
+
+### A filter chip I want is missing
+
+Chips are auto-detected: one appears only if your vault actually contains that
+kind of file. Also check that it is not hidden under **Settings → Hearth →
+Search → Search filters**, or on that board's *Filter chips* override.
+
+### My file icons from Iconic or Iconize do not show
+
+Check *Use icons from Iconic / Iconize* under **Settings → Hearth → Integrations
+→ File icons**. Note that a file using an icon from a downloaded icon pack keeps
+Hearth's own file-type icon; only Lucide icons and emoji are shown. If you set
+icons through Iconize's frontmatter property and renamed that property, tell
+Hearth the new name.
+
+---
+
+## General questions
+
+### Does Hearth send any of my data anywhere?
+
+No. There is no telemetry, no account and no phone-home. The only outbound
+requests are the ones a card you added needs, and *Disable external calls*
+silences all of them at once. See [chapter 17](17-privacy-and-network.md).
+
+### Is Hearth free?
+
+Yes, and MIT-licensed. There is an optional Ko-fi tip link in *Settings → Hearth
+→ About*; no features are locked behind it.
+
+### Was Hearth written by AI?
+
+Yes, and the README says so plainly. Every pull request is tested in a testing
+vault by a human before merging, and every release is beta tested in a testing
+vault by a human before being promoted to stable.
+
+### Can I use Hearth in more than one vault?
+
+Yes. Its configuration lives in each vault's plugin data, so each vault has its
+own dashboards. You can move a board between vaults with *Export dashboard* and
+*Import*, and you can carry your publishing handle across with its recovery key.
+
+### Can I translate Hearth?
+
+Yes, and translations are explicitly one of the most valuable contributions
+right now. User-facing strings live in `src/locales/`; English (`en.ts`) is the
+source of truth. Copy it, translate the values and register the file — see
+`src/locales/README.md` and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+
+### The card I want does not exist
+
+Press **Arrange → Add card**, and use **Request a card** at the bottom of the
+left rail. It opens either a pre-filled GitHub issue or a pre-filled email,
+carrying a few prompts and your Hearth and Obsidian versions. You can edit
+anything before sending.
+
+### How do I report a bug?
+
+**Settings → Hearth → About → Report an issue** opens the GitHub issue tracker.
+Bug reports and feature ideas are the most valuable contributions to Hearth right
+now. For anything larger than a small, obvious fix, open an issue before writing
+code — Hearth moves fast and big pull requests against a fast-moving codebase
+tend to go stale.
+
+### Where are the release notes?
+
+**Settings → Hearth → About → What's new** inside Obsidian, or
+[`CHANGELOG.md`](../../CHANGELOG.md) in the repository.

--- a/docs/user-guide/19-glossary.md
+++ b/docs/user-guide/19-glossary.md
@@ -1,0 +1,191 @@
+# 19. Glossary of Hearth terms
+
+Terms used throughout this guide and inside the Hearth plugin, defined. Entries
+are alphabetical. Where a term is Obsidian's rather than Hearth's, that is said.
+
+---
+
+**Action bar** — In Mobile mode (search only), a row of buttons under the search
+field, replacing the button that would otherwise sit beside it. Each button can
+run a command, open a note or file, or open a URL. Configured at *Settings →
+Hearth → Mobile → Mobile action bar*.
+
+**Arrange mode** — Hearth's edit mode for a dashboard, entered with the
+**Arrange** button in the top-right of the Home view. Cards can be added, moved,
+resized, configured and removed only while arranging.
+
+**Auto-shift tiles** — A beta option on the Links, Commands and New note from
+template cards. When on, tiles shove each other aside as one is dragged, the way
+phone widgets do. Off by default, which leaves tiles free-form and able to
+overlap.
+
+**Banner** — One of the two ways a background can be worn: a strip across the top
+of the board, with the cards below it on the theme's own surface, the way a cover
+image sits above a note. The alternative is *Full background*.
+
+**Board** — A synonym for dashboard, used throughout Hearth's own wording.
+
+**Card** — One panel on a dashboard. A card has a kind, an optional title, a
+position and size, optional style overrides, and optional behaviour when the
+board is stacked into one column.
+
+**Card surface** — The collective name for the four visual properties every card
+shares: opacity, blur, corner radius and border width. They exist vault-wide, per
+dashboard and per card.
+
+**Cascade** — Hearth's three-level settings model: a vault-wide default, an
+optional per-dashboard override, and (for card properties) an optional per-card
+override. The most specific level with an opinion wins.
+
+**Chip** — Two unrelated uses. (1) A *filter chip* is one of the auto-detected
+file-type buttons under the search field. (2) A *chip* is one of the display
+styles for a custom task field: a small pill on the task.
+
+**Collapsed (on a narrow board)** — A per-card option that shows only the card's
+title row in the stacked mobile column, building the card when it is tapped open.
+A card nobody opens costs one row and runs nothing.
+
+**Command mode** — What the search field becomes when the query starts with `>`:
+a launcher for any command registered in Obsidian.
+
+**Dashboard** — One arrangement of cards, with its own name, switcher icon, and
+optional overrides of almost every visual setting. A vault can hold many.
+
+**Dashboard gallery** — A server that stores published dashboards, which Hearth
+can browse, install from and publish to. Off entirely if no gallery address is
+set. Anyone can run their own.
+
+**Dashboard switcher** — The strip of buttons in the top-left of the Home view,
+one per dashboard, plus a `+` to create one.
+
+**Dashboard type** — Either **Cards** (the normal board) or **Plugin view** (the
+whole board given over to one other plugin's view).
+
+**Disable external calls** — The master privacy switch at *Settings → Hearth →
+Behaviour → Privacy & network*, which blocks every outbound network request
+Hearth makes.
+
+**Edge-merging** — When two cards are snapped edge to edge, their shared border
+drops out so the pair reads as one continuous tile, and they blur as one seamless
+sheet. Automatic; there is nothing to switch on.
+
+**Favorites** — Hearth's own list of starred notes, separate from Obsidian's
+Bookmarks. Shown by the Favorites card, which normally follows one vault-wide
+list but can be given a list of its own.
+
+**Fit to page** — A setting that keeps the dashboard to one screen instead of
+allowing it to scroll. On by default. A plugin view board always fits the pane.
+
+**Flattening** — In an export, writing the vault's resolved appearance values
+onto the dashboard itself so it looks the same in another vault instead of
+picking up that vault's settings. Controlled by *Copy this vault's appearance
+settings onto the dashboard*.
+
+**Free-form layout** — Hearth's board geometry: cards are stored as a position, a
+width as a percentage of the board, and a height in pixels, and may sit anywhere.
+Not a rigid row-and-column grid.
+
+**Frosted glass** — Translucent cards with a backdrop blur behind them. Blur
+defaults to 0 for power reasons; translucency is on by default.
+
+**Handle** — Your anonymous publishing identity, derived from a signing key
+generated in your vault that never leaves it. Needed to publish or vote in a
+gallery; not needed to browse or install.
+
+**Headerless card** — A card whose *Title* is empty, drawn without a header row.
+
+**Home view** — The Obsidian view Hearth registers. It contains the switcher, the
+Arrange button, the title block, the search section and the dashboard.
+
+**Karma** — On a gallery profile, every upvote across everything that handle has
+published, minus every downvote.
+
+**Kill switch** — Used in Hearth's own wording for *Connect to Operon*: turning
+it off stops Operon cards reading and stops Hearth ever asking Operon for
+access.
+
+**Launchpad** — The Links card: a grid of buttons opening notes, URLs or
+commands.
+
+**Live weather sky** — A painted sky used as the board's background, either
+following the real conditions and time of day over a place you pick, or pinned to
+one condition. A pinned sky needs no location and never goes online.
+
+**Lucide icon** — An icon from the [Lucide](https://lucide.dev/icons) set, which
+Obsidian uses. Hearth accepts Lucide ids in title icons, tab icons, switcher
+icons and tile icons, and provides a searchable picker so you do not have to
+remember ids.
+
+**Minimal tier** — The lowest performance tier: a flat colour instead of the
+wallpaper, opaque cards, no motion, and no card refreshing itself on a timer.
+
+**Mobile mode (search only)** — An optional mode in which Hearth on phones and
+tablets hides the dashboard entirely and shows only the search field with an
+action bar. Distinct from the stacked column, which is the default behaviour on a
+narrow board.
+
+**Package** — The JSON file format Hearth's export produces and its import
+consumes, describing one dashboard, one whole layout, or one vault's settings.
+Documented in [`docs/dashboard-package.md`](../dashboard-package.md).
+
+**Performance tier** — A single control with four steps — Full, Balanced,
+Reduced, Minimal — where each step down drops the next most expensive thing the
+board does. Nothing you configured is overwritten; your settings return when you
+move back up.
+
+**Pinned card** — A card set to appear on every dashboard, sharing one definition
+and position. Distinct from *Copy to dashboard*, which makes an independent
+duplicate.
+
+**Plugin view card** — A card that hosts another plugin's registered side-panel
+view. By far the heaviest card Hearth has, because it runs that plugin's full
+view live.
+
+**Plugin view dashboard** — A whole board given over to one plugin's view at full
+size, with the switcher, header and background still around it. The board keeps
+its cards, and switching back to *Cards* brings them back.
+
+**Quick view** — On the Tasks card, a compact popover with a task's editable
+metadata and description, opened by clicking the task instead of jumping into its
+note. On by default.
+
+**Recovery key** — The key behind your publishing handle. Held nowhere but your
+vault; the only way to carry the handle to another install or get it back.
+
+**Redaction** — The blanking of every word inside your cards before the gallery
+screenshot is taken. Card titles, the header and anything a card shows that is not
+yours are kept. You are asked to look at the result and confirm it before
+publishing.
+
+**Seamless** — An option on the Search bar card that drops the card frame — no
+border, background or title row — so it reads as a standalone search bar on the
+board.
+
+**Setup wizard** — The six-step flow that builds your first dashboard from a
+handful of questions and from what it finds installed in your vault. Rerunnable
+from *Settings → Hearth → About*, where it always adds a new board.
+
+**Snap** — The magnetic alignment of a dragged card to the edges and centres of
+its neighbours and of the board. The threshold is 8 pixels.
+
+**Stacked column** — What a board becomes when it is too narrow for its free-form
+layout: one full-width column, top to bottom, in the order the desktop board
+reads in. The stored layout is untouched.
+
+**Tier** — See *Performance tier*.
+
+**Tile** — One button on a Links, Commands or New note from template card. Tiles
+can be resized by dragging their bottom-right corner, in half-cell steps.
+
+**Title block** — The large heading at the top of the Home view and the mark
+beside it.
+
+**Title icon** — The mark beside the title. Accepts a Lucide icon id, an emoji or
+a couple of characters, a vault image path, or an image URL. Empty means the
+Hearth crystal.
+
+**Transparent modes** — Hearth's description of its search modes: you do not
+switch between them with a control, the mode is decided by what you type.
+
+**Vault-wide** — A setting that applies to every dashboard unless a dashboard
+overrides it. Vault-wide settings live under *Settings → Hearth*.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,102 @@
+# The Hearth User Guide
+
+This is the complete user-facing documentation for **Hearth**, a community
+plugin for [Obsidian](https://obsidian.md) that turns a tab in your vault into
+a home screen: a search bar, a dashboard of live cards, and an application
+launcher, all in one view.
+
+This guide is written to be read two ways.
+
+**By a person.** Start at [Introduction](01-introduction.md) and read forward,
+or jump to whichever chapter names the thing you are trying to do. Every
+chapter stands on its own and repeats the context it needs, so you can start in
+the middle without being lost.
+
+**By a language model** (this guide is maintained with tools such as NotebookLM
+in mind). Each chapter is self-contained, names its subject explicitly rather
+than relying on pronouns or on "as described above", and defines terms where it
+uses them. Settings are given by their exact on-screen label and the exact path
+you reach them by, so an answer generated from this guide can be followed
+literally in the application.
+
+## What Hearth is, in one paragraph
+
+Hearth is an Obsidian plugin. It registers a view called **Home** which can open
+on startup, replace empty new tabs, and be opened at any time from a ribbon icon
+or a command. The Home view contains an optional title, an optional search bar,
+and a **dashboard**: a freely arranged grid of **cards**. A card is a small live
+panel — an embedded note, a task list, a calendar, a clock, a weather forecast, a
+grid of launcher buttons, another plugin's side panel, and about thirty other
+kinds. You can have many dashboards and switch between them. Everything is
+configured from inside the view itself or from **Settings → Hearth**.
+
+## Chapters
+
+### Getting oriented
+
+1. [Introduction — what Hearth is and who it is for](01-introduction.md)
+2. [Installing Hearth and your first run](02-getting-started.md)
+3. [The anatomy of the Home view](03-the-home-view.md)
+
+### Using Hearth day to day
+
+4. [Search: modes, filters and the action button](04-search.md)
+5. [Dashboards: creating, switching and configuring boards](05-dashboards.md)
+6. [Arrange mode: adding, moving, resizing and styling cards](06-arranging-cards.md)
+
+### The card reference
+
+7. [Cards for notes and files](07-cards-notes-and-files.md)
+8. [Cards for planning: tasks, calendars and clocks](08-cards-planning.md)
+9. [Cards for vault insight, tools and fun](09-cards-vault-tools-and-fun.md)
+10. [Integration cards: Dataview, Templater, Git, Jira, Operon and more](10-cards-integrations.md)
+
+### Making it yours
+
+11. [Appearance: backgrounds, banners, frosted glass and icons](11-appearance.md)
+12. [Performance tiers and battery life](12-performance.md)
+13. [Hearth on a phone or a narrow pane](13-mobile.md)
+
+### Reference and support
+
+14. [Integrations: every plugin and service Hearth works with](14-integrations.md)
+15. [Complete settings reference](15-settings-reference.md)
+16. [Sharing dashboards: export, import and the gallery](16-sharing-and-gallery.md)
+17. [Privacy, network access and your data](17-privacy-and-network.md)
+18. [Troubleshooting and frequently asked questions](18-troubleshooting.md)
+19. [Glossary of Hearth terms](19-glossary.md)
+
+## Conventions used throughout this guide
+
+- **Settings → Hearth → Appearance** means: open Obsidian's own Settings window,
+  choose *Hearth* in the left-hand list of community plugins, then choose the
+  *Appearance* category from the ribbon across the top of Hearth's settings page.
+- **Arrange** refers to the button in the top-right corner of the Home view that
+  puts the dashboard into edit mode. Almost everything about cards is edited
+  there, not in the plugin settings.
+- *Italics* mark the exact label of a control as it appears on screen.
+- "Vault-wide" means the setting applies to every dashboard unless a particular
+  dashboard overrides it. "Per-board" means it lives on one dashboard. "Per-card"
+  means it lives on one card. Hearth uses this three-level cascade in several
+  places, and the guide always says which level a setting sits at.
+
+## Version this guide describes
+
+This guide describes Hearth **3.1.0**. Hearth moves quickly; the
+[CHANGELOG](../../CHANGELOG.md) is the authoritative record of what changed in
+each release, and *Settings → Hearth → About → What's new* shows the same notes
+inside Obsidian.
+
+## Related documents
+
+The following documents live in the same repository but are written for
+developers and self-hosters rather than for users of the plugin:
+
+- [`docs/dashboard-package.md`](../dashboard-package.md) — the JSON file format
+  that Hearth's export produces and its import consumes.
+- [`docs/gallery-api.md`](../gallery-api.md) — the HTTP contract a dashboard
+  gallery server has to implement.
+- [`docs/gallery-hosting.md`](../gallery-hosting.md) — how to run your own
+  dashboard gallery.
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — how to report bugs, suggest
+  features and contribute translations.


### PR DESCRIPTION
## What does this PR do?

Adds `docs/user-guide/` — a 20-file, chapter-by-chapter manual for people using Hearth, and links it from the README.

The README is an excellent tour, but it is a tour: it names features rather than documenting them. There was no place to look up what a specific setting does, what a card's every option means, or what a particular empty-state message is telling you. This fills that gap without touching the README's role.

**Structure**

| Files | Covers |
| --- | --- |
| `README.md` | Index, conventions, how the guide is meant to be read |
| `01`–`03` | Introduction, install + setup wizard, anatomy of the Home view |
| `04`–`06` | Search, dashboards, arrange mode |
| `07`–`10` | Every card, grouped exactly as the Add card picker groups them |
| `11`–`13` | Appearance, performance tiers, mobile |
| `14`–`17` | Integrations catalogue, full settings reference, export/import + gallery, privacy & network |
| `18`–`19` | Troubleshooting/FAQ, glossary |

**Written for two readers.** It reads normally for a person, and it is also structured for document-Q&A tools such as NotebookLM: every chapter is self-contained and restates its context instead of leaning on "as described above", and every setting is given as its exact on-screen label plus full path (`Settings → Hearth → Behaviour → Privacy & network → Disable external calls`), so an answer generated from the guide is literally followable in the app.

**Facts come from the source, not from the README.** `src/locales/en.ts` for labels and descriptions, `src/types.ts` for defaults, `src/settings.ts` for the real tab-to-section composition. That means the numbers in the guide are the ones the code uses: the 600 px narrow threshold (`NARROW_MAX_WIDTH`), the 8 px snap and 120×56 px minimum card, the 40-result search cap and 6-entry search history, card opacity 0.5 / blur 0 / radius 14 / border 1, `PLUGIN_BOARD_KEEP_ALIVE_MAX = 3`, stacked-height 184 default clamped to 56–420.

### Three places the guide deliberately differs from the current README

Worth a look during review, since they may be README bugs rather than guide bugs:

1. **Grid columns and row height are not exposed in any UI.** The README says a board can override "the global width, columns, row height…". `gridColumns` / `rowHeight` exist in the data model with per-board overrides, but `gridSection()` renders only *Fit to page* and *Compact spacing*, and the dashboard modal's Layout tab doesn't render them either. The guide documents them as internal seed values used when Hearth places a card for you.
2. **The Gallery button lives in the arrange toolbar**, beside *Add card*, and only when a gallery address is configured — not as standalone view chrome.
3. A source comment in `dashboard.ts` says Hearth "ships pointing at none" for the gallery, but `DEFAULT_GALLERY_URL` is populated. The guide documents the actual behaviour; the stale comment is untouched here.

## Related issue

None — docs-only addition.

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [x] 📝 Docs
- [ ] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [ ] `npm run build` passes locally
- [ ] I've tested this in an actual vault

Both unchecked, honestly: this PR adds Markdown only and touches no source, and `node_modules` was not installed in the environment this was written in, so the build was never run here. CI will cover it.

What I did verify: all 20 files are valid Markdown, and every relative link across them resolves (checked programmatically — 0 broken, including the links out to `dashboard-package.md`, `gallery-hosting.md`, `CHANGELOG.md` and `CONTRIBUTING.md`).

The guide states it describes **3.1.0**, in a "Version this guide describes" section, so it is clear when it starts to drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKYGKKCU49md62fwQeGebE

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKYGKKCU49md62fwQeGebE)_