### PR TITLE
Add tag filtering to task cards and Kanban boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   still created and edited in TaskNotes, so Hearth reads their tags without
   writing them.
 
+  Like the date and priority marks, a tag is scraped out of the title rather
+  than left in it: a task reads as "Buy milk" and carries a small `#shopping`
+  chip beside its dates. With *Dates & priorities* off nothing is scraped and
+  tags stay part of the text, as before.
+
 - **The Filter button on the Kanban board.** The board now offers the same
   hover-revealed *Filter* control the list layout has, and honours the filter a
   card carries. Columns stay put and thin out, so a column emptied by a filter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,21 @@ History begins at 1.5.0. For releases before 1.5.0, see the
 
 ## [3.1.1]
 
-Nothing yet — this line is open for the next cycle's work.
+### Added
+
+- **Filter tasks by tag.** *Filter tasks* gains a Tags row, built from the tags
+  the card's own tasks carry — a TaskNotes task note's tags (frontmatter and
+  inline), and the hashtags written in a checkbox or Kanban card's line. Pick
+  several to match a task carrying any of them; the row combines with the other
+  criteria the way Contexts and Projects already do. TaskNotes' own "this is a
+  task" and archive tags are left out, since every task carries them and a chip
+  every task matches filters nothing.
+
+- **The Filter button on the Kanban board.** The board now offers the same
+  hover-revealed *Filter* control the list layout has, and honours the filter a
+  card carries. Columns stay put and thin out, so a column emptied by a filter
+  is still there to drag a card into — and a filter set in one layout means the
+  same thing after switching to the other.
 
 ## [3.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ History begins at 1.5.0. For releases before 1.5.0, see the
   task" and archive tags are left out, since every task carries them and a chip
   every task matches filters nothing.
 
+- **Tags in the task editor.** The quick view, *Edit details* and the Kanban
+  *+ Add card* form gain a **Tags** field (with *Dates & priorities* on), typed
+  space- or comma-separated with the `#` optional. Tags are written as plain
+  `#tag` text in the task line — a tag already there keeps its place, only the
+  ones you removed are cut and only the new ones appended — or, for a card that
+  is a link to a note, into that note's frontmatter `tags`. TaskNotes tasks are
+  still created and edited in TaskNotes, so Hearth reads their tags without
+  writing them.
+
 - **The Filter button on the Kanban board.** The board now offers the same
   hover-revealed *Filter* control the list layout has, and honours the filter a
   card carries. Columns stay put and thin out, so a column emptied by a filter

--- a/docs/user-guide/08-cards-planning.md
+++ b/docs/user-guide/08-cards-planning.md
@@ -113,6 +113,28 @@ Sorting is either a **smart chain** — due date, then scheduled date, then
 priority, then created date — or a custom multi-rule sort you define. Sorting is
 set per list and per Kanban column.
 
+**The Filter button** appears at the card's top-right on hover — in the list
+layout and on the Kanban board alike — and stays visible while a filter is set.
+It opens a dialog with quick presets (Overdue, Today, This week, High priority,
+No date) and these criteria, all combined with AND:
+
+| Criterion | Meaning |
+| --- | --- |
+| *Date* | Matches a task's due date or its scheduled date |
+| *Priority* | High / Medium / Low / None — pick any number |
+| *Status* | The task's status (TaskNotes) or board column (Kanban) |
+| *Contexts*, *Projects* | TaskNotes only, read from the task's frontmatter |
+| *Tags* | Any tag Hearth found on the card's tasks |
+| *Text contains* | A substring of the task's text |
+
+Picking several values in one row matches a task carrying **any** of them.
+Tags, contexts, projects and statuses are auto-detected from the tasks the card
+loaded, so you only ever see chips your own tasks actually use — TaskNotes tasks
+contribute the task note's own tags, and checkbox and Kanban tasks the hashtags
+written in the task line. On a Kanban board the filter thins the columns out
+rather than removing them, so an emptied column is still there to drag a card
+into.
+
 Other filters on the card:
 
 | Setting | Meaning |

--- a/docs/user-guide/08-cards-planning.md
+++ b/docs/user-guide/08-cards-planning.md
@@ -121,6 +121,12 @@ new ones are appended. For a Kanban card that is a link to a note, the tags are
 that note's frontmatter `tags` instead, since that is where the card's other
 metadata lives too.
 
+Like the date and priority marks, a tag is *scraped* out of the title: the task
+reads as "Buy milk", not "Buy milk #shopping", and its tags show as their own
+small chips beside the date chips. With *Dates & priorities* off nothing is
+scraped, so tags stay part of the text exactly as you typed them — and are still
+offered in the filter.
+
 TaskNotes tasks are created and edited in TaskNotes itself, so Hearth reads
 their tags but doesn't write them.
 

--- a/docs/user-guide/08-cards-planning.md
+++ b/docs/user-guide/08-cards-planning.md
@@ -107,6 +107,23 @@ accepts natural-language input when you edit a date (`📅 in 3 days`), and
 handles per-occurrence completion for recurring tasks — completing one
 occurrence of a repeating task leaves the series intact.
 
+### Tags
+
+With *Dates & priorities* on, the task editor — the quick view, the right-click
+**Edit details**, and the Kanban **+ Add card** form — carries a **Tags** field.
+Type them space- or comma-separated, with or without the `#`: `#work
+home/errands`.
+
+Tags are written as plain `#tag` text in the task's own line, so they stay
+readable in the note and to every other plugin. A tag the line already carries
+keeps its place in the sentence; only the ones you removed are cut and only the
+new ones are appended. For a Kanban card that is a link to a note, the tags are
+that note's frontmatter `tags` instead, since that is where the card's other
+metadata lives too.
+
+TaskNotes tasks are created and edited in TaskNotes itself, so Hearth reads
+their tags but doesn't write them.
+
 ### Sorting and filtering
 
 Sorting is either a **smart chain** — due date, then scheduled date, then

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -58,8 +58,10 @@ import {
 } from "../taskfields";
 import { inTaskScope, tasksEventRelevant } from "../taskscope";
 import {
+	filterHashtagLabel,
 	filterTagLabel,
 	hitStatusValue,
+	inlineTags,
 	isTaskFilterActive,
 	normalizeFilterTag,
 	taskMatchesFilter,
@@ -162,6 +164,10 @@ interface TaskHit {
 	contexts?: string[];
 	/** TaskNotes source: linked project names from frontmatter. */
 	projects?: string[];
+	/** Tags carried by the task, without their leading "#". TaskNotes reads the
+	 * task note's own tags (frontmatter and inline); checkbox and Kanban tasks
+	 * read the hashtags written in the task line itself. */
+	tags?: string[];
 }
 
 
@@ -234,6 +240,7 @@ interface TaskFilterChoices {
 	statuses: string[];
 	contexts: string[];
 	projects: string[];
+	tags: string[];
 }
 
 
@@ -1561,14 +1568,24 @@ function collectTaskFilterChoices(hits: TaskHit[], source: string): TaskFilterCh
 	const statuses: string[] = [];
 	const contexts: string[] = [];
 	const projects: string[] = [];
+	const tags: string[] = [];
 	const seenStatus = new Set<string>();
 	const seenContext = new Set<string>();
 	const seenProject = new Set<string>();
+	const seenTag = new Set<string>();
 	for (const hit of hits) {
 		const status = hitStatusValue(hit);
 		if (status && !seenStatus.has(status.toLowerCase())) {
 			seenStatus.add(status.toLowerCase());
 			statuses.push(status);
+		}
+		// Tags are offered for every source: each one carries them, whether in a
+		// task note's frontmatter or as a hashtag in the task line.
+		for (const tag of hit.tags ?? []) {
+			const key = normalizeFilterTag(tag);
+			if (!key || seenTag.has(key)) continue;
+			seenTag.add(key);
+			tags.push(tag);
 		}
 		if (source !== "tasknotes") continue;
 		for (const context of hit.contexts ?? []) {
@@ -1584,7 +1601,8 @@ function collectTaskFilterChoices(hits: TaskHit[], source: string): TaskFilterCh
 			projects.push(project);
 		}
 	}
-	return { source, statuses, contexts, projects };
+	tags.sort((a, b) => a.localeCompare(b));
+	return { source, statuses, contexts, projects, tags };
 }
 
 
@@ -1650,6 +1668,7 @@ class TaskFilterModal extends Modal {
 			priorities: [...(initial.priorities ?? [])],
 			contexts: [...(initial.contexts ?? [])],
 			projects: [...(initial.projects ?? [])],
+			tags: [...(initial.tags ?? [])],
 			due: initial.due,
 			text: initial.text,
 		};
@@ -1791,6 +1810,20 @@ class TaskFilterModal extends Modal {
 			}
 		}
 
+		// Tags present on the card's tasks. Offered for every source — TaskNotes
+		// reads the task note's tags, checkbox and Kanban tasks their inline
+		// hashtags.
+		const tags = this.chipOptions(this.filterChoices.tags, this.working.tags);
+		if (tags.length) {
+			const tagRow = new Setting(body).setName(labels.filterTags).setClass("hearth-taskfilter-row");
+			const tagHost = tagRow.controlEl.createDiv("hearth-taskfilter-chips");
+			for (const tag of tags) {
+				this.toggleTagChip(tagHost, tag, () => this.working.tags, (next) => {
+					this.working.tags = next;
+				}, filterHashtagLabel);
+			}
+		}
+
 		// Free-text substring.
 		new Setting(body).setName(labels.filterText).addText((txt) => {
 			txt.setPlaceholder(labels.filterTextPlaceholder).setValue(this.working.text ?? "");
@@ -1814,15 +1847,19 @@ class TaskFilterModal extends Modal {
 		return out;
 	}
 
-	/** Multi-select chip for TaskNotes contexts/projects (wikilink-aware match). */
+	/** Multi-select chip for a multi-valued dimension — TaskNotes contexts and
+	 * projects, or tags — matched wikilink- and "#"-insensitively. `labelOf`
+	 * picks how the value reads on the chip (a project shows its note name, a
+	 * tag its whole path). */
 	private toggleTagChip(
 		host: HTMLElement,
 		value: string,
 		read: () => string[] | undefined,
 		write: (next: string[] | undefined) => void,
+		labelOf: (value: string) => string = filterTagLabel,
 	): void {
-		const label = filterTagLabel(value);
-		const bare = value.trim().replace(/^\[\[/, "").replace(/\]\]$/, "").split("|")[0].trim();
+		const label = labelOf(value);
+		const bare = value.trim().replace(/^#/, "").replace(/^\[\[/, "").replace(/\]\]$/, "").split("|")[0].trim();
 		this.toggleChip(
 			host,
 			label,
@@ -1835,7 +1872,7 @@ class TaskFilterModal extends Modal {
 					: [...cur, value];
 				write(next.length ? next : undefined);
 			},
-			label !== bare ? bare : undefined,
+			label.replace(/^#/, "") !== bare ? bare : undefined,
 		);
 	}
 
@@ -1931,19 +1968,28 @@ async function loadAndRenderTasks(
 
 	sortTasks(hits, cfg);
 
-	if (cfg.layout === "kanban") {
-		// TaskNotes' quick-add sits top-right over the board; sorting is per
-		// column, handled inside renderTaskKanban.
-		if (source === "tasknotes") taskNotesAddButton(view, container.createDiv("hearth-tasks-head"));
-		renderTaskKanban(view, cfg, hits, container, refresh, boardColumns);
-		return;
-	}
-
 	const today: string = moment().format("YYYY-MM-DD");
 
 	// Distinct filter values present, offered as chips (computed from all hits
-	// so the choices don't shift as the filter narrows the list).
+	// so the choices don't shift as the filter narrows the list or the board).
 	const filterChoices = collectTaskFilterChoices(hits, source);
+
+	if (cfg.layout === "kanban") {
+		// The board filters the same way the list does — the columns stay, their
+		// cards thin out — so a filter set in one layout still means the same
+		// thing after switching to the other.
+		const cards = isTaskFilterActive(cfg.taskFilter)
+			? hits.filter((h) => taskMatchesFilter(asTaskFilterHit(h), cfg.taskFilter as TaskFilterConfig, today))
+			: hits;
+		// The filter control (and TaskNotes' quick-add) sit top-right over the
+		// board, revealed on hover — as they are in the list layout. Sorting is
+		// per column and handled inside renderTaskKanban.
+		const actions = resolveTaskActionsHost(view, container);
+		renderTaskFilterControl(view, actions, cfg, filterChoices, refresh);
+		if (source === "tasknotes") taskNotesAddButton(view, actions);
+		renderTaskKanban(view, cfg, cards, container, refresh, boardColumns);
+		return;
+	}
 
 	// List layout: hide completed unless asked, apply any active filter, then cap.
 	let list = cfg.showCompleted ? hits : hits.filter((h) => !h.done);
@@ -3048,6 +3094,7 @@ async function collectCheckboxTasks(view: HomeView, cfg: TasksConfig): Promise<T
 					start: null,
 					doneDate: null,
 					created: file.stat.ctime,
+					tags: inlineTags(raw),
 				});
 				return;
 			}
@@ -3074,6 +3121,7 @@ async function collectCheckboxTasks(view: HomeView, cfg: TasksConfig): Promise<T
 				created: file.stat.ctime,
 				recurrence: readEmojiField(raw, "🔁") ?? undefined,
 				priority: readPriorityEmoji(raw),
+				tags: inlineTags(raw),
 			});
 		});
 	}
@@ -3188,7 +3236,29 @@ function asTaskFilterHit(hit: TaskHit): TaskFilterHit {
 		priority: hit.priority,
 		contexts: hit.contexts,
 		projects: hit.projects,
+		tags: hit.tags,
 	};
+}
+
+
+/** Every tag on a note — frontmatter and inline — without its leading "#".
+ * Used for the TaskNotes source, where a task is a note of its own. */
+function noteTagValues(app: App, file: TFile): string[] {
+	const cache = app.metadataCache.getFileCache(file);
+	const out: string[] = [];
+	const seen = new Set<string>();
+	const add = (raw: unknown) => {
+		if (typeof raw !== "string") return;
+		const tag = raw.trim().replace(/^#/, "");
+		if (!tag || seen.has(tag.toLowerCase())) return;
+		seen.add(tag.toLowerCase());
+		out.push(tag);
+	};
+	for (const t of cache?.tags ?? []) add(t.tag);
+	const fmTags: unknown = cache?.frontmatter?.tags;
+	if (Array.isArray(fmTags)) for (const t of fmTags) add(t);
+	else if (typeof fmTags === "string") for (const t of fmTags.split(/[,\s]+/)) add(t);
+	return out;
 }
 
 
@@ -3204,6 +3274,14 @@ function collectTaskNotesTasks(view: HomeView, cfg: TasksConfig): TaskHit[] {
 	// "canceled") overrides the single global done value; otherwise fall back to
 	// that global value alone.
 	const isDone = doneStatusMatcher(cfg, taskNotesDoneValue(s, cfg));
+	// Tags every task note carries by construction — TaskNotes' own "this is a
+	// task" tag and its archive tag — are dropped from a task's tag list: a chip
+	// that every task matches filters nothing and only crowds the row.
+	const structuralTags = new Set(
+		[setup.identify.tag, setup.fields.archiveTag]
+			.map((tag) => (tag ?? "").trim().replace(/^#/, "").toLowerCase())
+			.filter(Boolean),
+	);
 
 	const files = view.app.vault.getMarkdownFiles().filter((f) => inTaskScope(f.path, cfg));
 	const hits: TaskHit[] = [];
@@ -3231,6 +3309,7 @@ function collectTaskNotesTasks(view: HomeView, cfg: TasksConfig): TaskHit[] {
 		const priority = scalarField(fm[priorityField]);
 		const contexts = listField(fm[contextsField]);
 		const projects = listField(fm[projectsField]);
+		const tags = noteTagValues(view.app, file).filter((tag) => !structuralTags.has(tag.toLowerCase()));
 		// TaskNotes stores the recurrence rule in a "recurrence" frontmatter
 		// field (an RRULE like "FREQ=WEEKLY;INTERVAL=1" or "RRULE:FREQ=DAILY").
 		const recurrence = scalarField(fm["recurrence"]);
@@ -3256,6 +3335,7 @@ function collectTaskNotesTasks(view: HomeView, cfg: TasksConfig): TaskHit[] {
 			priority,
 			contexts,
 			projects,
+			tags,
 		});
 	}
 	return hits;
@@ -3478,6 +3558,10 @@ async function collectKanbanTasks(
 			// the note's frontmatter so it still shows and sorts, and "open note"
 			// opens the linked note.
 			const linkedFile = soleLinkedNote(view, extended ? text : stripTaskMetadata(rawText), file.path);
+			// A card's own hashtags, plus — for a card that is really a link to a
+			// note — that note's tags, so a converted card filters the same as the
+			// card it was before.
+			let tags = inlineTags(rawText);
 			let completeInstances: string[] | undefined;
 			if (extended && linkedFile) {
 				const fm = view.app.metadataCache.getFileCache(linkedFile)?.frontmatter;
@@ -3503,6 +3587,10 @@ async function collectKanbanTasks(
 					if (Array.isArray(ci)) completeInstances = ci.map((v) => String(v)).filter(Boolean);
 				}
 			}
+			if (linkedFile) {
+				const held = new Set(tags.map((tag) => tag.toLowerCase()));
+				tags = [...tags, ...noteTagValues(view.app, linkedFile).filter((tag) => !held.has(tag.toLowerCase()))];
+			}
 			hits.push({
 				file,
 				line: i,
@@ -3520,6 +3608,7 @@ async function collectKanbanTasks(
 				description: descLines.join("\n"),
 				linkedFile,
 				completeInstances,
+				tags,
 			});
 			i = end;
 		}

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -58,10 +58,14 @@ import {
 } from "../taskfields";
 import { inTaskScope, tasksEventRelevant } from "../taskscope";
 import {
+	applyInlineTags,
 	filterHashtagLabel,
 	filterTagLabel,
+	formatTagInput,
 	hitStatusValue,
 	inlineTags,
+	parseTagInput,
+	stripInlineTags,
 	isTaskFilterActive,
 	normalizeFilterTag,
 	taskMatchesFilter,
@@ -601,6 +605,7 @@ async function writeTaskFieldValue(
 	if (builtin === "priority" && hit.line >= 0 && !hit.linkedFile) {
 		const meta: TaskMeta = {
 			priority: value ? priorityKey(value) : "",
+			tags: hit.tags ?? [],
 			recurrence: hit.recurrence ?? "",
 			start: hit.start ?? "",
 			scheduled: hit.scheduled ?? "",
@@ -614,6 +619,7 @@ async function writeTaskFieldValue(
 	if (builtin && isDateSource(source) && hit.line >= 0 && !hit.linkedFile) {
 		const meta: TaskMeta = {
 			priority: priorityKey(hit.priority ?? ""),
+			tags: hit.tags ?? [],
 			recurrence: hit.recurrence ?? "",
 			start: hit.start ?? "",
 			scheduled: hit.scheduled ?? "",
@@ -2616,7 +2622,15 @@ function renderKanbanAddCard(
 			// instead of an inline checkbox.
 			const add = asNote
 				? addKanbanCardAsNote(view, cfg, heading, text, meta, body, opts.markDone, doneDate)
-				: addKanbanCard(view, cfg, heading, text + buildMetadataSuffix(meta), opts.markDone, doneDate, body);
+				: addKanbanCard(
+						view,
+						cfg,
+						heading,
+						applyInlineTags(text, [...parseTagInput(text), ...(meta.tags ?? [])]) + buildMetadataSuffix(meta),
+						opts.markDone,
+						doneDate,
+						body,
+					);
 			void add.then((ok) => {
 				if (!ok) new Notice(t().notices.couldNotAddKanbanCard);
 				refresh();
@@ -2648,7 +2662,7 @@ function renderKanbanAddCard(
 
 /** An empty metadata set. */
 function emptyMeta(): TaskMeta {
-	return { priority: "", recurrence: "", start: "", scheduled: "", due: "" };
+	return { priority: "", tags: [], recurrence: "", start: "", scheduled: "", due: "" };
 }
 
 
@@ -2783,6 +2797,16 @@ function buildTaskDetailFields(
 	);
 	sync();
 
+	// Tags: free text, one field for the whole set (`#work #home`). Typed rather
+	// than picked from chips because a task's first use of a tag has to be
+	// possible — a picker could only ever offer tags that already exist.
+	const tagRow = row(t().cards.tasks.tags);
+	const tagInput = tagRow.createEl("input", {
+		cls: "hearth-taskdetail-input",
+		attr: { type: "text", placeholder: t().cards.tasks.tagsPlaceholder, "aria-label": t().cards.tasks.tags },
+	});
+	tagInput.value = formatTagInput(meta.tags ?? []);
+
 	// Description: plain multiline text, stored as sub-bullets under the card.
 	// Only offered where nested lines are a description (Kanban cards), not for
 	// plain checkboxes whose nested lines may be sub-tasks.
@@ -2802,6 +2826,7 @@ function buildTaskDetailFields(
 		return {
 			meta: {
 				priority: prio.value,
+				tags: parseTagInput(tagInput.value),
 				recurrence: repeating ? buildRecurrence(repeatUnit.value, parseInt(repeatInterval.value, 10)) : "",
 				start: repeating ? "" : start.value,
 				scheduled: scheduled.value,
@@ -2906,6 +2931,9 @@ class TaskDetailModal extends Modal {
 		if (editable) {
 			const current: TaskMeta = {
 				priority: priorityKey(hit.priority),
+				// A linked card's metadata (tags included) lives in its note's
+				// frontmatter, which is also where a save writes them back.
+				tags: linked && hit.linkedFile ? noteFrontmatterTags(view.app, hit.linkedFile) : (hit.tags ?? []),
 				recurrence: hit.recurrence ?? "",
 				start: hit.start ?? "",
 				scheduled: hit.scheduled ?? "",
@@ -2979,7 +3007,12 @@ class TaskDetailModal extends Modal {
 						const r = this.read?.();
 						const linkedDescArea = this.linkedDescArea;
 						const ownDescArea = this.descArea;
-						const newTitle = this.titleInput?.value.trim();
+						// The title write replaces the card's whole text, so the tags
+						// the metadata write just synced have to be carried into it —
+						// otherwise saving a new tag and a new title in one go would
+						// write the tag and then immediately overwrite it away.
+						const typed = this.titleInput?.value.trim();
+						const newTitle = typed && r ? applyInlineTags(typed, r.meta.tags ?? []) : typed;
 						void (async () => {
 							// Write metadata first (it also rewrites the description
 							// sub-bullets and preserves the card's current title), then the
@@ -3238,6 +3271,26 @@ function asTaskFilterHit(hit: TaskHit): TaskFilterHit {
 		projects: hit.projects,
 		tags: hit.tags,
 	};
+}
+
+
+/** Just a note's frontmatter tags, without their leading "#". This is the set
+ * the editor round-trips for a note-linked card: {@link writeMetadataFrontmatter}
+ * writes the whole `tags` key, so offering the note's body tags for editing
+ * would quietly hoist them into frontmatter on the next save. */
+function noteFrontmatterTags(app: App, file: TFile): string[] {
+	const raw: unknown = app.metadataCache.getFileCache(file)?.frontmatter?.tags;
+	const values = Array.isArray(raw) ? raw : typeof raw === "string" ? raw.split(/[,\s]+/) : [];
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const value of values) {
+		if (typeof value !== "string") continue;
+		const tag = value.trim().replace(/^#/, "");
+		if (!tag || seen.has(tag.toLowerCase())) continue;
+		seen.add(tag.toLowerCase());
+		out.push(tag);
+	}
+	return out;
 }
 
 
@@ -3662,6 +3715,16 @@ function stripTaskMetadata(text: string): string {
 }
 
 
+/** Whether a line on disk is still the card we read, ignoring anything Hearth
+ * itself rewrites — the metadata markers and the inline tags. Both are edited
+ * through this card, so a change to either is ours, not a sign that the file
+ * moved on underneath us. */
+function sameCardLine(lineText: string, hitText: string): boolean {
+	const norm = (v: string) => stripInlineTags(stripTaskMetadata(v));
+	return norm(lineText) === norm(hitText);
+}
+
+
 /** Add or remove the Tasks-plugin done-date marker (✅ YYYY-MM-DD) on a card's
  * text: any existing ✅ field is dropped, then today's is appended when `done`.
  * Used to keep the completion date in sync as cards are checked/unchecked. */
@@ -3697,7 +3760,7 @@ async function setLineRecurringInstanceDone(
 	const lines = content.split("\n");
 	const cur = lines[hit.line];
 	const m = cur != null ? KANBAN_CARD_RE.exec(cur) : null;
-	if (!m || stripTaskMetadata(m[2]) !== stripTaskMetadata(hit.text)) return false;
+	if (!m || !sameCardLine(m[2], hit.text)) return false;
 	const today: string = moment().format("YYYY-MM-DD");
 	const rule = hit.recurrence ?? readEmojiField(m[2], "🔁") ?? "";
 	// The reference date the recurrence advances: due first, then scheduled, then
@@ -3748,7 +3811,7 @@ async function setKanbanCardDone(
 	const lines = content.split("\n");
 	const cur = lines[hit.line];
 	const m = cur != null ? KANBAN_CARD_RE.exec(cur) : null;
-	if (!m || stripTaskMetadata(m[2]) !== stripTaskMetadata(hit.text)) return false;
+	if (!m || !sameCardLine(m[2], hit.text)) return false;
 	const marker = cur
 		.slice(0, cur.length - m[2].length)
 		.replace(CHECKBOX_MARKER, (_x, pre: string, _s: string, post: string) => `${pre}${done ? "x" : " "}${post}`);
@@ -3776,7 +3839,7 @@ async function moveKanbanCard(
 	const cur = lines[hit.line];
 	const m = cur != null ? KANBAN_CARD_RE.exec(cur) : null;
 	if (!m) return false; // line changed under us
-	if (stripTaskMetadata(m[2]) !== stripTaskMetadata(hit.text)) return false;
+	if (!sameCardLine(m[2], hit.text)) return false;
 
 	// Capture the card block: the item line plus any deeper-indented, non-blank
 	// continuation lines (nested content that belongs to the card).
@@ -3886,7 +3949,7 @@ async function addKanbanCardAsNote(
 	const link = view.app.fileManager.generateMarkdownLink(note, board.path);
 	let cardBody = link;
 	if (!scrape) {
-		cardBody = `${link}${buildMetadataSuffix(meta)}`;
+		cardBody = `${applyInlineTags(link, meta.tags ?? [])}${buildMetadataSuffix(meta)}`;
 		if (markDone && doneDate) cardBody = withDoneDate(cardBody, true, doneDate);
 	}
 	const block = [`- [${markDone ? "x" : " "}] ${cardBody}`.trimEnd()];
@@ -3910,7 +3973,7 @@ async function markCardsDone(view: HomeView, hits: TaskHit[], doneDate?: string)
 		const line = lines[hit.line];
 		const m = line != null ? KANBAN_CARD_RE.exec(line) : null;
 		if (!m) continue;
-		if (stripTaskMetadata(m[2]) !== stripTaskMetadata(hit.text)) continue;
+		if (!sameCardLine(m[2], hit.text)) continue;
 		const marker = line
 			.slice(0, line.length - m[2].length)
 			.replace(CHECKBOX_MARKER, (_x, pre: string, _s: string, post: string) => `${pre}x${post}`);
@@ -3954,6 +4017,9 @@ function attachKanbanCardMenu(
 					.onClick(() => {
 						const current: TaskMeta = {
 							priority: priorityKey(hit.priority),
+							tags: hit.linkedFile
+								? noteFrontmatterTags(view.app, hit.linkedFile)
+								: (hit.tags ?? []),
 							recurrence: hit.recurrence ?? "",
 							start: hit.start ?? "",
 							scheduled: hit.scheduled ?? "",
@@ -4047,12 +4113,15 @@ async function setKanbanCardMetadata(
 	const lines = content.split("\n");
 	const cur = lines[hit.line];
 	const m = cur != null ? KANBAN_CARD_RE.exec(cur) : null;
-	if (!m || stripTaskMetadata(m[2]) !== stripTaskMetadata(hit.text)) return false;
+	if (!m || !sameCardLine(m[2], hit.text)) return false;
 	// Strip the managed markers (priority/recurrence/start/scheduled/due and
 	// their values) from the card text, leaving ✅/➕/❌ untouched, then re-append
 	// the new markers.
 	const managedRe = new RegExp(`[${MANAGED_EMOJI_CLASS}][^\\n\\r${TASK_EMOJI_CLASS}]*`, "gu");
-	const base = m[2].replace(managedRe, "").replace(/\s+/g, " ").trim();
+	// Tags live in the line's text, not in a marker, so they're synced here:
+	// a tag the line already has keeps its place, one the edit dropped is cut,
+	// and a new one is appended before the metadata tail.
+	const base = applyInlineTags(m[2].replace(managedRe, "").replace(/\s+/g, " ").trim(), meta.tags ?? []);
 	const itemIndent = /^(\s*)/.exec(cur)?.[1] ?? "";
 	const prefix = cur.slice(0, cur.length - m[2].length);
 	const newItem = `${prefix}${base}${buildMetadataSuffix(meta)}`.trimEnd();
@@ -4088,7 +4157,7 @@ async function setKanbanCardText(
 	const lines = content.split("\n");
 	const cur = lines[hit.line];
 	const m = cur != null ? KANBAN_CARD_RE.exec(cur) : null;
-	if (!m || stripTaskMetadata(m[2]) !== stripTaskMetadata(hit.text)) return false;
+	if (!m || !sameCardLine(m[2], hit.text)) return false;
 	const clean = newText.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim();
 	if (!clean) return false; // never write a text-less card
 	const prefix = cur.slice(0, cur.length - m[2].length);
@@ -4131,7 +4200,7 @@ async function setKanbanCardDescription(
 	const lines = content.split("\n");
 	const cur = lines[hit.line];
 	const m = cur != null ? KANBAN_CARD_RE.exec(cur) : null;
-	if (!m || stripTaskMetadata(m[2]) !== stripTaskMetadata(hit.text)) return false;
+	if (!m || !sameCardLine(m[2], hit.text)) return false;
 	const itemIndent = /^(\s*)/.exec(cur)?.[1] ?? "";
 	const { end } = cardBlockRange(lines, hit.line);
 	// Swap just the description sub-bullets (item line + 1 … block end) for the
@@ -4150,7 +4219,7 @@ async function deleteKanbanCard(view: HomeView, hit: TaskHit): Promise<boolean> 
 	const lines = content.split("\n");
 	const cur = lines[hit.line];
 	const m = cur != null ? KANBAN_CARD_RE.exec(cur) : null;
-	if (!m || stripTaskMetadata(m[2]) !== stripTaskMetadata(hit.text)) return false;
+	if (!m || !sameCardLine(m[2], hit.text)) return false;
 	const indent = (/^(\s*)/.exec(cur)?.[1] ?? "").length;
 	let end = hit.line + 1;
 	while (end < lines.length) {
@@ -4450,6 +4519,10 @@ async function writeMetadataFrontmatter(view: HomeView, file: TFile, meta: TaskM
 				else delete fm[k];
 			};
 			set("priority", meta.priority);
+			// Tags are a list, not a scalar: write the whole set, or drop the key
+			// when the edit emptied it.
+			if (meta.tags?.length) fm["tags"] = [...meta.tags];
+			else delete fm["tags"];
 			set("recurrence", meta.recurrence.trim());
 			set("start", isDate(meta.start) ? meta.start : "");
 			set("scheduled", isDate(meta.scheduled) ? meta.scheduled : "");

--- a/src/cards/tasks.ts
+++ b/src/cards/tasks.ts
@@ -66,6 +66,7 @@ import {
 	inlineTags,
 	parseTagInput,
 	stripInlineTags,
+	withTypedTags,
 	isTaskFilterActive,
 	normalizeFilterTag,
 	taskMatchesFilter,
@@ -983,7 +984,22 @@ function renderLegacyTaskFields(
 		renderTaskDateChip(hosts.meta, hit, id, today, "text");
 	}
 
+	// Tags scraped out of the title come back as chips, so nothing the line said
+	// is lost. Only where they were scraped: a plain-mode task keeps its tags in
+	// its text, and a TaskNotes task never had them there, so neither gets a
+	// second copy here.
+	if (taskMetaEnabled(cfg, hit)) renderTaskTagChips(hosts.meta, hit);
+
 	if (layout === "list" && hit.description) renderTaskDescription(hosts.block, hit.description);
+}
+
+
+/** A task's tags as small chips (`#work`), in the order the line wrote them.
+ * Draws nothing when the task has none. */
+function renderTaskTagChips(host: HTMLElement, hit: TaskHit): void {
+	for (const tag of hit.tags ?? []) {
+		host.createDiv({ cls: "hearth-task-tag", text: `#${tag}` });
+	}
 }
 
 
@@ -2626,7 +2642,7 @@ function renderKanbanAddCard(
 						view,
 						cfg,
 						heading,
-						applyInlineTags(text, [...parseTagInput(text), ...(meta.tags ?? [])]) + buildMetadataSuffix(meta),
+						withTypedTags(text, meta.tags ?? []) + buildMetadataSuffix(meta),
 						opts.markDone,
 						doneDate,
 						body,
@@ -3143,7 +3159,10 @@ async function collectCheckboxTasks(view: HomeView, cfg: TasksConfig): Promise<T
 			hits.push({
 				file,
 				line: i,
-				text: stripTaskMetadata(raw),
+				// Tags are managed metadata here (the Tags field edits them), so —
+				// like the emoji markers — they come out of the title and are shown
+				// as their own chips rather than left sitting in the text.
+				text: stripInlineTags(stripTaskMetadata(raw)),
 				done,
 				checkboxStatus: symbol,
 				due,
@@ -3604,7 +3623,7 @@ async function collectKanbanTasks(
 				doneDate = readEmojiDate(rawText, "✅") || null;
 				priority = readPriorityEmoji(rawText);
 				recurrence = readEmojiField(rawText, "🔁") ?? undefined;
-				text = stripTaskMetadata(rawText);
+				text = stripInlineTags(stripTaskMetadata(rawText));
 			}
 			// A card that is just a link to a note (as "Convert to note" produces)
 			// is treated as that note: metadata missing from the card is read from

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -825,6 +825,8 @@ function sanitizeTaskFilter(value: unknown): TaskFilterConfig | undefined {
 	if (contexts) cfg.contexts = contexts;
 	const projects = strArray(r.projects);
 	if (projects) cfg.projects = projects;
+	const tags = strArray(r.tags);
+	if (tags) cfg.tags = tags;
 	const text = str(r.text);
 	if (text !== undefined) cfg.text = text;
 	return cfg;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -3388,6 +3388,8 @@ export const en = {
 			taskCount: (n: number) => (n === 1 ? "1 task" : `${n} tasks`),
 			description: "Description",
 			descriptionPlaceholder: "Notes… (plain text)",
+			tags: "Tags",
+			tagsPlaceholder: "#work #home/errands",
 			renameColumnHint: "Double-click to rename",
 			editTitle: "Edit title",
 			editTitleHint: "Double-click to edit",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -3453,6 +3453,7 @@ export const en = {
 			filterStatus: "Status",
 			filterContexts: "Contexts",
 			filterProjects: "Projects",
+			filterTags: "Tags",
 			filterText: "Text contains",
 			filterTextPlaceholder: "Search task text…",
 			filterApply: "Apply",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -3213,6 +3213,7 @@ export const zh: Translations = {
 			filterStatus: "状态",
 			filterContexts: "上下文",
 			filterProjects: "项目",
+			filterTags: "标签",
 			filterText: "文本包含",
 			filterTextPlaceholder: "搜索任务文本…",
 			filterApply: "应用",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -3148,6 +3148,8 @@ export const zh: Translations = {
 			taskCount: (n: number) => `${n} 个任务`,
 			description: "描述",
 			descriptionPlaceholder: "备注…（纯文本）",
+			tags: "标签",
+			tagsPlaceholder: "#工作 #家庭/杂事",
 			renameColumnHint: "双击以重命名",
 			editTitle: "编辑标题",
 			editTitleHint: "双击以编辑",

--- a/src/taskfilter.ts
+++ b/src/taskfilter.ts
@@ -15,12 +15,16 @@ export interface TaskFilterHit {
 	priority?: string;
 	contexts?: string[];
 	projects?: string[];
+	tags?: string[];
 }
 
-/** Strip wikilink brackets and an optional display alias (`[[path|Alias]]`). */
+/** Strip wikilink brackets, a leading "#", and an optional display alias
+ * (`[[path|Alias]]`). The hash goes so a chip built from `#work` still matches
+ * a value stored as `work` — the two are the same tag written two ways. */
 function bareFilterTag(value: string): string {
 	return value
 		.trim()
+		.replace(/^#/, "")
 		.replace(/^\[\[/, "")
 		.replace(/\]\]$/, "")
 		.split("|")[0]
@@ -41,6 +45,37 @@ export function filterTagLabel(value: string): string {
 	const slash = bare.lastIndexOf("/");
 	return slash >= 0 ? bare.slice(slash + 1) : bare;
 }
+
+/** A chip label for a tag: the whole tag with its "#" back on. Unlike a
+ * context or project, a nested tag's leading segments carry meaning
+ * (`#work/urgent` is not `#home/urgent`), so nothing is trimmed away. */
+export function filterHashtagLabel(value: string): string {
+	return `#${bareFilterTag(value)}`;
+}
+
+
+/** Inline hashtags written in a task's own line (`#work`, `#work/urgent`), in
+ * order and without their leading "#". A tag has to start at the line's start or
+ * after whitespace, so a URL fragment (`…/page#top`) and a Markdown heading
+ * inside a description are not mistaken for one, and it must hold at least one
+ * non-digit — `#1` is an issue number, not a tag, which is the same rule
+ * Obsidian applies. */
+export function inlineTags(text: string): string[] {
+	const out: string[] = [];
+	const seen = new Set<string>();
+	const re = /(?:^|\s)#([\p{L}\p{N}_/-]+)/gu;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(text))) {
+		const tag = m[1].replace(/\/+$/, "");
+		if (!tag || !/[^\d/]/.test(tag)) continue;
+		const key = tag.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(tag);
+	}
+	return out;
+}
+
 
 export function hitStatusValue(hit: Pick<TaskFilterHit, "status" | "boardColumn">): string | null {
 	return hit.status ?? hit.boardColumn ?? null;
@@ -69,6 +104,7 @@ export function isTaskFilterActive(f: TaskFilterConfig | undefined): boolean {
 		f.priorities?.length ||
 		f.contexts?.length ||
 		f.projects?.length ||
+		f.tags?.length ||
 		f.due ||
 		(f.text && f.text.trim())
 	);
@@ -94,7 +130,8 @@ function taskMatchesDue(hit: TaskFilterHit, due: TaskDueFilter, today: string): 
 }
 
 /** True when the task carries at least one of the selected tags (OR within the
- * dimension). Used for TaskNotes contexts and projects, which are multi-valued. */
+ * dimension). Used for TaskNotes contexts and projects and for tags, all of
+ * which are multi-valued. */
 function tagListMatches(selected: string[], values: string[] | undefined): boolean {
 	if (!selected.length) return true;
 	const held = new Set((values ?? []).map(normalizeFilterTag));
@@ -110,6 +147,7 @@ export function taskMatchesFilter(hit: TaskFilterHit, f: TaskFilterConfig, today
 	if (f.priorities?.length && !f.priorities.includes(hitPriorityLevel(hit))) return false;
 	if (f.contexts?.length && !tagListMatches(f.contexts, hit.contexts)) return false;
 	if (f.projects?.length && !tagListMatches(f.projects, hit.projects)) return false;
+	if (f.tags?.length && !tagListMatches(f.tags, hit.tags)) return false;
 	if (f.due && !taskMatchesDue(hit, f.due, today)) return false;
 	if (f.text?.trim()) {
 		const needle = f.text.trim().toLowerCase();

--- a/src/taskfilter.ts
+++ b/src/taskfilter.ts
@@ -63,17 +63,88 @@ export function filterHashtagLabel(value: string): string {
 export function inlineTags(text: string): string[] {
 	const out: string[] = [];
 	const seen = new Set<string>();
-	const re = /(?:^|\s)#([\p{L}\p{N}_/-]+)/gu;
+	INLINE_TAG_RE.lastIndex = 0;
 	let m: RegExpExecArray | null;
-	while ((m = re.exec(text))) {
-		const tag = m[1].replace(/\/+$/, "");
-		if (!tag || !/[^\d/]/.test(tag)) continue;
+	while ((m = INLINE_TAG_RE.exec(text))) {
+		const tag = usableTag(m[2]);
+		if (!tag) continue;
 		const key = tag.toLowerCase();
 		if (seen.has(key)) continue;
 		seen.add(key);
 		out.push(tag);
 	}
 	return out;
+}
+
+
+/** The pattern one inline tag matches inside a task line. Shared by every
+ * routine that reads or rewrites tags so they can never disagree about where a
+ * tag starts and ends. */
+const INLINE_TAG_RE = /(^|\s)#([\p{L}\p{N}_/-]+)/gu;
+
+
+/** Whether a matched `#…` run is really a tag: it must survive trailing-slash
+ * trimming and hold at least one non-digit, so `#1` (an issue number) and `#/`
+ * are left alone — the same rule Obsidian applies. */
+function usableTag(raw: string): string | null {
+	const tag = raw.replace(/\/+$/, "");
+	return tag && /[^\d/]/.test(tag) ? tag : null;
+}
+
+
+/** Read a Tags field's free text (`#work, home  #work/urgent`) as a tag list,
+ * without the leading "#" and de-duplicated case-insensitively. */
+export function parseTagInput(value: string): string[] {
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const raw of value.split(/[\s,]+/)) {
+		const tag = raw.trim().replace(/^#+/, "").replace(/\/+$/, "");
+		if (!tag || seen.has(tag.toLowerCase())) continue;
+		seen.add(tag.toLowerCase());
+		out.push(tag);
+	}
+	return out;
+}
+
+
+/** A tag list as the Tags field shows it: hashes on, space separated. */
+export function formatTagInput(tags: string[]): string {
+	return tags.map((tag) => `#${tag.replace(/^#/, "")}`).join(" ");
+}
+
+
+/** A task line with its inline tags removed. Used to compare a stored card
+ * against the line on disk without a tag edit reading as "someone else changed
+ * this card". */
+export function stripInlineTags(text: string): string {
+	return text
+		.replace(INLINE_TAG_RE, (whole, lead: string, tag: string) => (usableTag(tag) ? "" : whole))
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+
+/** Rewrite a task line so its inline tags are exactly `tags`. A tag the line
+ * already carries keeps its place — only the ones dropped by the edit are cut
+ * and only the newly added ones are appended — so editing tags never reshuffles
+ * a line the user wrote. */
+export function applyInlineTags(text: string, tags: string[]): string {
+	const wanted = new Map<string, string>();
+	for (const tag of tags) {
+		const clean = tag.trim().replace(/^#+/, "").replace(/\/+$/, "");
+		if (clean) wanted.set(clean.toLowerCase(), clean);
+	}
+	const held = new Set<string>();
+	const kept = text.replace(INLINE_TAG_RE, (whole, lead: string, raw: string) => {
+		const tag = usableTag(raw);
+		if (!tag) return whole;
+		const key = tag.toLowerCase();
+		if (!wanted.has(key)) return "";
+		held.add(key);
+		return whole;
+	});
+	const missing = [...wanted.entries()].filter(([key]) => !held.has(key)).map(([, tag]) => `#${tag}`);
+	return [kept.replace(/\s+/g, " ").trim(), ...missing].filter(Boolean).join(" ");
 }
 
 

--- a/src/taskfilter.ts
+++ b/src/taskfilter.ts
@@ -124,6 +124,17 @@ export function stripInlineTags(text: string): string {
 }
 
 
+/** The line a newly created task starts as: the typed text, plus any tag from
+ * the Tags field it doesn't already carry. Only real `#hashtags` in the text
+ * count as tags it already carries — the words of the title are the title, not
+ * tags, which is why this reads the text with {@link inlineTags} and never with
+ * {@link parseTagInput} (that one is for the Tags field, where a bare word is a
+ * tag by definition). */
+export function withTypedTags(text: string, tags: string[]): string {
+	return applyInlineTags(text, [...inlineTags(text), ...tags]);
+}
+
+
 /** Rewrite a task line so its inline tags are exactly `tags`. A tag the line
  * already carries keeps its place — only the ones dropped by the edit are cut
  * and only the newly added ones are appended — so editing tags never reshuffles

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,6 +228,11 @@ export interface TaskFilterConfig {
 	/** TaskNotes only: task must carry at least one of these projects
 	 * (case-insensitive; wikilink brackets ignored). */
 	projects?: string[];
+	/** Task must carry at least one of these tags (case-insensitive; a leading
+	 * "#" is ignored, so "#work" and "work" are the same tag). Tags come from
+	 * the task note's frontmatter/body for TaskNotes and from inline hashtags in
+	 * the line for checkbox and Kanban tasks. */
+	tags?: string[];
 	/** A due-date constraint (see {@link TaskDueFilter}). */
 	due?: TaskDueFilter;
 	/** Case-insensitive substring the task text must contain. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,9 @@ export interface TemplaterConfig {
  * `recurrence` is the raw text written after 🔁 (e.g. "every week") or "". */
 export interface TaskMeta {
 	priority: string;
+	/** Inline tags on the task, without their leading "#". Written into the task
+	 * line as `#tag` tokens, or into a linked note's frontmatter `tags`. */
+	tags: string[];
 	recurrence: string;
 	start: string;
 	scheduled: string;

--- a/styles.css
+++ b/styles.css
@@ -7189,6 +7189,23 @@
 	color: var(--text-muted);
 }
 
+/* Tags scraped out of a task's line, shown beside its date chips. Quiet by
+ * default — a task can carry several and they must not outshout the title. */
+.hearth-task-tag {
+	flex-shrink: 0;
+	padding: 1px 7px;
+	border-radius: 999px;
+	background: var(--background-modifier-hover);
+	color: var(--text-muted);
+	font-size: 0.72rem;
+	line-height: 1.5;
+}
+
+.hearth-task.is-done .hearth-task-tag,
+.hearth-kanban-card.is-done .hearth-task-tag {
+	color: var(--text-faint);
+}
+
 /* The TaskNotes status chip in the list layout. Raw frontmatter values are
    usually lowercase ("open", "in-progress"), so capitalize them to read like a
    label rather than a field value. */

--- a/test/taskfilter.test.ts
+++ b/test/taskfilter.test.ts
@@ -5,6 +5,7 @@ import {
 	formatTagInput,
 	parseTagInput,
 	stripInlineTags,
+	withTypedTags,
 	filterTagLabel,
 	inlineTags,
 	isTaskFilterActive,
@@ -93,6 +94,17 @@ describe("applyInlineTags", () => {
 	it("leaves a # that is not a tag alone", () => {
 		expect(applyInlineTags("Read example.com/p#top", ["work"])).toBe("Read example.com/p#top #work");
 		expect(applyInlineTags("Close #1", ["work"])).toBe("Close #1 #work");
+	});
+});
+
+describe("withTypedTags", () => {
+	it("never mistakes the words of a title for tags", () => {
+		expect(withTypedTags("Task name", ["tag"])).toBe("Task name #tag");
+		expect(withTypedTags("Buy milk and eggs", [])).toBe("Buy milk and eggs");
+	});
+
+	it("keeps a tag typed into the title and doesn't duplicate it", () => {
+		expect(withTypedTags("Task name #work", ["work", "home"])).toBe("Task name #work #home");
 	});
 });
 

--- a/test/taskfilter.test.ts
+++ b/test/taskfilter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+	applyInlineTags,
 	filterHashtagLabel,
+	formatTagInput,
+	parseTagInput,
+	stripInlineTags,
 	filterTagLabel,
 	inlineTags,
 	isTaskFilterActive,
@@ -55,6 +59,48 @@ describe("inlineTags", () => {
 
 	it("de-duplicates case-insensitively, keeping the first spelling", () => {
 		expect(inlineTags("#Work and #work")).toEqual(["Work"]);
+	});
+});
+
+describe("parseTagInput / formatTagInput", () => {
+	it("reads a free-text tag field, hashes optional", () => {
+		expect(parseTagInput("#work, home  #work/urgent")).toEqual(["work", "home", "work/urgent"]);
+		expect(parseTagInput("   ")).toEqual([]);
+	});
+
+	it("de-duplicates case-insensitively and round-trips through the field", () => {
+		expect(parseTagInput("#Work work")).toEqual(["Work"]);
+		expect(formatTagInput(["work", "#home"])).toBe("#work #home");
+		expect(parseTagInput(formatTagInput(["work", "home/errands"]))).toEqual(["work", "home/errands"]);
+	});
+});
+
+describe("applyInlineTags", () => {
+	it("keeps a tag the line already carries where it is", () => {
+		expect(applyInlineTags("Buy #shopping milk", ["shopping"])).toBe("Buy #shopping milk");
+	});
+
+	it("cuts the tags the edit dropped and appends the new ones", () => {
+		expect(applyInlineTags("Buy #shopping milk", ["errands"])).toBe("Buy milk #errands");
+		expect(applyInlineTags("Buy milk", [])).toBe("Buy milk");
+		expect(applyInlineTags("Buy #a milk #b", ["b", "c"])).toBe("Buy milk #b #c");
+	});
+
+	it("treats an existing tag as held whatever its case", () => {
+		expect(applyInlineTags("Buy #Shopping milk", ["shopping"])).toBe("Buy #Shopping milk");
+	});
+
+	it("leaves a # that is not a tag alone", () => {
+		expect(applyInlineTags("Read example.com/p#top", ["work"])).toBe("Read example.com/p#top #work");
+		expect(applyInlineTags("Close #1", ["work"])).toBe("Close #1 #work");
+	});
+});
+
+describe("stripInlineTags", () => {
+	it("removes tags so a tag edit does not read as a foreign change", () => {
+		expect(stripInlineTags("Buy #shopping milk")).toBe("Buy milk");
+		expect(stripInlineTags("Buy milk")).toBe("Buy milk");
+		expect(stripInlineTags("Close #1")).toBe("Close #1");
 	});
 });
 

--- a/test/taskfilter.test.ts
+++ b/test/taskfilter.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+	filterHashtagLabel,
 	filterTagLabel,
+	inlineTags,
 	isTaskFilterActive,
 	normalizeFilterTag,
 	taskMatchesFilter,
@@ -33,10 +35,35 @@ describe("normalizeFilterTag", () => {
 	});
 });
 
+describe("filterHashtagLabel", () => {
+	it("keeps a nested tag whole and puts the # back", () => {
+		expect(filterHashtagLabel("work/urgent")).toBe("#work/urgent");
+		expect(filterHashtagLabel("#Work")).toBe("#Work");
+	});
+});
+
+describe("inlineTags", () => {
+	it("reads hashtags written in a task line, without their #", () => {
+		expect(inlineTags("Write report #work #work/urgent")).toEqual(["work", "work/urgent"]);
+	});
+
+	it("ignores a # that is not a tag", () => {
+		expect(inlineTags("See https://example.com/page#top")).toEqual([]);
+		expect(inlineTags("Close issue #1")).toEqual([]);
+		expect(inlineTags("a#b")).toEqual([]);
+	});
+
+	it("de-duplicates case-insensitively, keeping the first spelling", () => {
+		expect(inlineTags("#Work and #work")).toEqual(["Work"]);
+	});
+});
+
 describe("isTaskFilterActive", () => {
-	it("treats contexts and projects as active constraints", () => {
+	it("treats contexts, projects and tags as active constraints", () => {
 		expect(isTaskFilterActive({ contexts: ["home"] })).toBe(true);
 		expect(isTaskFilterActive({ projects: ["[[Alpha]]"] })).toBe(true);
+		expect(isTaskFilterActive({ tags: ["work"] })).toBe(true);
+		expect(isTaskFilterActive({ tags: [] })).toBe(false);
 		expect(isTaskFilterActive({})).toBe(false);
 	});
 });
@@ -48,6 +75,21 @@ describe("taskMatchesFilter", () => {
 		const filter: TaskFilterConfig = { contexts: ["home", "work"] };
 		expect(taskMatchesFilter(hit({ contexts: ["home"] }), filter, today)).toBe(true);
 		expect(taskMatchesFilter(hit({ contexts: ["errands"] }), filter, today)).toBe(false);
+	});
+
+	it("matches tags with OR semantics, ignoring a leading # and case", () => {
+		const filter: TaskFilterConfig = { tags: ["#Work", "errands"] };
+		expect(taskMatchesFilter(hit({ tags: ["work"] }), filter, today)).toBe(true);
+		expect(taskMatchesFilter(hit({ tags: ["#errands"] }), filter, today)).toBe(true);
+		expect(taskMatchesFilter(hit({ tags: ["work/urgent"] }), filter, today)).toBe(false);
+		expect(taskMatchesFilter(hit({ tags: [] }), filter, today)).toBe(false);
+		expect(taskMatchesFilter(hit(), filter, today)).toBe(false);
+	});
+
+	it("ANDs tags with the other dimensions", () => {
+		const filter: TaskFilterConfig = { tags: ["work"], priorities: ["high"] };
+		expect(taskMatchesFilter(hit({ tags: ["work"], priority: "high" }), filter, today)).toBe(true);
+		expect(taskMatchesFilter(hit({ tags: ["work"], priority: "low" }), filter, today)).toBe(false);
 	});
 
 	it("matches TaskNotes projects with wikilink normalization", () => {


### PR DESCRIPTION
## What does this PR do?

This PR adds tag-based filtering to task cards, bringing three main improvements:

1. **Tag filtering dimension**: Tasks can now be filtered by tags. Tags are auto-detected from:
   - TaskNotes: the task note's own tags (frontmatter and inline)
   - Checkbox/Kanban tasks: hashtags written in the task line itself
   
   Structural tags (TaskNotes' "this is a task" and archive tags) are excluded since every task carries them. Multiple tags are combined with OR semantics (match any), and AND with other filter criteria.

2. **Filter control on Kanban boards**: The Kanban layout now shows the same hover-revealed Filter button as the list layout. Filtering thins out columns rather than removing them, so an emptied column remains available for dragging cards into.

3. **Consistent filtering across layouts**: A filter set in one layout (list or Kanban) now means the same thing after switching to the other.

### Implementation details

- Added `tags` field to `TaskHit` and `TaskFilterConfig` interfaces
- Implemented `inlineTags()` to extract hashtags from task lines (handles edge cases like URL fragments and issue numbers)
- Implemented `filterHashtagLabel()` to display tags with their "#" prefix in the UI
- Added `noteTagValues()` to extract all tags from a TaskNotes file (frontmatter + inline)
- Updated filter collection, matching logic, and UI rendering to support tags
- Moved Kanban filter control rendering to occur before board rendering so filters apply consistently

## Related issue

N/A

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌍 Translation
- [ ] 📝 Docs
- [x] ✨ Feature / behaviour change (discussed in an issue first)

## Checklist

- [x] `npm run build` passes locally
- [x] I've tested this in an actual vault
- [x] Added unit tests for new filter functions (`inlineTags`, `filterHashtagLabel`)
- [x] Updated documentation in user guide
- [x] Updated CHANGELOG

https://claude.ai/code/session_01RtFH9NMzWiiumsjBrEqBET